### PR TITLE
fix: warm up game-loop bench scenes before measuring

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -107,16 +107,15 @@ _Use these to track end-to-end regression across all optimization tickets in EPI
 File: `benchmarks/gameLoop.bench.test.ts`
 
 > Times are in **ms** (milliseconds).
-> Note: 250 and 500 body scenes have high rme (±11%) because bodies settle over iterations,
-> causing the per-step cost profile to shift. This is expected; use these for order-of-magnitude
-> tracking rather than precise sub-percent comparisons.
+> Scenes are pre-settled via a warm-up pass before benchmarking begins, so numbers
+> reflect steady-state cost with all bodies at rest rather than mid-freefall cost.
 
 | Benchmark | hz | mean (ms) | p75 (ms) | p99 (ms) | rme |
 |---|---|---|---|---|---|
-| 50 bodies | 336 | 2.977 | 3.147 | 4.196 | ±1.65% |
-| 100 bodies | 129 | 7.765 | 9.111 | 10.011 | ±5.76% |
-| 250 bodies | 129 | 7.750 | 10.749 | 14.953 | ±11.51% |
-| 500 bodies | 159 | 6.308 | 8.596 | 13.283 | ±11.23% |
+| 50 bodies | 300 | 3.337 | 3.552 | 3.984 | ±1.44% |
+| 100 bodies | 88 | 11.327 | 11.774 | 13.370 | ±1.80% |
+| 250 bodies | 27 | 36.433 | 37.285 | 38.745 | ±2.20% |
+| 500 bodies | 11 | 91.643 | 95.514 | 97.933 | ±3.83% |
 
 ---
 


### PR DESCRIPTION
## Problem

The original game-loop bench built scenes with bodies stacked in a 10-column grid, with the tallest body at y = 2 + floor((bodyCount-1)/10) * 2. For 500 bodies that is y = 100. Freefall from y=100 takes ~270 physics steps to reach the ground, but vitest only ran ~81 bench iterations for that scene — meaning ~450 of the 500 bodies were still in free-fall (no collision pairs) when the bench was recorded.

This caused the nonsensical result: 500 bodies appeared faster than 100 bodies, and 100/250/500 all clustered around ~129 hz.

## Fix

makeScene now runs a warm-up pass after construction using warmupSteps = ceil(sqrt(2 * maxHeight / gravity) / DT) * 2. The x2 factor adds a settling buffer for bounce damping. All bodies are on or near the ground before the first bench iteration runs.

## Updated baselines

| Benchmark | Before (hz) | After (hz) | mean (ms) |
|---|---|---|---|
| 50 bodies | 336 | 300 | 3.3 |
| 100 bodies | 129 | 88 | 11.3 |
| 250 bodies | 129 | 27 | 36.4 |
| 500 bodies | 159 | 11 | 91.6 |

Costs now scale correctly with body count. The ~3-4x cost increase per 2x body count at the high end is consistent with near-O(n^2) broad-phase behavior, which TICKET-006 is targeting.

Generated with Claude Code