### PR TITLE
TICKET-005: Fix per-step allocations in PhysicsService

### DIFF
--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-001-engine-performance-pass/done/TICKET-004-pool-vec3-quat-in-collision-detection.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-001-engine-performance-pass/done/TICKET-004-pool-vec3-quat-in-collision-detection.md
@@ -2,10 +2,10 @@
 id: TICKET-004
 epic: EPIC-001
 title: Pool Vec3/Quat in collision detection
-status: todo
+status: done
 priority: high
 created: 2026-02-24
-updated: 2026-02-24
+updated: 2026-02-25
 ---
 
 ## Description
@@ -27,3 +27,5 @@ Introduce a simple object pool so narrow-phase collision math reuses pre-allocat
 ## Notes
 
 - **2026-02-24**: Ticket created. Blocked by TICKET-002 (need baseline). Can be implemented alongside TICKET-005 and TICKET-006 once baseline is captured.
+- **2026-02-25**: Status changed to in-progress
+- **2026-02-25**: Status changed to done. Vec3 pool implemented in detect.ts. PR #11 merged.


### PR DESCRIPTION
## Summary

Eliminates three sources of heap allocation that fired every physics step (60 Hz):

1. **Removed dead `startPairs` Map** — was populated but never read; collision-start events were already emitted via the `_currentPairs` iteration.

2. **Persistent Maps with pointer swap** — replaced the two `new Map()` calls per step with two instance Maps (`_lastPairs`, `_currentPairs`) reused via `.clear()` + end-of-step pointer swap (classic double-buffer pattern).

3. **Numeric pair keys** — replaced the template-literal string key ``${ai}|${bi}`` with triangular-number encoding: `lo + hi*(hi+1)/2`. Unique for any ordered pair of non-negative integers, order-independent, and makes Map lookup a numeric comparison instead of a string hash.

All 40 physics tests pass.

Closes TICKET-005