### PR TITLE
TICKET-006: Fix broad-phase fallback and switch to numeric keys

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -119,9 +119,13 @@ _Target of TICKET-005, TICKET-006._
 File: `packages/physics/src/domain/services/physicsStep.bench.test.ts`
 
 > Times are in **ms** (milliseconds). Scene: N dynamic sphere bodies above a static ground plane.
-> Baselines are unchanged post-TICKET-004. This benchmark uses sphere-sphere and sphere-plane
-> paths which were already scalar-heavy; TICKET-004 eliminates allocations primarily in
-> box/capsule paths and reduces GC pressure over sustained play (not visible in short-run hz).
+> Baselines are unchanged post-TICKET-006. The sphere-plane scene is not sensitive to the
+> broad-phase fallback fix (TICKET-006) because planes always pair against every body regardless.
+> The fallback fix has the largest impact in settled scenes with spread-apart bodies: a 100-body
+> settled scene previously triggered the O(n²) fallback generating 4950 spurious narrow-phase
+> calls per step; post-fix it generates 0 (only bodies whose AABBs actually overlap are tested).
+> TICKET-005 and TICKET-006 savings are primarily GC pressure and worst-case frame spikes; the
+> short-run hz on this particular benchmark is largely unchanged.
 
 | Benchmark | hz | mean (ms) | p75 (ms) | p99 (ms) | rme |
 |---|---|---|---|---|---|


### PR DESCRIPTION
## Summary

- **Removes the O(n²) naive fallback** that incorrectly triggered when the spatial grid returned zero pairs. Zero pairs is the *correct* result when no AABBs overlap (e.g. a settled 100-body scene). The fallback was generating up to `n*(n-1)/2 = 4950` spurious narrow-phase calls per step in those cases.
- **Numeric cell keys**: replaces string `${x},${y},${z}` with a bit-packed integer `((x+0x8000)*0x10000+(y+0x8000))*0x10000+(z+0x8000)`, collision-free for grid coordinates in [-32768, 32767].
- **Numeric pair-dedup keys**: replaces string `` `${ai}|${bi}` `` with triangular encoding `lo + hi*(hi+1)/2` — unique, order-independent, no hash collisions.

The short-run sphere-plane benchmark hz is largely unchanged (planes always pair against every body regardless of fallback), but settled scenes with spread-apart bodies benefit directly from the fallback removal.

Closes TICKET-006