### PR TITLE
TICKET-001: Wire StatsOverlaySystem into platformer demo

### DIFF
--- a/demos/platformer/src/main.ts
+++ b/demos/platformer/src/main.ts
@@ -1,7 +1,7 @@
 import { World, installDefaults } from '@pulse-ts/core';
 import { installInput } from '@pulse-ts/input';
 import { installPhysics } from '@pulse-ts/physics';
-import { installThree } from '@pulse-ts/three';
+import { installThree, StatsOverlaySystem } from '@pulse-ts/three';
 import { bindings } from './config/bindings';
 import { LevelNode } from './nodes/LevelNode';
 
@@ -21,6 +21,8 @@ const three = installThree(world, {
 // Enable shadows on the renderer
 three.renderer.shadowMap.enabled = true;
 three.renderer.shadowMap.type = 2; // THREE.PCFSoftShadowMap
+
+world.addSystem(new StatsOverlaySystem({ position: 'top-left' }));
 
 world.mount(LevelNode);
 world.start();


### PR DESCRIPTION
Adds the FPS/SPS stats overlay to the platformer's main.ts so performance can be visually monitored during manual testing.

- Imports `StatsOverlaySystem` from `@pulse-ts/three`
- Installs it with `world.addSystem(new StatsOverlaySystem({ position: 'top-left' }))` before world start
- Overlay updates every 300ms (default), displays FPS and fixed step rate, zero noticeable frame cost

Closes TICKET-001. Unblocks TICKET-007.