### PR TITLE
fix: physics interpolation for player mesh and camera follow

### DIFF
--- a/demos/platformer/src/nodes/CameraRigNode.ts
+++ b/demos/platformer/src/nodes/CameraRigNode.ts
@@ -1,4 +1,6 @@
 import {
+    useWorld,
+    useFixedEarly,
     useFrameUpdate,
     Transform,
     getComponent,
@@ -16,30 +18,56 @@ export interface CameraRigNodeProps {
 }
 
 export function CameraRigNode(props: Readonly<CameraRigNodeProps>) {
+    const world = useWorld();
     const { camera } = useThreeContext();
 
     // Initial camera position
     camera.position.set(CAMERA_OFFSET_X, CAMERA_OFFSET_Y, CAMERA_OFFSET_Z);
     camera.lookAt(0, 1, 0);
 
+    // Previous physics position of the target — snapshotted each fixed step
+    // so the frame update can interpolate between prevTarget and curTarget
+    // using alpha. Without this the camera lurches once per physics tick
+    // (visible as jitter when physics Hz != render Hz).
+    let prevTargetX = 0;
+    let prevTargetY = 0;
+    let prevTargetZ = 0;
+
+    // Snapshot in fixed.early — before PhysicsSystem integrates transforms in
+    // fixed.update — so prevTarget holds the pre-step position and the frame
+    // update can interpolate correctly between the two physics states.
+    useFixedEarly(() => {
+        const t = getComponent(props.target, Transform);
+        if (!t) return;
+        prevTargetX = t.localPosition.x;
+        prevTargetY = t.localPosition.y;
+        prevTargetZ = t.localPosition.z;
+    });
+
     useFrameUpdate((dt) => {
         const targetTransform = getComponent(props.target, Transform);
         if (!targetTransform) return;
 
-        const targetPos = targetTransform.localPosition;
+        const cur = targetTransform.localPosition;
+        const alpha = world.getAmbientAlpha();
 
-        // Desired camera position: offset from player
-        const desiredX = targetPos.x + CAMERA_OFFSET_X;
-        const desiredY = targetPos.y + CAMERA_OFFSET_Y;
-        const desiredZ = targetPos.z + CAMERA_OFFSET_Z;
+        // Interpolated target position between previous and current physics state
+        const tx = prevTargetX + (cur.x - prevTargetX) * alpha;
+        const ty = prevTargetY + (cur.y - prevTargetY) * alpha;
+        const tz = prevTargetZ + (cur.z - prevTargetZ) * alpha;
 
-        // Smooth follow via lerp
+        // Desired camera position: offset from interpolated player position
+        const desiredX = tx + CAMERA_OFFSET_X;
+        const desiredY = ty + CAMERA_OFFSET_Y;
+        const desiredZ = tz + CAMERA_OFFSET_Z;
+
+        // Smooth follow via exponential decay lerp
         const t = 1 - Math.exp(-LERP_SPEED * dt);
         camera.position.x += (desiredX - camera.position.x) * t;
         camera.position.y += (desiredY - camera.position.y) * t;
         camera.position.z += (desiredZ - camera.position.z) * t;
 
-        // Look at player
-        camera.lookAt(targetPos.x, targetPos.y + 1, targetPos.z);
+        // Look at interpolated player position
+        camera.lookAt(tx, ty + 1, tz);
     });
 }


### PR DESCRIPTION
## Problem

The camera (and player mesh) snapped to the physics position once per fixed step rather than moving smoothly every rendered frame. At 60 Hz physics with a 120 Hz display, the player and camera would update visibly only every other frame — producing the "jagged" / "laggy" feeling.

## Root cause

The engine uses a fixed-step physics loop (default 60 Hz) decoupled from the render loop. `world.getAmbientAlpha()` exposes the fraction of the current fixed step that has elapsed this frame, which is exactly the interpolation factor needed — but nothing was using it.

## Fix

Both `PlayerNode` and `CameraRigNode` now:
1. **Snapshot** the pre-step physics position in `fixed.early` (before `PhysicsSystem` integrates transforms in `fixed.update`)
2. **Interpolate** between that snapshot and the current position in `useFrameUpdate` using `world.getAmbientAlpha()`

The camera's exponential-decay smooth-follow lerp then operates on the already-interpolated target position, so both the player mesh and the camera track smoothly at full render frame rate.