### PR TITLE
TICKET-010: Implement kinematic rigid bodies in @pulse-ts/physics

### DIFF
--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-002-platformer-demo-advanced-features/todo/TICKET-010-kinematic-rigid-bodies.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-002-platformer-demo-advanced-features/todo/TICKET-010-kinematic-rigid-bodies.md
@@ -1,0 +1,38 @@
+---
+id: TICKET-010
+epic: EPIC-002
+title: Kinematic rigid bodies
+status: in-progress
+priority: high
+created: 2026-02-25
+updated: 2026-02-25
+branch: ticket-010-kinematic-rigid-bodies
+---
+
+## Description
+
+Implement the `kinematic` RigidBodyType in `@pulse-ts/physics`. The type already exists in the union (`'dynamic' | 'kinematic' | 'static'`) but currently behaves identically to `static` — no code handles it specially.
+
+A kinematic body:
+- Moves via scripted velocity (set `linearVelocity` / `angularVelocity` directly each step)
+- Has infinite mass from the collision solver's perspective (forces and impulses don't affect it)
+- Pushes and carries dynamic bodies that collide with it (velocity-based push, not force-based)
+- Does NOT respond to gravity
+
+Required changes:
+- **`integration.ts`** — `integrateTransforms`: move kinematic bodies by their `linearVelocity * dt` and `angularVelocity * dt` (like dynamic, but skip the velocity-integration step)
+- **`integration.ts`** — `integrateVelocities`: skip kinematic bodies (no gravity, no damping)
+- **`solver.ts`** — treat kinematic bodies as infinite mass (invMass = 0) in constraint solving, but still apply the reaction to the dynamic counterpart
+- **`PhysicsService.ts`** — `registerRigidBody` / `step`: no special changes needed; kinematic bodies are already in `this.bodies`
+
+## Acceptance Criteria
+
+- [ ] `type: 'kinematic'` on a RigidBody causes it to move by its velocity each step without responding to forces or gravity
+- [ ] Dynamic bodies colliding with a kinematic body are pushed correctly (kinematic wins)
+- [ ] Setting `linearVelocity` on a kinematic body moves it predictably
+- [ ] All existing physics tests pass
+- [ ] New tests covering kinematic body movement and kinematic-dynamic interaction
+
+## Notes
+
+- **2026-02-25**: Ticket created. Blocks TICKET-011 (moving platforms).

--- a/packages/physics/src/domain/engine/dynamics/integration.kinematic.test.ts
+++ b/packages/physics/src/domain/engine/dynamics/integration.kinematic.test.ts
@@ -1,0 +1,134 @@
+import { World, Node, attachComponent, Transform, Vec3 } from '@pulse-ts/core';
+import { RigidBody } from '../../../public/components/RigidBody';
+import { Collider } from '../../../public/components/Collider';
+import { integrateVelocities, integrateTransforms } from './integration';
+import {
+    solveContactsIterative,
+    type ContactConstraint,
+} from '../solver/solver';
+
+function makeBody(type: 'dynamic' | 'kinematic' | 'static' = 'dynamic') {
+    const world = new World();
+    const node = new Node();
+    world.add(node);
+    const t = attachComponent(node, Transform);
+    const rb = attachComponent(node, RigidBody);
+    rb.type = type;
+    rb.mass = 1;
+    return { world, node, t, rb };
+}
+
+const gravity = new Vec3(0, -10, 0);
+const dt = 1 / 60;
+
+describe('kinematic body — integrateTransforms', () => {
+    it('moves by linearVelocity each step', () => {
+        const { t, rb } = makeBody('kinematic');
+        rb.linearVelocity.set(2, 0, 0);
+        integrateTransforms([rb], dt);
+        expect(t.localPosition.x).toBeCloseTo(2 * dt, 6);
+        expect(t.localPosition.y).toBeCloseTo(0, 6);
+    });
+
+    it('rotates by angularVelocity each step', () => {
+        const { t, rb } = makeBody('kinematic');
+        rb.angularVelocity.set(0, Math.PI, 0); // 180 deg/s around Y
+        integrateTransforms([rb], dt);
+        // Some rotation must have been applied
+        const rot = t.localRotation;
+        expect(rot.w).toBeLessThan(1);
+        expect(rot.y).not.toBeCloseTo(0, 3);
+    });
+
+    it('does not move when linearVelocity is zero', () => {
+        const { t, rb } = makeBody('kinematic');
+        integrateTransforms([rb], dt);
+        expect(t.localPosition.x).toBeCloseTo(0, 6);
+        expect(t.localPosition.y).toBeCloseTo(0, 6);
+    });
+});
+
+describe('kinematic body — integrateVelocities', () => {
+    it('does not accumulate gravity', () => {
+        const { rb } = makeBody('kinematic');
+        integrateVelocities([rb], gravity, dt, () => false);
+        expect(rb.linearVelocity.y).toBeCloseTo(0, 6);
+    });
+
+    it('ignores applied impulses (clears without applying)', () => {
+        const { rb } = makeBody('kinematic');
+        rb.applyImpulse(0, 100, 0);
+        integrateVelocities([rb], gravity, dt, () => false);
+        expect(rb.linearVelocity.y).toBeCloseTo(0, 6);
+        expect(rb.impulse.y).toBeCloseTo(0, 6); // accumulator cleared
+    });
+
+    it('ignores applied forces (clears without applying)', () => {
+        const { rb } = makeBody('kinematic');
+        rb.applyForce(0, 200, 0);
+        integrateVelocities([rb], gravity, dt, () => false);
+        expect(rb.linearVelocity.y).toBeCloseTo(0, 6);
+        expect(rb.force.y).toBeCloseTo(0, 6); // accumulator cleared
+    });
+
+    it('preserves externally set velocity unchanged', () => {
+        const { rb } = makeBody('kinematic');
+        rb.linearVelocity.set(3, 5, -2);
+        integrateVelocities([rb], gravity, dt, () => false);
+        expect(rb.linearVelocity.x).toBeCloseTo(3, 6);
+        expect(rb.linearVelocity.y).toBeCloseTo(5, 6);
+        expect(rb.linearVelocity.z).toBeCloseTo(-2, 6);
+    });
+});
+
+describe('kinematic body — solver interaction', () => {
+    it('inverseMass is 0 (infinite mass from solver perspective)', () => {
+        const { rb } = makeBody('kinematic');
+        expect(rb.inverseMass).toBe(0);
+    });
+
+    it('moving kinematic body pushes dynamic body via velocity-based contact', () => {
+        // Kinematic wall moving +X at 5 m/s, dynamic box overlapping it on the right.
+        // After one round of solveContactsIterative the dynamic box gains +X velocity;
+        // the kinematic body's velocity must remain unchanged (infinite mass).
+        const world = new World();
+
+        const kNode = new Node();
+        world.add(kNode);
+        const kT = attachComponent(kNode, Transform);
+        const kRb = attachComponent(kNode, RigidBody);
+        kRb.type = 'kinematic';
+        kRb.mass = 1;
+        kRb.linearVelocity.set(5, 0, 0);
+        const kCol = attachComponent(kNode, Collider);
+        kCol.kind = 'box';
+        kCol.halfX = kCol.halfY = kCol.halfZ = 0.5;
+        kT.localPosition.set(0, 0, 0);
+
+        const dNode = new Node();
+        world.add(dNode);
+        const dT = attachComponent(dNode, Transform);
+        const dRb = attachComponent(dNode, RigidBody);
+        dRb.type = 'dynamic';
+        dRb.mass = 1;
+        dRb.linearVelocity.set(0, 0, 0);
+        const dCol = attachComponent(dNode, Collider);
+        dCol.kind = 'box';
+        dCol.halfX = dCol.halfY = dCol.halfZ = 0.5;
+        dT.localPosition.set(0.9, 0, 0); // overlapping from the right
+
+        const constraint: ContactConstraint = {
+            a: kCol,
+            b: dCol,
+            nx: 1, ny: 0, nz: 0,
+            depth: 0.1,
+            px: 0.45, py: 0, pz: 0,
+        };
+        solveContactsIterative([constraint], 4, dt);
+
+        // Dynamic body gains positive X velocity (pushed right by the kinematic wall)
+        expect(dRb.linearVelocity.x).toBeGreaterThan(0);
+        // Kinematic body's velocity is untouched (invMass = 0, solver skips it)
+        expect(kRb.linearVelocity.x).toBeCloseTo(5, 6);
+    });
+});

--- a/packages/physics/src/domain/engine/dynamics/integration.ts
+++ b/packages/physics/src/domain/engine/dynamics/integration.ts
@@ -100,7 +100,10 @@ export function integrateTransforms(
     for (const rb of bodies) {
         const t = getComponent(rb.owner, Transform);
         if (!t) continue;
-        if (rb.type === 'dynamic') {
+        // Both dynamic and kinematic bodies integrate velocity → position/rotation.
+        // Kinematic velocity is set externally each step (no gravity or forces applied);
+        // dynamic velocity is managed by integrateVelocities.
+        if (rb.type === 'dynamic' || rb.type === 'kinematic') {
             t.localPosition.addScaled(rb.linearVelocity, dt);
             const wx = rb.angularVelocity.x,
                 wy = rb.angularVelocity.y,

--- a/packages/physics/src/domain/types.ts
+++ b/packages/physics/src/domain/types.ts
@@ -3,7 +3,10 @@ import type { Vec3, Node } from '@pulse-ts/core';
 /**
  * Supported high-level rigid body motion types.
  * - `dynamic`: simulated; affected by forces, impulses, gravity, and collisions.
- * - `kinematic`: controlled externally (e.g., set directly); does not respond to forces.
+ * - `kinematic`: scripted movement; set `linearVelocity`/`angularVelocity` each step to drive
+ *   motion. Integrates velocity → position like dynamic, but ignores gravity, forces, impulses,
+ *   and damping. Has infinite mass from the collision solver's perspective — pushes dynamic
+ *   bodies but is never displaced by them.
  * - `static`: immovable; used for level geometry or anchors.
  */
 export type RigidBodyType = 'dynamic' | 'kinematic' | 'static';


### PR DESCRIPTION
## Summary

The `'kinematic'` `RigidBodyType` was already declared in the union but was completely unimplemented — it behaved identically to `'static'` (no movement).

## What kinematic bodies do

Set `linearVelocity` / `angularVelocity` on the body each fixed step; the physics system integrates that velocity into position/rotation, but never modifies the velocity itself (no gravity, no forces, no damping, no impulses). From the collision solver's perspective the body has infinite mass — it pushes dynamic bodies but is never displaced by them.

## Changes

**`integration.ts` — `integrateTransforms`**
One-line change: `if (rb.type === 'dynamic')` → `if (rb.type === 'dynamic' || rb.type === 'kinematic')`. Both types integrate `linearVelocity` and `angularVelocity` into position/rotation using identical math. The world-plane bounce guard remains dynamic-only.

**`integrateVelocities`** — no change needed. The existing non-dynamic branch already clears accumulators and skips gravity/damping, leaving kinematic `linearVelocity` untouched.

**Solver** — no change needed. `inverseMass` already returns `0` for non-dynamic bodies, giving infinite mass. The solver already reads `linearVelocity` for relative-velocity computation, so a moving kinematic body already correctly pushes dynamic bodies.

**`types.ts`** — updated JSDoc to describe the real behaviour.

## Tests

9 new tests in `integration.kinematic.test.ts` covering: linear/angular integration, gravity immunity, force/impulse immunity, velocity preservation, `inverseMass === 0`, and kinematic→dynamic push via the constraint solver.

Unblocks TICKET-011 (moving/rotating platforms) and TICKET-020 (patrolling enemy).