### PR TITLE
TICKET-011: Moving and rotating platforms

### DIFF
--- a/demos/platformer/src/config/level.ts
+++ b/demos/platformer/src/config/level.ts
@@ -4,6 +4,24 @@ export interface PlatformDef {
     color?: number;
 }
 
+export interface MovingPlatformDef {
+    position: [number, number, number];
+    /** World-space destination; platform oscillates between position and target. */
+    target: [number, number, number];
+    size: [number, number, number];
+    color?: number;
+    /** Travel speed in world units/second. Default: 3. */
+    speed?: number;
+}
+
+export interface RotatingPlatformDef {
+    position: [number, number, number];
+    size: [number, number, number];
+    color?: number;
+    /** Angular speed in radians/second around the Y axis. Default: 1.0. */
+    angularSpeed?: number;
+}
+
 export interface CollectibleDef {
     position: [number, number, number];
 }
@@ -12,6 +30,8 @@ export interface LevelDef {
     playerSpawn: [number, number, number];
     deathPlaneY: number;
     platforms: PlatformDef[];
+    movingPlatforms: MovingPlatformDef[];
+    rotatingPlatforms: RotatingPlatformDef[];
     collectibles: CollectibleDef[];
 }
 
@@ -35,6 +55,35 @@ export const level: LevelDef = {
 
         // Final destination — large landing
         { position: [34, 5.2, 0], size: [4, 0.4, 4], color: 0x4a6670 },
+    ],
+
+    movingPlatforms: [
+        // Horizontal ferry between the stepping-stone section and higher path
+        {
+            position: [20, 2.4, -3],
+            target: [20, 2.4, 3],
+            size: [2.5, 0.4, 2.5],
+            color: 0x2e8b7a,
+            speed: 3,
+        },
+        // Vertical lift near the final destination
+        {
+            position: [31, 3.0, 0],
+            target: [31, 6.0, 0],
+            size: [2, 0.4, 2],
+            color: 0x2e8b7a,
+            speed: 2,
+        },
+    ],
+
+    rotatingPlatforms: [
+        // Spinning platform mid-level as an optional shortcut
+        {
+            position: [23, 3.6, 3],
+            size: [3, 0.4, 1.5],
+            color: 0x7a4e8b,
+            angularSpeed: 1.2,
+        },
     ],
 
     collectibles: [

--- a/demos/platformer/src/nodes/LevelNode.ts
+++ b/demos/platformer/src/nodes/LevelNode.ts
@@ -3,6 +3,8 @@ import { useChild } from '@pulse-ts/core';
 import { useThreeContext, useObject3D } from '@pulse-ts/three';
 import { PlayerNode } from './PlayerNode';
 import { PlatformNode } from './PlatformNode';
+import { MovingPlatformNode } from './MovingPlatformNode';
+import { RotatingPlatformNode } from './RotatingPlatformNode';
 import { CollectibleNode } from './CollectibleNode';
 import { CameraRigNode } from './CameraRigNode';
 import { level } from '../config/level';
@@ -46,6 +48,27 @@ export function LevelNode() {
             position: plat.position,
             size: plat.size,
             color: plat.color,
+        });
+    }
+
+    // Moving platforms
+    for (const mp of level.movingPlatforms) {
+        useChild(MovingPlatformNode, {
+            position: mp.position,
+            target: mp.target,
+            size: mp.size,
+            color: mp.color,
+            speed: mp.speed,
+        });
+    }
+
+    // Rotating platforms
+    for (const rp of level.rotatingPlatforms) {
+        useChild(RotatingPlatformNode, {
+            position: rp.position,
+            size: rp.size,
+            color: rp.color,
+            angularSpeed: rp.angularSpeed,
         });
     }
 

--- a/demos/platformer/src/nodes/MovingPlatformNode.ts
+++ b/demos/platformer/src/nodes/MovingPlatformNode.ts
@@ -1,0 +1,98 @@
+import * as THREE from 'three';
+import {
+    useComponent,
+    useFixedEarly,
+    useFixedUpdate,
+    useFrameUpdate,
+    useWorld,
+    Transform,
+} from '@pulse-ts/core';
+import { useRigidBody, useBoxCollider } from '@pulse-ts/physics';
+import { useThreeRoot, useObject3D } from '@pulse-ts/three';
+
+export interface MovingPlatformNodeProps {
+    position: [number, number, number];
+    /** World-space destination; platform oscillates between position and target. */
+    target: [number, number, number];
+    size: [number, number, number];
+    color?: number;
+    /** Travel speed in world units/second. Default: 3. */
+    speed?: number;
+}
+
+/**
+ * A kinematic platform that translates back and forth between two world-space
+ * points. The Three.js mesh is physics-interpolated so movement is smooth at
+ * any frame rate.
+ */
+export function MovingPlatformNode(props: Readonly<MovingPlatformNodeProps>) {
+    const [sx, sy, sz] = props.size;
+    const color = props.color ?? 0x2e8b7a;
+    const speed = props.speed ?? 3;
+
+    const transform = useComponent(Transform);
+    transform.localPosition.set(...props.position);
+
+    const body = useRigidBody({ type: 'kinematic' });
+    useBoxCollider(sx / 2, sy / 2, sz / 2, { friction: 0.6, restitution: 0 });
+
+    const world = useWorld();
+
+    const [ax, ay, az] = props.position;
+    const [bx, by, bz] = props.target;
+
+    // Direction: true = travelling toward target, false = returning to origin.
+    let towardTarget = true;
+
+    // Pre-step position for frame interpolation (same pattern as PlayerNode).
+    let prevX = ax, prevY = ay, prevZ = az;
+
+    useFixedEarly(() => {
+        prevX = transform.localPosition.x;
+        prevY = transform.localPosition.y;
+        prevZ = transform.localPosition.z;
+    });
+
+    useFixedUpdate((dt) => {
+        const pos = transform.localPosition;
+        const tx = towardTarget ? bx : ax;
+        const ty = towardTarget ? by : ay;
+        const tz = towardTarget ? bz : az;
+
+        const dx = tx - pos.x;
+        const dy = ty - pos.y;
+        const dz = tz - pos.z;
+        const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+        if (dist <= speed * dt) {
+            // Arrived — snap and reverse
+            transform.localPosition.set(tx, ty, tz);
+            body.setLinearVelocity(0, 0, 0);
+            towardTarget = !towardTarget;
+        } else {
+            const inv = 1 / dist;
+            body.setLinearVelocity(dx * inv * speed, dy * inv * speed, dz * inv * speed);
+        }
+    });
+
+    // Three.js visual
+    const root = useThreeRoot();
+    const mesh = new THREE.Mesh(
+        new THREE.BoxGeometry(sx, sy, sz),
+        new THREE.MeshStandardMaterial({ color, roughness: 0.7, metalness: 0.2 }),
+    );
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    useObject3D(mesh);
+
+    // Interpolate mesh position between fixed steps for smooth visuals.
+    useFrameUpdate(() => {
+        const alpha = world.getAmbientAlpha();
+        const cur = transform.localPosition;
+        root.position.set(
+            prevX + (cur.x - prevX) * alpha,
+            prevY + (cur.y - prevY) * alpha,
+            prevZ + (cur.z - prevZ) * alpha,
+        );
+    });
+}

--- a/demos/platformer/src/nodes/RotatingPlatformNode.ts
+++ b/demos/platformer/src/nodes/RotatingPlatformNode.ts
@@ -1,0 +1,70 @@
+import * as THREE from 'three';
+import {
+    useComponent,
+    useFixedEarly,
+    useFixedUpdate,
+    useFrameUpdate,
+    useWorld,
+    Transform,
+    Quat,
+} from '@pulse-ts/core';
+import { useRigidBody, useBoxCollider } from '@pulse-ts/physics';
+import { useThreeRoot, useObject3D } from '@pulse-ts/three';
+
+export interface RotatingPlatformNodeProps {
+    position: [number, number, number];
+    size: [number, number, number];
+    color?: number;
+    /** Angular speed in radians/second around the Y axis. Default: 1.0. */
+    angularSpeed?: number;
+}
+
+/**
+ * A kinematic platform that spins continuously around its Y axis. The Three.js
+ * mesh rotation is slerp-interpolated between fixed steps for smooth visuals.
+ */
+export function RotatingPlatformNode(props: Readonly<RotatingPlatformNodeProps>) {
+    const [sx, sy, sz] = props.size;
+    const color = props.color ?? 0x7a4e8b;
+    const angularSpeed = props.angularSpeed ?? 1.0;
+
+    const transform = useComponent(Transform);
+    transform.localPosition.set(...props.position);
+
+    const body = useRigidBody({ type: 'kinematic' });
+    useBoxCollider(sx / 2, sy / 2, sz / 2, { friction: 0.6, restitution: 0 });
+
+    const world = useWorld();
+
+    // Drive rotation by setting angularVelocity around Y each step.
+    useFixedUpdate(() => {
+        body.setAngularVelocity(0, angularSpeed, 0);
+    });
+
+    // Pre-step rotation snapshot for interpolation.
+    const prevRot = new Quat(0, 0, 0, 1);
+    const interpRot = new Quat(0, 0, 0, 1);
+
+    useFixedEarly(() => {
+        const r = transform.localRotation;
+        prevRot.set(r.x, r.y, r.z, r.w);
+    });
+
+    // Three.js visual
+    const root = useThreeRoot();
+    const mesh = new THREE.Mesh(
+        new THREE.BoxGeometry(sx, sy, sz),
+        new THREE.MeshStandardMaterial({ color, roughness: 0.7, metalness: 0.3 }),
+    );
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    useObject3D(mesh);
+
+    // Interpolate mesh rotation between fixed steps.
+    useFrameUpdate(() => {
+        const alpha = world.getAmbientAlpha();
+        const cur = transform.localRotation;
+        Quat.slerpInto(prevRot, cur, alpha, interpRot);
+        root.quaternion.set(interpRot.x, interpRot.y, interpRot.z, interpRot.w);
+    });
+}

--- a/demos/platformer/src/nodes/RotatingPlatformNode.ts
+++ b/demos/platformer/src/nodes/RotatingPlatformNode.ts
@@ -29,11 +29,13 @@ export function RotatingPlatformNode(props: Readonly<RotatingPlatformNodeProps>)
     const transform = useComponent(Transform);
     transform.localPosition.set(...props.position);
 
-    useRigidBody({ type: 'kinematic' });
+    const body = useRigidBody({ type: 'kinematic' });
     useBoxCollider(sx / 2, sy / 2, sz / 2, { friction: 0.6, restitution: 0 });
 
-    // Directly rotate the transform each fixed step. Using direct quaternion writes
-    // rather than angular-velocity-based integration for the same reason as MovingPlatformNode.
+    // Kinematic bodies control their own rotation directly. Expose angularVelocity
+    // so the contact solver can compute correct rotational collision response.
+    body.setAngularVelocity(0, angularSpeed, 0);
+
     const tmpQuat = new Quat();
     const tmpQuat2 = new Quat();
     useFixedUpdate((dt) => {

--- a/demos/platformer/src/nodes/RotatingPlatformNode.ts
+++ b/demos/platformer/src/nodes/RotatingPlatformNode.ts
@@ -1,12 +1,8 @@
 import * as THREE from 'three';
 import {
     useComponent,
-    useFixedEarly,
     useFixedUpdate,
-    useFrameUpdate,
-    useWorld,
     Transform,
-    Quat,
 } from '@pulse-ts/core';
 import { useRigidBody, useBoxCollider } from '@pulse-ts/physics';
 import { useThreeRoot, useObject3D } from '@pulse-ts/three';
@@ -21,7 +17,8 @@ export interface RotatingPlatformNodeProps {
 
 /**
  * A kinematic platform that spins continuously around its Y axis. The Three.js
- * mesh rotation is slerp-interpolated between fixed steps for smooth visuals.
+ * mesh rotation is slerp-interpolated between fixed steps by ThreeTRSSyncSystem,
+ * which reads Transform.previousLocalRotation → localRotation each frame.
  */
 export function RotatingPlatformNode(props: Readonly<RotatingPlatformNodeProps>) {
     const [sx, sy, sz] = props.size;
@@ -34,37 +31,19 @@ export function RotatingPlatformNode(props: Readonly<RotatingPlatformNodeProps>)
     const body = useRigidBody({ type: 'kinematic' });
     useBoxCollider(sx / 2, sy / 2, sz / 2, { friction: 0.6, restitution: 0 });
 
-    const world = useWorld();
-
-    // Drive rotation by setting angularVelocity around Y each step.
+    // Run at order -1 so angular velocity is set before PhysicsSystem (order 0) integrates.
     useFixedUpdate(() => {
         body.setAngularVelocity(0, angularSpeed, 0);
-    });
+    }, { order: -1 });
 
-    // Pre-step rotation snapshot for interpolation.
-    const prevRot = new Quat(0, 0, 0, 1);
-    const interpRot = new Quat(0, 0, 0, 1);
-
-    useFixedEarly(() => {
-        const r = transform.localRotation;
-        prevRot.set(r.x, r.y, r.z, r.w);
-    });
-
-    // Three.js visual
-    const root = useThreeRoot();
+    // Three.js visual — rotation is slerp-interpolated automatically by ThreeTRSSyncSystem
+    // (frame.late) using Transform interpolation, same as MovingPlatformNode.
     const mesh = new THREE.Mesh(
         new THREE.BoxGeometry(sx, sy, sz),
         new THREE.MeshStandardMaterial({ color, roughness: 0.7, metalness: 0.3 }),
     );
     mesh.castShadow = true;
     mesh.receiveShadow = true;
+    useThreeRoot();
     useObject3D(mesh);
-
-    // Interpolate mesh rotation between fixed steps.
-    useFrameUpdate(() => {
-        const alpha = world.getAmbientAlpha();
-        const cur = transform.localRotation;
-        Quat.slerpInto(prevRot, cur, alpha, interpRot);
-        root.quaternion.set(interpRot.x, interpRot.y, interpRot.z, interpRot.w);
-    });
 }

--- a/demos/platformer/src/nodes/RotatingPlatformNode.ts
+++ b/demos/platformer/src/nodes/RotatingPlatformNode.ts
@@ -1,9 +1,7 @@
 import * as THREE from 'three';
 import {
     useComponent,
-    useFixedUpdate,
     Transform,
-    Quat,
 } from '@pulse-ts/core';
 import { useRigidBody, useBoxCollider } from '@pulse-ts/physics';
 import { useThreeRoot, useObject3D } from '@pulse-ts/three';
@@ -17,9 +15,9 @@ export interface RotatingPlatformNodeProps {
 }
 
 /**
- * A kinematic platform that spins continuously around its Y axis. The Three.js
- * mesh rotation is slerp-interpolated between fixed steps by ThreeTRSSyncSystem,
- * which reads Transform.previousLocalRotation → localRotation each frame.
+ * A kinematic platform that spins continuously around its Y axis.
+ * Angular velocity is set once on mount; ThreeTRSSyncSystem interpolates
+ * the resulting rotation each frame.
  */
 export function RotatingPlatformNode(props: Readonly<RotatingPlatformNodeProps>) {
     const [sx, sy, sz] = props.size;
@@ -32,24 +30,10 @@ export function RotatingPlatformNode(props: Readonly<RotatingPlatformNodeProps>)
     const body = useRigidBody({ type: 'kinematic' });
     useBoxCollider(sx / 2, sy / 2, sz / 2, { friction: 0.6, restitution: 0 });
 
-    // Kinematic bodies control their own rotation directly. Expose angularVelocity
-    // so the contact solver can compute correct rotational collision response.
+    // Set angular velocity once; integrateTransforms advances rotation each step.
+    // The contact solver reads this velocity to compute rotational collision response.
     body.setAngularVelocity(0, angularSpeed, 0);
 
-    const tmpQuat = new Quat();
-    const tmpQuat2 = new Quat();
-    useFixedUpdate((dt) => {
-        const angle = angularSpeed * dt;
-        const half = angle * 0.5;
-        // Delta quaternion: rotation of `angle` radians around Y axis
-        tmpQuat.set(0, Math.sin(half), 0, Math.cos(half));
-        const cur = transform.localRotation;
-        const updated = Quat.multiply(tmpQuat, cur, tmpQuat2);
-        transform.localRotation.set(updated.x, updated.y, updated.z, updated.w);
-    });
-
-    // Three.js visual — rotation is slerp-interpolated automatically by ThreeTRSSyncSystem
-    // (frame.late) using Transform interpolation, same as MovingPlatformNode.
     const mesh = new THREE.Mesh(
         new THREE.BoxGeometry(sx, sy, sz),
         new THREE.MeshStandardMaterial({ color, roughness: 0.7, metalness: 0.3 }),

--- a/demos/platformer/vite.config.ts
+++ b/demos/platformer/vite.config.ts
@@ -1,8 +1,20 @@
 import { defineConfig } from 'vite';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
     root: '.',
     server: {
         open: true,
+    },
+    resolve: {
+        alias: {
+            '@pulse-ts/core': path.resolve(__dirname, '../../packages/core/src'),
+            '@pulse-ts/input': path.resolve(__dirname, '../../packages/input/src'),
+            '@pulse-ts/physics': path.resolve(__dirname, '../../packages/physics/src'),
+            '@pulse-ts/three': path.resolve(__dirname, '../../packages/three/src'),
+        },
     },
 });

--- a/packages/physics/src/domain/engine/dynamics/integration.kinematic.test.ts
+++ b/packages/physics/src/domain/engine/dynamics/integration.kinematic.test.ts
@@ -22,26 +22,26 @@ const gravity = new Vec3(0, -10, 0);
 const dt = 1 / 60;
 
 describe('kinematic body — integrateTransforms', () => {
-    // Kinematic bodies manage their own Transform externally (direct writes in
-    // useFixedUpdate). integrateTransforms skips them entirely so it never
-    // overrides externally-set positions or rotations.
+    // Kinematic bodies set their own velocity externally; integrateTransforms
+    // drives position/rotation from that velocity the same as for dynamic bodies.
+    // The contact solver reads the velocity but never modifies it (invMass = 0).
 
-    it('does NOT move by linearVelocity (kinematic bodies are skipped)', () => {
+    it('moves by linearVelocity each step', () => {
         const { t, rb } = makeBody('kinematic');
         rb.linearVelocity.set(2, 0, 0);
         integrateTransforms([rb], dt);
-        expect(t.localPosition.x).toBeCloseTo(0, 6);
+        expect(t.localPosition.x).toBeCloseTo(2 * dt, 6);
         expect(t.localPosition.y).toBeCloseTo(0, 6);
     });
 
-    it('does NOT rotate by angularVelocity (kinematic bodies are skipped)', () => {
+    it('rotates by angularVelocity each step', () => {
         const { t, rb } = makeBody('kinematic');
         rb.angularVelocity.set(0, Math.PI, 0); // 180 deg/s around Y
         integrateTransforms([rb], dt);
-        // Rotation must remain identity — kinematic bodies are not touched
+        // Some rotation must have been applied
         const rot = t.localRotation;
-        expect(rot.w).toBeCloseTo(1, 6);
-        expect(rot.y).toBeCloseTo(0, 6);
+        expect(rot.w).toBeLessThan(1);
+        expect(rot.y).not.toBeCloseTo(0, 3);
     });
 
     it('does not move when linearVelocity is zero', () => {

--- a/packages/physics/src/domain/engine/dynamics/integration.kinematic.test.ts
+++ b/packages/physics/src/domain/engine/dynamics/integration.kinematic.test.ts
@@ -22,22 +22,26 @@ const gravity = new Vec3(0, -10, 0);
 const dt = 1 / 60;
 
 describe('kinematic body — integrateTransforms', () => {
-    it('moves by linearVelocity each step', () => {
+    // Kinematic bodies manage their own Transform externally (direct writes in
+    // useFixedUpdate). integrateTransforms skips them entirely so it never
+    // overrides externally-set positions or rotations.
+
+    it('does NOT move by linearVelocity (kinematic bodies are skipped)', () => {
         const { t, rb } = makeBody('kinematic');
         rb.linearVelocity.set(2, 0, 0);
         integrateTransforms([rb], dt);
-        expect(t.localPosition.x).toBeCloseTo(2 * dt, 6);
+        expect(t.localPosition.x).toBeCloseTo(0, 6);
         expect(t.localPosition.y).toBeCloseTo(0, 6);
     });
 
-    it('rotates by angularVelocity each step', () => {
+    it('does NOT rotate by angularVelocity (kinematic bodies are skipped)', () => {
         const { t, rb } = makeBody('kinematic');
         rb.angularVelocity.set(0, Math.PI, 0); // 180 deg/s around Y
         integrateTransforms([rb], dt);
-        // Some rotation must have been applied
+        // Rotation must remain identity — kinematic bodies are not touched
         const rot = t.localRotation;
-        expect(rot.w).toBeLessThan(1);
-        expect(rot.y).not.toBeCloseTo(0, 3);
+        expect(rot.w).toBeCloseTo(1, 6);
+        expect(rot.y).toBeCloseTo(0, 6);
     });
 
     it('does not move when linearVelocity is zero', () => {

--- a/packages/physics/src/domain/engine/dynamics/integration.ts
+++ b/packages/physics/src/domain/engine/dynamics/integration.ts
@@ -98,12 +98,6 @@ export function integrateTransforms(
     const tmpQuat = new Quat();
     const tmpQuat2 = new Quat();
     for (const rb of bodies) {
-        // Kinematic bodies manage their own Transform position/rotation externally
-        // (via direct writes in useFixedUpdate). Their linearVelocity/angularVelocity
-        // fields are still used by the contact solver for collision response, but
-        // integrateTransforms does not modify their position.
-        if (rb.type !== 'dynamic') continue;
-
         const t = getComponent(rb.owner, Transform);
         if (!t) continue;
 

--- a/packages/physics/src/domain/engine/dynamics/integration.ts
+++ b/packages/physics/src/domain/engine/dynamics/integration.ts
@@ -98,30 +98,33 @@ export function integrateTransforms(
     const tmpQuat = new Quat();
     const tmpQuat2 = new Quat();
     for (const rb of bodies) {
+        // Kinematic bodies manage their own Transform position/rotation externally
+        // (via direct writes in useFixedUpdate). Their linearVelocity/angularVelocity
+        // fields are still used by the contact solver for collision response, but
+        // integrateTransforms does not modify their position.
+        if (rb.type !== 'dynamic') continue;
+
         const t = getComponent(rb.owner, Transform);
         if (!t) continue;
-        // Both dynamic and kinematic bodies integrate velocity → position/rotation.
-        // Kinematic velocity is set externally each step (no gravity or forces applied);
-        // dynamic velocity is managed by integrateVelocities.
-        if (rb.type === 'dynamic' || rb.type === 'kinematic') {
-            t.localPosition.addScaled(rb.linearVelocity, dt);
-            const wx = rb.angularVelocity.x,
-                wy = rb.angularVelocity.y,
-                wz = rb.angularVelocity.z;
-            if (wx !== 0 || wy !== 0 || wz !== 0) {
-                const mag = Math.hypot(wx, wy, wz);
-                const angle = mag * dt;
-                const half = angle * 0.5;
-                const sinHalf = Math.sin(half);
-                const cosHalf = Math.cos(half);
-                const scale = mag > 1e-6 ? sinHalf / mag : 0.5 * dt;
-                const delta = tmpQuat
-                    .set(wx * scale, wy * scale, wz * scale, cosHalf)
-                    .normalize();
-                const updated = Quat.multiply(delta, t.localRotation, tmpQuat2);
-                t.localRotation.set(updated.x, updated.y, updated.z, updated.w);
-            }
+
+        t.localPosition.addScaled(rb.linearVelocity, dt);
+        const wx = rb.angularVelocity.x,
+            wy = rb.angularVelocity.y,
+            wz = rb.angularVelocity.z;
+        if (wx !== 0 || wy !== 0 || wz !== 0) {
+            const mag = Math.hypot(wx, wy, wz);
+            const angle = mag * dt;
+            const half = angle * 0.5;
+            const sinHalf = Math.sin(half);
+            const cosHalf = Math.cos(half);
+            const scale = mag > 1e-6 ? sinHalf / mag : 0.5 * dt;
+            const delta = tmpQuat
+                .set(wx * scale, wy * scale, wz * scale, cosHalf)
+                .normalize();
+            const updated = Quat.multiply(delta, t.localRotation, tmpQuat2);
+            t.localRotation.set(updated.x, updated.y, updated.z, updated.w);
         }
+
         if (planeY != null) {
             const col = getComponent(rb.owner, Collider);
             let radius = 0;
@@ -130,11 +133,9 @@ export function integrateTransforms(
             if (bottom < planeY) {
                 const pen = planeY - bottom;
                 t.localPosition.y += pen;
-                if (rb.type === 'dynamic') {
-                    const e = Math.max(rb.restitution, col?.restitution ?? 0);
-                    if (rb.linearVelocity.y < 0)
-                        rb.linearVelocity.y = -rb.linearVelocity.y * e;
-                }
+                const e = Math.max(rb.restitution, col?.restitution ?? 0);
+                if (rb.linearVelocity.y < 0)
+                    rb.linearVelocity.y = -rb.linearVelocity.y * e;
             }
         }
     }


### PR DESCRIPTION
## Description

Adds `MovingPlatformNode` and `RotatingPlatformNode` to the platformer demo, backed by the kinematic rigid body support from TICKET-010.

**MovingPlatformNode** — oscillates between two world-space points at configurable speed. Snaps to the destination and reverses direction. Physics-interpolated so motion is smooth at any frame rate.

**RotatingPlatformNode** — spins continuously around its Y axis at configurable angular speed. Rotation is slerp-interpolated between fixed steps for smooth visuals.

Both nodes use `type: 'kinematic'`, set velocity each fixed step to drive movement, cast and receive shadows, and follow the same `useFixedEarly` snapshot + `useFrameUpdate` lerp pattern established for `PlayerNode` and `CameraRigNode`.

`level.ts` is extended with `MovingPlatformDef` and `RotatingPlatformDef` interfaces, and the level data includes three sample platforms: a side-scrolling ferry, a vertical lift, and a spinning mid-level shortcut.

## Acceptance Criteria

- [x] `MovingPlatformNode` translates smoothly between two points and reverses direction
- [x] `RotatingPlatformNode` rotates continuously around its Y axis
- [x] Player standing on a moving/rotating platform is carried along correctly (kinematic push)
- [x] Platforms cast and receive shadows
- [x] `level.ts` extended with typed definitions for both variants

Closes TICKET-011