### PR TITLE
TICKET-012: Goal object and win screen

### DIFF
--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-002-platformer-demo-advanced-features/done/TICKET-012-goal-object-and-win-screen.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-002-platformer-demo-advanced-features/done/TICKET-012-goal-object-and-win-screen.md
@@ -2,10 +2,10 @@
 id: TICKET-012
 epic: EPIC-002
 title: Goal object and win screen
-status: todo
+status: done
 priority: high
 created: 2026-02-25
-updated: 2026-02-25
+updated: 2026-02-26
 ---
 
 ## Description
@@ -18,11 +18,13 @@ Add a goal object (e.g., a glowing portal or star) at the end of the level. When
 
 ## Acceptance Criteria
 
-- [ ] A visually distinct goal object appears at the end of the level
-- [ ] Touching the goal triggers the win screen
-- [ ] Win screen is clearly readable and offers a way to restart
-- [ ] Win screen does not require a UI framework — plain DOM is fine
+- [x] A visually distinct goal object appears at the end of the level
+- [x] Touching the goal triggers the win screen
+- [x] Win screen is clearly readable and offers a way to restart
+- [x] Win screen does not require a UI framework — plain DOM is fine
 
 ## Notes
 
 - **2026-02-25**: Ticket created. No blockers.
+- **2026-02-26**: Starting implementation — GoalNode FC, showWinScreen helper, level config, LevelNode wiring.
+- **2026-02-26**: Complete. Created GoalNode with octahedron visual, spin/bob animation, trigger collider, and win screen overlay. All 11 tests pass.

--- a/demos/platformer/src/components/PlayerTag.ts
+++ b/demos/platformer/src/components/PlayerTag.ts
@@ -1,0 +1,7 @@
+import { Component } from '@pulse-ts/core';
+
+/**
+ * Marker component that identifies a node as the player.
+ * Attach via `useComponent(PlayerTag)` in `PlayerNode`.
+ */
+export class PlayerTag extends Component {}

--- a/demos/platformer/src/config/level.ts
+++ b/demos/platformer/src/config/level.ts
@@ -33,6 +33,7 @@ export interface LevelDef {
     movingPlatforms: MovingPlatformDef[];
     rotatingPlatforms: RotatingPlatformDef[];
     collectibles: CollectibleDef[];
+    goalPosition: [number, number, number];
 }
 
 export const level: LevelDef = {
@@ -93,4 +94,6 @@ export const level: LevelDef = {
         { position: [23, 5.2, 0] },
         { position: [34, 6.8, 0] },
     ],
+
+    goalPosition: [34, 6.8, 0],
 };

--- a/demos/platformer/src/nodes/GoalNode.test.ts
+++ b/demos/platformer/src/nodes/GoalNode.test.ts
@@ -1,0 +1,53 @@
+import { showWinScreen } from './GoalNode';
+
+describe('showWinScreen', () => {
+    let container: HTMLElement;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    it('creates overlay with heading and button', () => {
+        const overlay = showWinScreen(container);
+
+        const heading = overlay.querySelector('h1');
+        expect(heading).not.toBeNull();
+        expect(heading!.textContent).toBe('You Win!');
+
+        const button = overlay.querySelector('button');
+        expect(button).not.toBeNull();
+        expect(button!.textContent).toBe('Play Again');
+    });
+
+    it('appends overlay to the provided container', () => {
+        const overlay = showWinScreen(container);
+
+        expect(container.contains(overlay)).toBe(true);
+    });
+
+    it('has correct positioning styles', () => {
+        const overlay = showWinScreen(container);
+
+        expect(overlay.style.position).toBe('absolute');
+        expect(overlay.style.inset).toBe('0');
+        expect(overlay.style.zIndex).toBe('10000');
+    });
+
+    it('has a semi-transparent backdrop', () => {
+        const overlay = showWinScreen(container);
+
+        expect(overlay.style.backgroundColor).toBe('rgba(0, 0, 0, 0.7)');
+    });
+
+    it('returns the overlay element', () => {
+        const overlay = showWinScreen(container);
+
+        expect(overlay).toBeInstanceOf(HTMLElement);
+        expect(overlay.tagName).toBe('DIV');
+    });
+});

--- a/demos/platformer/src/nodes/GoalNode.ts
+++ b/demos/platformer/src/nodes/GoalNode.ts
@@ -1,0 +1,141 @@
+import * as THREE from 'three';
+import {
+    useComponent,
+    useFrameUpdate,
+    useWorld,
+    Transform,
+} from '@pulse-ts/core';
+import { useRigidBody, useSphereCollider, useOnCollisionStart } from '@pulse-ts/physics';
+import { useThreeRoot, useObject3D, useThreeContext } from '@pulse-ts/three';
+
+const GOAL_RADIUS = 0.6;
+const SPIN_SPEED = 1.2;
+const BOB_SPEED = 1.5;
+const BOB_AMPLITUDE = 0.3;
+const TRIGGER_RADIUS = 1.0;
+
+export interface GoalNodeProps {
+    position: [number, number, number];
+}
+
+/**
+ * Goal object that the player touches to win the level.
+ *
+ * Renders a glowing octahedron with spin and bob animation. When the player
+ * enters its trigger sphere, the world pauses and a win screen overlay appears.
+ *
+ * @param props - Goal position in world space.
+ *
+ * @example
+ * ```ts
+ * import { useChild } from '@pulse-ts/core';
+ * import { GoalNode } from './GoalNode';
+ *
+ * useChild(GoalNode, { position: [34, 6.8, 0] });
+ * ```
+ */
+export function GoalNode(props: Readonly<GoalNodeProps>) {
+    const world = useWorld();
+
+    const transform = useComponent(Transform);
+    transform.localPosition.set(...props.position);
+
+    useRigidBody({ type: 'static' });
+    useSphereCollider(TRIGGER_RADIUS, { isTrigger: true });
+
+    // Three.js visual — octahedron for a gem/trophy look
+    const root = useThreeRoot();
+    const geometry = new THREE.OctahedronGeometry(GOAL_RADIUS, 0);
+    const material = new THREE.MeshStandardMaterial({
+        color: 0xffd700,
+        roughness: 0.2,
+        metalness: 0.8,
+        emissive: 0xffa500,
+        emissiveIntensity: 0.6,
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.castShadow = true;
+    useObject3D(mesh);
+
+    const baseY = props.position[1];
+    let elapsed = 0;
+
+    // Spin and bob animation
+    useFrameUpdate((dt) => {
+        elapsed += dt;
+        mesh.rotation.y += SPIN_SPEED * dt;
+        root.position.set(
+            transform.localPosition.x,
+            baseY + Math.sin(elapsed * BOB_SPEED) * BOB_AMPLITUDE,
+            transform.localPosition.z,
+        );
+    });
+
+    // Win trigger — pause world and show overlay
+    const { renderer } = useThreeContext();
+    useOnCollisionStart(() => {
+        world.pause();
+        const container = renderer.domElement.parentElement ?? document.body;
+        showWinScreen(container);
+    });
+}
+
+/**
+ * Creates and appends a full-screen "You Win!" overlay to the given container.
+ *
+ * The overlay includes a heading and a "Play Again" button that reloads the page.
+ * Styled with absolute positioning and a semi-transparent backdrop.
+ *
+ * @param container - The HTML element to append the overlay to.
+ * @returns The overlay element (useful for testing).
+ *
+ * @example
+ * ```ts
+ * const overlay = showWinScreen(document.getElementById('game')!);
+ * ```
+ */
+export function showWinScreen(container: HTMLElement): HTMLElement {
+    const overlay = document.createElement('div');
+    Object.assign(overlay.style, {
+        position: 'absolute',
+        inset: '0',
+        zIndex: '10000',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    } as Partial<CSSStyleDeclaration>);
+
+    const heading = document.createElement('h1');
+    heading.textContent = 'You Win!';
+    Object.assign(heading.style, {
+        color: '#ffd700',
+        fontSize: '4rem',
+        fontFamily: 'sans-serif',
+        marginBottom: '1.5rem',
+        textShadow: '0 0 20px rgba(255, 215, 0, 0.6)',
+    } as Partial<CSSStyleDeclaration>);
+    overlay.appendChild(heading);
+
+    const button = document.createElement('button');
+    button.textContent = 'Play Again';
+    Object.assign(button.style, {
+        padding: '0.8rem 2rem',
+        fontSize: '1.5rem',
+        fontFamily: 'sans-serif',
+        cursor: 'pointer',
+        border: 'none',
+        borderRadius: '8px',
+        backgroundColor: '#ffd700',
+        color: '#1a1a2e',
+        fontWeight: 'bold',
+    } as Partial<CSSStyleDeclaration>);
+    button.addEventListener('click', () => {
+        location.reload();
+    });
+    overlay.appendChild(button);
+
+    container.appendChild(overlay);
+    return overlay;
+}

--- a/demos/platformer/src/nodes/GoalNode.ts
+++ b/demos/platformer/src/nodes/GoalNode.ts
@@ -6,7 +6,8 @@ import {
     getComponent,
     Transform,
 } from '@pulse-ts/core';
-import { useRigidBody, useSphereCollider, useOnCollisionStart, RigidBody } from '@pulse-ts/physics';
+import { useRigidBody, useSphereCollider, useOnCollisionStart } from '@pulse-ts/physics';
+import { PlayerTag } from '../components/PlayerTag';
 import { useThreeRoot, useObject3D, useThreeContext } from '@pulse-ts/three';
 
 const GOAL_RADIUS = 0.6;
@@ -72,11 +73,10 @@ export function GoalNode(props: Readonly<GoalNodeProps>) {
         );
     });
 
-    // Win trigger — only fire for the player (dynamic body), not other statics
+    // Win trigger — only fire for the player, not other statics like collectibles
     const { renderer } = useThreeContext();
     useOnCollisionStart(({ other }) => {
-        const rb = getComponent(other, RigidBody);
-        if (!rb || rb.type !== 'dynamic') return;
+        if (!getComponent(other, PlayerTag)) return;
 
         world.pause();
         const container = renderer.domElement.parentElement ?? document.body;

--- a/demos/platformer/src/nodes/GoalNode.ts
+++ b/demos/platformer/src/nodes/GoalNode.ts
@@ -3,9 +3,10 @@ import {
     useComponent,
     useFrameUpdate,
     useWorld,
+    getComponent,
     Transform,
 } from '@pulse-ts/core';
-import { useRigidBody, useSphereCollider, useOnCollisionStart } from '@pulse-ts/physics';
+import { useRigidBody, useSphereCollider, useOnCollisionStart, RigidBody } from '@pulse-ts/physics';
 import { useThreeRoot, useObject3D, useThreeContext } from '@pulse-ts/three';
 
 const GOAL_RADIUS = 0.6;
@@ -71,9 +72,12 @@ export function GoalNode(props: Readonly<GoalNodeProps>) {
         );
     });
 
-    // Win trigger — pause world and show overlay
+    // Win trigger — only fire for the player (dynamic body), not other statics
     const { renderer } = useThreeContext();
-    useOnCollisionStart(() => {
+    useOnCollisionStart(({ other }) => {
+        const rb = getComponent(other, RigidBody);
+        if (!rb || rb.type !== 'dynamic') return;
+
         world.pause();
         const container = renderer.domElement.parentElement ?? document.body;
         showWinScreen(container);

--- a/demos/platformer/src/nodes/LevelNode.ts
+++ b/demos/platformer/src/nodes/LevelNode.ts
@@ -6,6 +6,7 @@ import { PlatformNode } from './PlatformNode';
 import { MovingPlatformNode } from './MovingPlatformNode';
 import { RotatingPlatformNode } from './RotatingPlatformNode';
 import { CollectibleNode } from './CollectibleNode';
+import { GoalNode } from './GoalNode';
 import { CameraRigNode } from './CameraRigNode';
 import { level } from '../config/level';
 
@@ -78,6 +79,9 @@ export function LevelNode() {
             position: col.position,
         });
     }
+
+    // Goal
+    useChild(GoalNode, { position: level.goalPosition });
 
     // Camera rig
     useChild(CameraRigNode, { target: playerNode });

--- a/demos/platformer/src/nodes/PlayerNode.ts
+++ b/demos/platformer/src/nodes/PlayerNode.ts
@@ -18,6 +18,7 @@ import {
     RigidBody,
 } from '@pulse-ts/physics';
 import { useThreeRoot, useObject3D } from '@pulse-ts/three';
+import { PlayerTag } from '../components/PlayerTag';
 
 const MOVE_SPEED = 8;
 const JUMP_IMPULSE = 8;
@@ -85,6 +86,7 @@ export interface PlayerNodeProps {
 
 export function PlayerNode(props: Readonly<PlayerNodeProps>) {
     const node = useNode();
+    useComponent(PlayerTag);
     const transform = useComponent(Transform);
     transform.localPosition.set(...props.spawn);
 


### PR DESCRIPTION
## Summary
- Add `GoalNode` FC — glowing gold octahedron with spin/bob animation, static rigid body with sphere trigger collider
- On player contact: pauses the world and displays a "You Win!" DOM overlay with a "Play Again" button (`location.reload()`)
- Add `goalPosition` to `LevelDef` and wire it into `LevelNode`
- `showWinScreen` exported as a pure function for testability; 5 unit tests added

## Test plan
- [x] `npm test -w demos/platformer --silent` — all 11 tests pass
- [ ] Manual: run demo, reach final platform, touch goal → game pauses, overlay appears
- [ ] Manual: click "Play Again" → page reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)