### PR TITLE
TICKET-016: Variable jump height (hold space for higher jump)

### DIFF
--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-002-platformer-demo-advanced-features/done/TICKET-016-variable-jump-height.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-002-platformer-demo-advanced-features/done/TICKET-016-variable-jump-height.md
@@ -2,10 +2,11 @@
 id: TICKET-016
 epic: EPIC-002
 title: Variable jump height (hold space for higher jump)
-status: todo
+status: done
 priority: medium
 created: 2026-02-25
-updated: 2026-02-25
+updated: 2026-02-26
+branch: ticket-016-variable-jump-height
 ---
 
 ## Description
@@ -20,11 +21,12 @@ Implementation:
 
 ## Acceptance Criteria
 
-- [ ] Quick tap produces a noticeably shorter jump than a held press
-- [ ] Maximum height (full hold) feels satisfying and clears the tallest platform gap
-- [ ] Holding jump in the air (after the hold window expires) does not continue to apply force
-- [ ] Works correctly alongside coyote time (TICKET-015)
+- [x] Quick tap produces a noticeably shorter jump than a held press
+- [x] Maximum height (full hold) feels satisfying and clears the tallest platform gap
+- [x] Holding jump in the air (after the hold window expires) does not continue to apply force
+- [x] Works correctly alongside coyote time (TICKET-015)
 
 ## Notes
 
 - **2026-02-25**: Ticket created. No blockers.
+- **2026-02-26**: Implementation complete. Reduced JUMP_IMPULSE from 8 to 5.5, added JUMP_HOLD_FORCE (38) and JUMP_HOLD_MAX (0.18s). Added jumpHoldTimer that starts on jump fire and applies sustained upward force while held. Timer resets on death-plane respawn. All tests pass.


### PR DESCRIPTION
## Summary

Adds variable jump height to the platformer demo. A quick tap produces a short hop while holding the jump button applies sustained upward force for up to 0.18s, reaching roughly the old max height. This gives players analog control over jump height — a standard platformer feel improvement.

## Changes

- Reduced `JUMP_IMPULSE` from 8 to 5.5 for a shorter base hop
- Added `JUMP_HOLD_FORCE` (38) and `JUMP_HOLD_MAX` (0.18s) constants
- Added `jumpHoldTimer` that starts on jump fire and counts down while held
- Uses `jump.down` (held every frame) to apply sustained force during hold window
- Reset `jumpHoldTimer` on death-plane respawn
- Works correctly alongside coyote time (TICKET-015)

Closes TICKET-016