### PR TITLE
TICKET-021: Particle burst on collectible pickup

### DIFF
--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-002-platformer-demo-advanced-features/done/TICKET-021-particle-burst-collectible.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-002-platformer-demo-advanced-features/done/TICKET-021-particle-burst-collectible.md
@@ -2,7 +2,7 @@
 id: TICKET-021
 epic: EPIC-002
 title: Particle burst on collectible pickup
-status: todo
+status: done
 priority: low
 created: 2026-02-25
 updated: 2026-02-26
@@ -23,11 +23,12 @@ This ticket will inform whether a `@pulse-ts/particles` package makes sense in a
 
 ## Acceptance Criteria
 
-- [ ] Burst appears at the collectible's world position on pickup
-- [ ] Particles fan outward and fade over ~0.5 s
-- [ ] No particles persist after the burst completes
-- [ ] No noticeable frame time impact (few particles, short-lived)
+- [x] Burst appears at the collectible's world position on pickup
+- [x] Particles fan outward and fade over ~0.5 s
+- [x] No particles persist after the burst completes
+- [x] No noticeable frame time impact (few particles, short-lived)
 
 ## Notes
 
 - **2026-02-25**: Ticket created. Polish pass — best done after core gameplay is stable.
+- **2026-02-26**: Implemented ParticleBurstNode (24 particles, 0.5s lifetime, gold color with additive blending). CollectibleNode spawns burst via world.mount() before self-destructing. All tests pass.

--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-002-platformer-demo-advanced-features/todo/TICKET-021-particle-burst-collectible.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-002-platformer-demo-advanced-features/todo/TICKET-021-particle-burst-collectible.md
@@ -5,7 +5,8 @@ title: Particle burst on collectible pickup
 status: todo
 priority: low
 created: 2026-02-25
-updated: 2026-02-25
+updated: 2026-02-26
+branch: ticket-021-particle-burst-collectible
 ---
 
 ## Description

--- a/demos/platformer/src/nodes/CollectibleNode.ts
+++ b/demos/platformer/src/nodes/CollectibleNode.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import {
     useComponent,
     useNode,
+    useWorld,
     useFrameUpdate,
     getComponent,
     Transform,
@@ -9,6 +10,7 @@ import {
 import { useRigidBody, useSphereCollider, useOnCollisionStart } from '@pulse-ts/physics';
 import { PlayerTag } from '../components/PlayerTag';
 import { useThreeRoot, useObject3D } from '@pulse-ts/three';
+import { ParticleBurstNode } from './ParticleBurstNode';
 
 const COLLECTIBLE_RADIUS = 0.25;
 const SPIN_SPEED = 2;
@@ -27,6 +29,7 @@ export interface CollectibleNodeProps {
 
 export function CollectibleNode(props: Readonly<CollectibleNodeProps>) {
     const node = useNode();
+    const world = useWorld();
 
     const transform = useComponent(Transform);
     transform.localPosition.set(...props.position);
@@ -66,6 +69,13 @@ export function CollectibleNode(props: Readonly<CollectibleNodeProps>) {
     useOnCollisionStart(({ other }) => {
         if (!getComponent(other, PlayerTag)) return;
         props.collectibleState.collected++;
+        world.mount(ParticleBurstNode, {
+            position: [
+                transform.localPosition.x,
+                transform.localPosition.y,
+                transform.localPosition.z,
+            ],
+        });
         node.destroy();
     });
 }

--- a/demos/platformer/src/nodes/ParticleBurstNode.test.ts
+++ b/demos/platformer/src/nodes/ParticleBurstNode.test.ts
@@ -1,0 +1,20 @@
+import { PARTICLE_COUNT, BURST_LIFETIME } from './ParticleBurstNode';
+
+describe('ParticleBurstNode', () => {
+    it('exports expected particle count', () => {
+        expect(PARTICLE_COUNT).toBe(24);
+    });
+
+    it('exports expected burst lifetime', () => {
+        expect(BURST_LIFETIME).toBe(0.5);
+    });
+
+    it('particle count is a positive integer', () => {
+        expect(Number.isInteger(PARTICLE_COUNT)).toBe(true);
+        expect(PARTICLE_COUNT).toBeGreaterThan(0);
+    });
+
+    it('burst lifetime is a positive number', () => {
+        expect(BURST_LIFETIME).toBeGreaterThan(0);
+    });
+});

--- a/demos/platformer/src/nodes/ParticleBurstNode.ts
+++ b/demos/platformer/src/nodes/ParticleBurstNode.ts
@@ -1,0 +1,106 @@
+import * as THREE from 'three';
+import { useNode, useFrameUpdate, useDestroy } from '@pulse-ts/core';
+import { useThreeRoot, useObject3D } from '@pulse-ts/three';
+
+/** Number of particles in a single burst. */
+export const PARTICLE_COUNT = 24;
+
+/** Total lifetime of the burst effect in seconds. */
+export const BURST_LIFETIME = 0.5;
+
+/** Gravity pull applied to particles each frame (units/s²). */
+const GRAVITY = 9.8;
+
+/** Base outward speed range for initial velocities. */
+const MIN_SPEED = 1.5;
+const MAX_SPEED = 4.0;
+
+export interface ParticleBurstNodeProps {
+    position: [number, number, number];
+}
+
+/**
+ * Self-contained particle burst effect using `THREE.Points`.
+ *
+ * Spawns a fixed number of particles that fan outward with random velocities,
+ * fade linearly to transparent, and self-destruct after the lifetime expires.
+ *
+ * @param props - World-space position where the burst originates.
+ *
+ * @example
+ * ```ts
+ * import { useWorld } from '@pulse-ts/core';
+ * import { ParticleBurstNode } from './ParticleBurstNode';
+ *
+ * const world = useWorld();
+ * world.mount(ParticleBurstNode, { position: [1, 2, 0] });
+ * ```
+ */
+export function ParticleBurstNode(props: Readonly<ParticleBurstNodeProps>) {
+    const node = useNode();
+    const root = useThreeRoot();
+    root.position.set(...props.position);
+
+    // Geometry: position buffer for each particle
+    const positions = new Float32Array(PARTICLE_COUNT * 3);
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+
+    const material = new THREE.PointsMaterial({
+        color: 0xf4d03f,
+        size: 0.08,
+        transparent: true,
+        opacity: 1,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+    });
+
+    const points = new THREE.Points(geometry, material);
+    useObject3D(points);
+
+    // Random initial velocities for each particle
+    const velocities: THREE.Vector3[] = [];
+    for (let i = 0; i < PARTICLE_COUNT; i++) {
+        const theta = Math.random() * Math.PI * 2;
+        const phi = Math.acos(2 * Math.random() - 1);
+        const speed = MIN_SPEED + Math.random() * (MAX_SPEED - MIN_SPEED);
+        velocities.push(
+            new THREE.Vector3(
+                Math.sin(phi) * Math.cos(theta) * speed,
+                Math.sin(phi) * Math.sin(theta) * speed,
+                Math.cos(phi) * speed,
+            ),
+        );
+    }
+
+    let elapsed = 0;
+
+    useFrameUpdate((dt) => {
+        elapsed += dt;
+
+        if (elapsed >= BURST_LIFETIME) {
+            node.destroy();
+            return;
+        }
+
+        // Update positions and apply gravity
+        const posAttr = geometry.getAttribute('position') as THREE.BufferAttribute;
+        for (let i = 0; i < PARTICLE_COUNT; i++) {
+            velocities[i].y -= GRAVITY * dt;
+
+            const idx = i * 3;
+            posAttr.array[idx] += velocities[i].x * dt;
+            posAttr.array[idx + 1] += velocities[i].y * dt;
+            posAttr.array[idx + 2] += velocities[i].z * dt;
+        }
+        posAttr.needsUpdate = true;
+
+        // Fade opacity linearly
+        material.opacity = 1 - elapsed / BURST_LIFETIME;
+    });
+
+    useDestroy(() => {
+        geometry.dispose();
+        material.dispose();
+    });
+}


### PR DESCRIPTION
## Summary

Adds a gold particle burst effect when collectibles are picked up. A new `ParticleBurstNode` spawns 24 particles that fan outward with gravity and fade over 0.5s, then self-destructs.

## Changes

- Created `ParticleBurstNode` — self-contained `THREE.Points` effect with random outward velocities, gravity, and linear opacity fade
- Modified `CollectibleNode` to spawn the burst via `world.mount()` before destroying itself
- Added tests for particle count and lifetime constants
- GPU cleanup via `useDestroy` (geometry + material disposal)

Closes TICKET-021

🤖 Generated with [Claude Code](https://claude.com/claude-code)