### PR TITLE
Fix: exclude vitest bench files from Jest

### DIFF
--- a/packages/core/jest.config.mjs
+++ b/packages/core/jest.config.mjs
@@ -6,6 +6,6 @@ export default {
         '^.+\\.(ts|tsx|js|jsx)$': ['babel-jest'],
     },
     testMatch: ['**/*.test.ts', '**/*.test.tsx'],
-    testPathIgnorePatterns: ['<rootDir>/*/node_modules/', '<rootDir>/*/dist/'],
+    testPathIgnorePatterns: ['<rootDir>/*/node_modules/', '<rootDir>/*/dist/', '\\.bench\\.test\\.ts$'],
     watchman: false,
 };


### PR DESCRIPTION
## Summary

- Adds `\.bench\.test\.ts$` to `testPathIgnorePatterns` in the core Jest config
- The `*.bench.test.ts` files import from `vitest` and are meant to run via `npm run bench` (vitest bench), not `npm test` (Jest)
- This eliminates the 2 spurious test suite failures that appeared on every `npm test -w packages/core` run

## Test plan

- [x] `npm test -w packages/core` — 22 suites, 66 tests, 0 failures
- [x] Bench files are still runnable via `npm run bench -w packages/core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)