### PR TITLE
TICKET-048: Audio polish

### DIFF
--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-008-bumper-balls-arena-demo/done/TICKET-048-audio-polish.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-008-bumper-balls-arena-demo/done/TICKET-048-audio-polish.md
@@ -2,7 +2,7 @@
 id: TICKET-048
 epic: EPIC-008
 title: Audio polish
-status: in-progress
+status: done
 priority: low
 created: 2026-02-26
 updated: 2026-02-28
@@ -18,11 +18,11 @@ Sound effects for the arena: knockout death sound (descending tone), round-win f
 
 ## Acceptance Criteria
 
-- [ ] Knockout death sound — descending tone via `useSound('tone', ...)`
-- [ ] Round-win fanfare — arpeggio via `useSound('arpeggio', ...)`
-- [ ] Dash whoosh — noise via `useSound('noise', ...)`
-- [ ] Countdown beeps — short tones for 3-2-1 countdown
-- [ ] Sounds integrated into appropriate game events
+- [x] Knockout death sound — descending tone via `useSound('tone', ...)`
+- [x] Round-win fanfare — arpeggio via `useSound('arpeggio', ...)`
+- [x] Dash whoosh — noise via `useSound('noise', ...)`
+- [x] Countdown beeps — short tones for 3-2-1 countdown
+- [x] Sounds integrated into appropriate game events
 
 ## Notes
 

--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-008-bumper-balls-arena-demo/in-progress/TICKET-048-audio-polish.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-008-bumper-balls-arena-demo/in-progress/TICKET-048-audio-polish.md
@@ -2,7 +2,7 @@
 id: TICKET-048
 epic: EPIC-008
 title: Audio polish
-status: todo
+status: in-progress
 priority: low
 created: 2026-02-26
 updated: 2026-02-28

--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-008-bumper-balls-arena-demo/todo/TICKET-048-audio-polish.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-008-bumper-balls-arena-demo/todo/TICKET-048-audio-polish.md
@@ -5,10 +5,11 @@ title: Audio polish
 status: todo
 priority: low
 created: 2026-02-26
-updated: 2026-02-26
+updated: 2026-02-28
 labels:
   - arena
   - audio
+branch: ticket-048-audio-polish
 ---
 
 ## Description


### PR DESCRIPTION
## Summary

Add round lifecycle sound effects to the arena demo's GameManagerNode: countdown beeps (3-2-1), a "GO!" tone, KO announcement tone, and match-win fanfare — all using `useSound` from `@pulse-ts/audio`.

## Changes

- Countdown beeps: sine 880Hz tone on each countdown tick (3, 2, 1)
- Countdown "GO!": higher sine 1320Hz tone when countdown reaches 0
- KO announcement: descending sawtooth [200→100]Hz on `ko_flash` phase
- Match-win fanfare: ascending C5→E5→G5→C6 arpeggio on `match_over` phase
- Track `prevCountdown` to detect value changes and avoid duplicate plays

Closes TICKET-048