### PR TITLE
feat: single-canvas local 2-player with gameplay tuning (TICKET-055)

### DIFF
--- a/.claude/ticket-tracker/counters.json
+++ b/.claude/ticket-tracker/counters.json
@@ -1,1 +1,1 @@
-{ "ticket": 53, "epic": 8 }
+{ "ticket": 55, "epic": 8 }

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-008-bumper-balls-arena-demo/done/TICKET-055-single-canvas-refactor-and-gameplay-tuning.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-008-bumper-balls-arena-demo/done/TICKET-055-single-canvas-refactor-and-gameplay-tuning.md
@@ -1,0 +1,43 @@
+---
+id: TICKET-055
+epic: EPIC-008
+title: Single-canvas refactor and gameplay tuning
+status: done
+priority: high
+branch: ticket-055-single-canvas-refactor-and-gameplay-tuning
+created: 2026-03-01
+updated: 2026-03-01
+labels:
+  - arena
+  - refactor
+  - gameplay
+---
+
+## Description
+
+Replace split-screen (two worlds + network) with a single-canvas, single-world local 2-player setup, plus gameplay tuning for camera, movement, knockback, and arena sizing.
+
+### Changes
+
+1. **Single-canvas architecture** — removed split-screen layout, MemoryHub, `installNetwork`, `RemotePlayerNode` usage. Both players are `LocalPlayerNode` instances in one world. Replaced network channels with shared `GameState` mutations (`pendingKnockout`, round-number tracking). Namespaced input bindings (`p1Move`/`p2Move`, `p1Dash`/`p2Dash`). Neutral overlays ("P1/P2" instead of "You/Opponent").
+2. **Fixed overhead camera** — replaced follow camera with a static camera centered on the arena. Eliminates rotation artifacts at steep angles.
+3. **Momentum-based movement** — impulse per tick + linear damping instead of direct velocity setting. Icy, heavy feel with gradual acceleration and long coasting.
+4. **Horizontal-only knockback** — removed upward impulse component that caused players to float when colliding repeatedly.
+5. **Impact sound cooldown** — prevents sound spam during sustained contact.
+6. **Arena and player sizing** — arena radius 10→14, player radius 0.5→0.8, spawn positions widened ±3→±5, camera height tuned. Platform uses shared `ARENA_RADIUS` config.
+
+## Acceptance Criteria
+
+- [x] Single canvas, single world, no network dependency for local play
+- [x] Both players controllable via namespaced input bindings
+- [x] Fixed overhead camera with no rotation artifacts
+- [x] Momentum-based movement with icy feel
+- [x] Horizontal-only knockback (no floating)
+- [x] Impact sound cooldown
+- [x] Arena enlarged, players enlarged, camera tuned
+- [x] All 57 tests pass
+- [x] Lint clean
+
+## Notes
+
+- **2026-03-01**: Ticket created. All work already complete.

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-008-bumper-balls-arena-demo/todo/TICKET-054-cylinder-collider-support.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-008-bumper-balls-arena-demo/todo/TICKET-054-cylinder-collider-support.md
@@ -1,0 +1,30 @@
+---
+id: TICKET-054
+epic: EPIC-008
+title: Cylinder collider support
+status: todo
+priority: medium
+created: 2026-03-01
+updated: 2026-03-01
+labels:
+  - physics
+  - engine
+  - arena
+---
+
+## Description
+
+Add `useCylinderCollider(radius, height, options)` hook to `@pulse-ts/physics`, then update the arena demo's `PlatformNode` to use it instead of the current `useBoxCollider`. The arena platform is visually a cylinder but uses a box collider, so players can walk past the circular edge at the corners without falling off.
+
+## Acceptance Criteria
+
+- [ ] `useCylinderCollider(radius, height, options)` hook added to `@pulse-ts/physics`
+- [ ] Cylinder collision detection integrated into the physics engine (cylinder vs sphere, cylinder vs box)
+- [ ] Unit tests for the new collider shape and its interactions
+- [ ] Arena `PlatformNode` updated to use `useCylinderCollider` instead of `useBoxCollider`
+- [ ] Players fall off at the circular edge, not the square corners
+- [ ] JSDoc for the new public hook
+
+## Notes
+
+- **2026-03-01**: Ticket created.

--- a/demos/arena/index.html
+++ b/demos/arena/index.html
@@ -17,28 +17,15 @@
                 overflow: hidden;
                 background: #0a0a0f;
             }
-            #split-screen {
-                display: flex;
+            #arena {
                 width: 100%;
                 height: 100%;
-            }
-            #split-screen canvas {
-                flex: 1;
-                min-width: 0;
-                height: 100%;
-            }
-            .divider {
-                width: 2px;
-                background: #222;
+                display: block;
             }
         </style>
     </head>
     <body>
-        <div id="split-screen">
-            <canvas id="p1"></canvas>
-            <div class="divider"></div>
-            <canvas id="p2"></canvas>
-        </div>
+        <canvas id="arena"></canvas>
         <script type="module" src="/src/main.ts"></script>
     </body>
 </html>

--- a/demos/arena/src/config/arena.ts
+++ b/demos/arena/src/config/arena.ts
@@ -1,5 +1,5 @@
 /** Radius of the circular arena platform. */
-export const ARENA_RADIUS = 10;
+export const ARENA_RADIUS = 14;
 
 /** Y position below which a player is considered knocked out. */
 export const DEATH_PLANE_Y = -10;
@@ -9,8 +9,8 @@ export const SPAWN_POSITIONS: readonly [
     [number, number, number],
     [number, number, number],
 ] = [
-    [-3, 2, 0],
-    [3, 2, 0],
+    [-5, 2, 0],
+    [5, 2, 0],
 ];
 
 /** Number of knockouts required to win a match. */

--- a/demos/arena/src/config/bindings.ts
+++ b/demos/arena/src/config/bindings.ts
@@ -1,21 +1,24 @@
 import { Axis1D, Axis2D, Key } from '@pulse-ts/input';
 
-/** Player 1 input bindings — WASD movement, Space to dash. */
-export const p1Bindings = {
-    move: Axis2D({
+/**
+ * Merged input bindings for both players in a single world.
+ * Action names are namespaced per player (p1Move, p2Move, etc.)
+ * so both players can be handled by a single `installInput` call.
+ */
+export const allBindings = {
+    /** Player 1 movement — WASD. */
+    p1Move: Axis2D({
         x: Axis1D({ pos: Key('KeyD'), neg: Key('KeyA') }),
         y: Axis1D({ pos: Key('KeyW'), neg: Key('KeyS') }),
     }),
-    dash: Key('Space'),
-    action: Key('ShiftLeft'),
-};
+    /** Player 1 dash — Space. */
+    p1Dash: Key('Space'),
 
-/** Player 2 input bindings — Arrow keys movement, Enter to dash. */
-export const p2Bindings = {
-    move: Axis2D({
+    /** Player 2 movement — Arrow keys. */
+    p2Move: Axis2D({
         x: Axis1D({ pos: Key('ArrowRight'), neg: Key('ArrowLeft') }),
         y: Axis1D({ pos: Key('ArrowUp'), neg: Key('ArrowDown') }),
     }),
-    dash: Key('Enter'),
-    action: Key('ShiftRight'),
+    /** Player 2 dash — Enter. */
+    p2Dash: Key('Enter'),
 };

--- a/demos/arena/src/contexts.ts
+++ b/demos/arena/src/contexts.ts
@@ -1,4 +1,4 @@
-import { createContext, type Node } from '@pulse-ts/core';
+import { createContext } from '@pulse-ts/core';
 
 /** Current phase of the round lifecycle. */
 export type RoundPhase =
@@ -20,13 +20,9 @@ export interface GameState {
     countdownValue: number;
     /** Player ID of the match winner (-1 = no winner yet). */
     matchWinner: number;
+    /** Pending knockout: player ID that just fell off (-1 = none). */
+    pendingKnockout: number;
 }
 
 /** Shared game state context — read/written by GameManagerNode, read by HUD. */
 export const GameCtx = createContext<GameState>('Game');
-
-/** Identifies which player this world controls (0 or 1). */
-export const PlayerIdCtx = createContext<number>('PlayerId');
-
-/** Reference to the local player's Node — read by camera rig and collision handlers. */
-export const LocalPlayerNodeCtx = createContext<Node>('LocalPlayerNode');

--- a/demos/arena/src/main.ts
+++ b/demos/arena/src/main.ts
@@ -3,33 +3,18 @@ import { installAudio } from '@pulse-ts/audio';
 import { installInput } from '@pulse-ts/input';
 import { installPhysics } from '@pulse-ts/physics';
 import { installThree, StatsOverlaySystem } from '@pulse-ts/three';
-import {
-    installNetwork,
-    createMemoryHub,
-    type MemoryHub,
-} from '@pulse-ts/network';
 import { ArenaNode } from './nodes/ArenaNode';
-import { p1Bindings, p2Bindings } from './config/bindings';
+import { allBindings } from './config/bindings';
 
-const p1Canvas = document.getElementById('p1') as HTMLCanvasElement;
-const p2Canvas = document.getElementById('p2') as HTMLCanvasElement;
+const canvas = document.getElementById('arena') as HTMLCanvasElement;
 
-// Shared networking hub — both worlds communicate through this
-const hub = createMemoryHub();
-
-async function createPlayerWorld(
-    canvas: HTMLCanvasElement,
-    bindings: typeof p1Bindings,
-    playerId: number,
-    memoryHub: MemoryHub,
-) {
+async function start() {
     const world = new World();
 
     installDefaults(world);
     installAudio(world);
-    installInput(world, { preventDefault: true, bindings });
+    installInput(world, { preventDefault: true, bindings: allBindings });
     installPhysics(world, { gravity: { x: 0, y: -20, z: 0 } });
-    await installNetwork(world);
 
     const three = installThree(world, {
         canvas,
@@ -39,23 +24,11 @@ async function createPlayerWorld(
     three.renderer.shadowMap.enabled = true;
     three.renderer.shadowMap.type = 1; // THREE.PCFShadowMap
 
-    world.addSystem(
-        new StatsOverlaySystem({
-            position: playerId === 0 ? 'top-left' : 'top-right',
-        }),
-    );
+    world.addSystem(new StatsOverlaySystem({ position: 'top-left' }));
 
-    world.mount(ArenaNode, { playerId, hub: memoryHub });
+    world.mount(ArenaNode);
 
-    return world;
+    world.start();
 }
 
-async function startSplitScreen() {
-    const world1 = await createPlayerWorld(p1Canvas, p1Bindings, 0, hub);
-    const world2 = await createPlayerWorld(p2Canvas, p2Bindings, 1, hub);
-
-    world1.start();
-    world2.start();
-}
-
-startSplitScreen();
+start();

--- a/demos/arena/src/nodes/CameraRigNode.test.ts
+++ b/demos/arena/src/nodes/CameraRigNode.test.ts
@@ -1,17 +1,16 @@
-import { CameraRigNode, CAMERA_OFFSET } from './CameraRigNode';
+import { CameraRigNode, CAMERA_HEIGHT, CAMERA_Z_OFFSET } from './CameraRigNode';
 
 describe('CameraRigNode', () => {
     it('exports the node function', () => {
         expect(typeof CameraRigNode).toBe('function');
     });
 
-    it('camera offset is elevated above the arena', () => {
-        const [, y] = CAMERA_OFFSET;
-        expect(y).toBeGreaterThan(10);
+    it('camera is elevated well above the arena', () => {
+        expect(CAMERA_HEIGHT).toBeGreaterThan(10);
     });
 
-    it('camera offset has a positive Z for rear view', () => {
-        const [, , z] = CAMERA_OFFSET;
-        expect(z).toBeGreaterThan(0);
+    it('camera has a small positive Z offset', () => {
+        expect(CAMERA_Z_OFFSET).toBeGreaterThan(0);
+        expect(CAMERA_Z_OFFSET).toBeLessThan(5);
     });
 });

--- a/demos/arena/src/nodes/CameraRigNode.ts
+++ b/demos/arena/src/nodes/CameraRigNode.ts
@@ -1,28 +1,19 @@
-import { useContext } from '@pulse-ts/core';
-import { useFollowCamera } from '@pulse-ts/three';
-import { LocalPlayerNodeCtx } from '../contexts';
+import { useThreeContext } from '@pulse-ts/three';
 
-/** Camera offset — elevated, slightly behind for a top-down-ish arena view. */
-export const CAMERA_OFFSET: [number, number, number] = [0, 18, 10];
+/** Fixed camera height above the arena center. */
+export const CAMERA_HEIGHT = 26;
 
-/** Look-ahead bias — slightly above the player so the camera tilts down. */
-const LOOK_AHEAD: [number, number, number] = [0, 0, 0];
-
-/** Smoothing factor — how quickly the camera catches up to the player. */
-const SMOOTHING = 6;
+/** Small Z offset to avoid degenerate straight-down lookAt. */
+export const CAMERA_Z_OFFSET = 2;
 
 /**
- * Camera rig that follows the local player from an elevated rear angle.
- * Each world mounts its own CameraRigNode, so each canvas independently
- * tracks its own player.
+ * Fixed overhead camera centered on the arena.
+ * Both players are always visible on the small platform, so there is
+ * no need to follow an individual player.
  */
 export function CameraRigNode() {
-    const playerNode = useContext(LocalPlayerNodeCtx);
+    const { camera } = useThreeContext();
 
-    useFollowCamera(playerNode, {
-        offset: CAMERA_OFFSET,
-        lookAhead: LOOK_AHEAD,
-        smoothing: SMOOTHING,
-        interpolate: true,
-    });
+    camera.position.set(0, CAMERA_HEIGHT, CAMERA_Z_OFFSET);
+    camera.lookAt(0, 0, 0);
 }

--- a/demos/arena/src/nodes/KnockoutOverlayNode.ts
+++ b/demos/arena/src/nodes/KnockoutOverlayNode.ts
@@ -1,14 +1,16 @@
 import { useFrameUpdate, useDestroy, useContext } from '@pulse-ts/core';
 import { useThreeContext } from '@pulse-ts/three';
-import { GameCtx, PlayerIdCtx } from '../contexts';
+import { GameCtx } from '../contexts';
+
+/** Player labels indexed by player ID. */
+const PLAYER_LABELS = ['P1', 'P2'];
 
 /**
- * DOM overlay that shows a white flash and "You scored!" / "Opponent scored!"
+ * DOM overlay that shows a white flash and "P1 scored!" / "P2 scored!"
  * text during the `ko_flash` phase. Fades out when the phase ends.
  */
 export function KnockoutOverlayNode() {
     const gameState = useContext(GameCtx);
-    const playerId = useContext(PlayerIdCtx);
     const { renderer } = useThreeContext();
     const container = renderer.domElement.parentElement ?? document.body;
 
@@ -48,10 +50,8 @@ export function KnockoutOverlayNode() {
         text.style.opacity = visible ? '1' : '0';
 
         if (visible) {
-            const scorerIsLocal = gameState.lastKnockedOut !== playerId;
-            text.textContent = scorerIsLocal
-                ? 'You scored!'
-                : 'Opponent scored!';
+            const scorer = 1 - gameState.lastKnockedOut;
+            text.textContent = `${PLAYER_LABELS[scorer]} scored!`;
         }
     });
 

--- a/demos/arena/src/nodes/LocalPlayerNode.test.ts
+++ b/demos/arena/src/nodes/LocalPlayerNode.test.ts
@@ -1,10 +1,12 @@
 import {
     PLAYER_RADIUS,
-    MOVE_SPEED,
+    MOVE_IMPULSE,
+    LINEAR_DAMPING,
     DASH_SPEED,
     DASH_DURATION,
     DASH_COOLDOWN,
     KNOCKBACK_FORCE,
+    IMPACT_COOLDOWN,
     KNOCKOUT_BURST_COUNT,
     DASH_TRAIL_RATE,
     computeDashDirection,
@@ -16,12 +18,16 @@ describe('LocalPlayerNode constants', () => {
         expect(PLAYER_RADIUS).toBeGreaterThan(0);
     });
 
-    it('move speed is positive', () => {
-        expect(MOVE_SPEED).toBeGreaterThan(0);
+    it('move impulse is positive', () => {
+        expect(MOVE_IMPULSE).toBeGreaterThan(0);
     });
 
-    it('dash speed exceeds move speed', () => {
-        expect(DASH_SPEED).toBeGreaterThan(MOVE_SPEED);
+    it('linear damping is positive', () => {
+        expect(LINEAR_DAMPING).toBeGreaterThan(0);
+    });
+
+    it('dash speed is high for burst movement', () => {
+        expect(DASH_SPEED).toBeGreaterThan(20);
     });
 
     it('dash duration is positive and short', () => {
@@ -35,6 +41,11 @@ describe('LocalPlayerNode constants', () => {
 
     it('knockback force is positive', () => {
         expect(KNOCKBACK_FORCE).toBeGreaterThan(0);
+    });
+
+    it('impact cooldown prevents sound spam', () => {
+        expect(IMPACT_COOLDOWN).toBeGreaterThan(0.1);
+        expect(IMPACT_COOLDOWN).toBeLessThan(2);
     });
 
     it('knockout burst count is a large positive number', () => {
@@ -93,27 +104,27 @@ describe('computeKnockback', () => {
         const [x, y, z] = computeKnockback(5, 0, 3, 0, 10);
         expect(x).toBeCloseTo(10);
         expect(z).toBeCloseTo(0);
-        expect(y).toBeCloseTo(5); // upward arc = magnitude * 0.5
+        expect(y).toBe(0);
     });
 
     it('pushes away from other player along Z axis', () => {
         const [x, y, z] = computeKnockback(0, 5, 0, 2, 10);
         expect(x).toBeCloseTo(0);
         expect(z).toBeCloseTo(10);
-        expect(y).toBeCloseTo(5);
+        expect(y).toBe(0);
     });
 
     it('pushes away diagonally and normalizes direction', () => {
         const [x, y, z] = computeKnockback(1, 1, 0, 0, 10);
         const horizontalLen = Math.sqrt(x * x + z * z);
         expect(horizontalLen).toBeCloseTo(10);
-        expect(y).toBeCloseTo(5);
+        expect(y).toBe(0);
     });
 
     it('handles overlapping positions with fallback direction', () => {
         const [x, y, z] = computeKnockback(3, 3, 3, 3, 8);
         expect(x).toBe(8);
-        expect(y).toBe(4);
+        expect(y).toBe(0);
         expect(z).toBe(0);
     });
 

--- a/demos/arena/src/nodes/MatchOverOverlayNode.ts
+++ b/demos/arena/src/nodes/MatchOverOverlayNode.ts
@@ -1,14 +1,19 @@
 import { useFrameUpdate, useDestroy, useContext } from '@pulse-ts/core';
 import { useThreeContext } from '@pulse-ts/three';
-import { GameCtx, PlayerIdCtx } from '../contexts';
+import { GameCtx } from '../contexts';
+
+/** Player colors: P1 = teal, P2 = coral. */
+const PLAYER_COLORS = ['#48c9b0', '#e74c3c'];
+
+/** Player labels indexed by player ID. */
+const PLAYER_LABELS = ['P1', 'P2'];
 
 /**
- * DOM overlay that shows "YOU WIN!" or "YOU LOSE!" with a dark backdrop
+ * DOM overlay that shows "P1 WINS!" or "P2 WINS!" with a dark backdrop
  * during the `match_over` phase. Fades in via CSS transition.
  */
 export function MatchOverOverlayNode() {
     const gameState = useContext(GameCtx);
-    const playerId = useContext(PlayerIdCtx);
     const { renderer } = useThreeContext();
     const container = renderer.domElement.parentElement ?? document.body;
 
@@ -47,9 +52,9 @@ export function MatchOverOverlayNode() {
         text.style.opacity = visible ? '1' : '0';
 
         if (visible) {
-            const isWinner = gameState.matchWinner === playerId;
-            text.textContent = isWinner ? 'YOU WIN!' : 'YOU LOSE!';
-            text.style.color = isWinner ? '#48c9b0' : '#e74c3c';
+            const winner = gameState.matchWinner;
+            text.textContent = `${PLAYER_LABELS[winner]} WINS!`;
+            text.style.color = PLAYER_COLORS[winner];
         }
     });
 

--- a/demos/arena/src/nodes/PlatformNode.ts
+++ b/demos/arena/src/nodes/PlatformNode.ts
@@ -3,9 +3,10 @@ import { useRigidBody, useBoxCollider } from '@pulse-ts/physics';
 import { useMesh, useObject3D } from '@pulse-ts/three';
 import { useAnimate } from '@pulse-ts/effects';
 import * as THREE from 'three';
+import { ARENA_RADIUS } from '../config/arena';
 
-/** Radius of the arena cylinder. */
-export const PLATFORM_RADIUS = 10;
+/** Radius of the arena cylinder (sourced from arena config). */
+export const PLATFORM_RADIUS = ARENA_RADIUS;
 
 /** Height (thickness) of the arena cylinder. */
 export const PLATFORM_HEIGHT = 0.5;

--- a/demos/arena/src/nodes/ScoreHudNode.ts
+++ b/demos/arena/src/nodes/ScoreHudNode.ts
@@ -1,14 +1,13 @@
 import { useFrameUpdate, useDestroy, useContext } from '@pulse-ts/core';
 import { useThreeContext } from '@pulse-ts/three';
-import { GameCtx, PlayerIdCtx } from '../contexts';
+import { GameCtx } from '../contexts';
 
 /**
  * DOM overlay showing P1 and P2 scores.
- * Positioned at the top-center of each canvas.
+ * Positioned at the top-center of the canvas.
  */
 export function ScoreHudNode() {
     const gameState = useContext(GameCtx);
-    const playerId = useContext(PlayerIdCtx);
     const { renderer } = useThreeContext();
     const container = renderer.domElement.parentElement ?? document.body;
 
@@ -28,13 +27,8 @@ export function ScoreHudNode() {
     } as Partial<CSSStyleDeclaration>);
     container.appendChild(el);
 
-    const labels = playerId === 0 ? ['P1', 'P2'] : ['P2', 'P1'];
-    const indices = playerId === 0 ? [0, 1] : [1, 0];
-
     useFrameUpdate(() => {
-        el.textContent =
-            `${labels[0]}: ${gameState.scores[indices[0]]}  |  ` +
-            `${labels[1]}: ${gameState.scores[indices[1]]}`;
+        el.textContent = `P1: ${gameState.scores[0]}  |  P2: ${gameState.scores[1]}`;
     });
 
     useDestroy(() => {


### PR DESCRIPTION
## Summary

- **Single-canvas architecture** — replaced split-screen (two worlds + network) with a single world, single canvas. Both players are `LocalPlayerNode` instances with namespaced input bindings (`p1Move`/`p2Move`, `p1Dash`/`p2Dash`). Network channels replaced with shared `GameState` mutations. Neutral overlays ("P1/P2" instead of "You/Opponent").
- **Fixed overhead camera** — static camera centered on the arena, eliminating rotation artifacts from the old follow camera.
- **Momentum-based movement** — impulse-per-tick + linear damping (0.15) for an icy, heavy feel with gradual acceleration and long coasting. Replaces direct velocity setting.
- **Horizontal-only knockback** — removed upward impulse component that caused players to float on repeated collisions. Increased force (8→20) to compensate for damping.
- **Impact sound cooldown** (0.4s) — prevents sound spam during sustained player contact.
- **Arena/player sizing** — arena radius 10→14, player radius 0.5→0.8, spawn positions ±3→±5, camera height tuned to 26. Platform now uses shared `ARENA_RADIUS` config.
- **TICKET-054 created** — tracks adding `useCylinderCollider` to the physics engine (platform currently uses box collider).

## Test plan

- [x] All 57 arena demo tests pass
- [x] Lint clean
- [x] Verified in browser: single canvas renders, both players controllable, scoring/overlays work, momentum feels right

🤖 Generated with [Claude Code](https://claude.com/claude-code)