### PR TITLE
fix: replay online bugs + multi-hit effects (TICKET-082)

### DIFF
--- a/.claude/rules/arena/online-sync-conventions.md
+++ b/.claude/rules/arena/online-sync-conventions.md
@@ -1,0 +1,72 @@
+---
+paths:
+  - "demos/arena/src/nodes/LocalPlayerNode.ts"
+  - "demos/arena/src/nodes/GameManagerNode.ts"
+  - "demos/arena/src/nodes/ArenaNode.ts"
+  - "demos/arena/src/replay.ts"
+  - "demos/arena/src/config/channels.ts"
+---
+
+# Online Mode Synchronization Conventions
+
+Two critical conventions discovered during online-mode bug fixes in Arena demo. These patterns ensure both players see consistent gameplay outcomes despite network latency and independent timer-based state machines.
+
+## Convention 1: Collision Side-Effects via Knockback Channel
+
+**Problem:** Physics collisions are detected asymmetrically. Only the machine where the local player's body intersects the remote player's kinematic body detects the collision. The remote machine may not detect it due to network position lag.
+
+**Convention:** Any side-effect that must happen on BOTH machines (e.g., `markHit()` for replay recording) must trigger in TWO places:
+
+1. **Local collision callback** (`useOnCollisionStart` in LocalPlayerNode)
+   - Detects the hit immediately
+   - Calls `markHit()` to record in local replay buffer
+
+2. **Knockback channel handler** (consumer receiving the replication message)
+   - Receives the knockback impulse event from the attacking machine
+   - Also calls `markHit()` on the receiving machine
+
+This ensures replay recording is synchronized across both machines, even though collision detection only fires locally on the attacker's side.
+
+### Key Files
+
+- `demos/arena/src/nodes/LocalPlayerNode.ts` — collision detection + knockback channel publish
+- `demos/arena/src/replay.ts` — `markHit()` called in two contexts (local collision + channel handler)
+- `demos/arena/src/config/channels.ts` — knockback channel definition
+
+### Implication
+
+The knockback channel is the **synchronization point** for collision effects in online mode. If you add a new collision side-effect, route it through the knockback channel so the receiving machine can execute it too.
+
+---
+
+## Convention 2: Gameplay-Critical Phase Transitions Need Host Authority
+
+**Problem:** Each machine independently runs through the phase chain (replay → ko_flash → resetting → countdown → playing) with local timers. Network latency in knockout detection and frame rate differences during replay cause timing divergence that accumulates through the chain. Without authority, both players may enter "playing" at different server times, creating desync in timed game logic.
+
+**Convention:** For any phase transition where both players must act simultaneously (e.g., countdown→playing), use host-authoritative synchronization. The host machine broadcasts the transition signal via a dedicated channel; remote players apply it on receipt rather than relying on local timers.
+
+Current implementation: `RoundResetChannel` carries the host's countdown completion signal. Both players transition to "playing" phase upon receiving this broadcast, not on local timer expiry.
+
+### Key Files
+
+- `demos/arena/src/nodes/GameManagerNode.ts` — phase state machine; host broadcasts `RoundResetChannel` to signal countdown completion
+- `demos/arena/src/nodes/ArenaNode.ts` — passes `isHost` flag to GameManagerNode so it knows whether to broadcast
+- `demos/arena/src/config/channels.ts` — `RoundResetChannel` definition
+
+### Implication
+
+When adding future phase transitions that require both players to synchronize:
+
+1. Identify the transition that must be simultaneous (e.g., "end of replay" → "start of ko_flash")
+2. Determine which machine has authority (typically the host or the player who triggered the condition)
+3. Have the authoritative machine broadcast the signal; remote machines apply it on receipt
+4. Do NOT rely on local timer-based detection for the transition
+
+This pattern prevents timing drift from accumulating through the phase chain and keeps both players in sync for timed game events.
+
+---
+
+## Related Rules
+
+- [Network Physics: Replicate Gameplay Events, Not Collision Detection](./network-physics.md) — detailed knockback dedup pattern
+- [Replay Mark Hit Timing Constraint](./replay-mark-hit-timing.md) — timing of `markHit()` within a single machine's frame commit cycle

--- a/.claude/rules/network/interpolation-system-ordering.md
+++ b/.claude/rules/network/interpolation-system-ordering.md
@@ -1,0 +1,20 @@
+# InterpolationSystem Ordering
+
+**Paths:** `packages/network/src/domain/systems/InterpolationSystem.ts`
+
+## Key Fact
+
+`InterpolationSystem` runs at `updatePhase: 'update'` with `order: 100`. It **unconditionally overwrites** `transform.localPosition` every frame for any entity registered as a `consumer` via `useReplicateTransform()`.
+
+## Implication for Position Overrides
+
+**You cannot override a replicated entity's position in a default-order `useFrameUpdate`** — the interpolation system will revert it at order 100. To set a custom position (e.g., replay playback):
+
+- Use `useFrameUpdate` with `order > 100` and write to `transform.localPosition` (not `root.position`)
+- The ThreeTRSSyncSystem (late phase) will then sync the updated localPosition to `root.position`
+
+Setting `root.position` directly is futile; it gets overwritten by ThreeTRSSyncSystem's copy from localPosition, which was already rewritten by InterpolationSystem.
+
+## Related
+
+- See `.claude/rules/three/trs-sync-ordering.md` for the complete pipeline: InterpolationSystem → localPosition → ThreeTRSSyncSystem → root.position

--- a/.claude/rules/three/trs-sync-ordering.md
+++ b/.claude/rules/three/trs-sync-ordering.md
@@ -14,6 +14,23 @@
 
 LocalPlayerNode's manual interpolation in `useFrameUpdate` (using `prevX`, `cur.x`, `alpha`) appears to work because trsSync does its own equivalent interpolation via `getLocalTRS(trs, alpha)`. Both produce the same result from the same transform data, so trsSync "overwriting" the manual interpolation is invisible — the values match.
 
+## InterpolationSystem Interaction (Network Replication)
+
+When an entity is registered as a `consumer` via `useReplicateTransform` in packages/network:
+
+1. **InterpolationSystem** (packages/network, order 100, update phase) overwrites `transform.localPosition` with interpolated values
+2. **ThreeTRSSyncSystem** (packages/three, late phase) then copies that `localPosition` to `root.position`
+
+**Consequence:** For replicated entities, **setting `root.position` directly in a default-order `useFrameUpdate` is futile** — InterpolationSystem will overwrite `localPosition` at order 100, then trsSync copies that back to `root.position`, undoing your write.
+
+**Solution:** To override a replicated entity's position (e.g., instant replay):
+- Use `useFrameUpdate` with `order > 100` and set `transform.localPosition` (not `root.position`)
+- Or use a late-phase callback to bypass the interpolation system
+
+**Key files:**
+- `packages/network/src/domain/systems/InterpolationSystem.ts` — order 100, update phase
+- `packages/network/src/domain/services/InterpolationService.ts` — performs smoothing
+
 ## Exception
 
 Direct `root.position` writes are valid for **child objects** added via `useObject3D()` (not the root itself), since trsSync only iterates roots registered with `ThreeService`.

--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-013-enhanced-game-experience/done/TICKET-082-instant-replay-system.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-013-enhanced-game-experience/done/TICKET-082-instant-replay-system.md
@@ -2,7 +2,7 @@
 id: TICKET-082
 epic: EPIC-013
 title: Instant replay system
-status: in-progress
+status: done
 branch: ticket-082-fix-replay-online-bugs
 priority: high
 created: 2026-03-02
@@ -56,3 +56,4 @@ players before proceeding with the normal next-round flow.
 - **2026-03-02**: Implementation complete — ring buffer recording, variable-speed playback, cinematic follow-cam with hit zoom, letterbox overlay, 167 tests passing.
 - **2026-03-02**: Polish rounds complete — velocity-proportional trails, self-KO bobbing text, hit impact burst, camera follows loser, particle clearing on replay entry. All 289 tests passing (105 effects + 184 arena).
 - **2026-03-02**: Reopened — two online-mode bugs: (1) remote player position stuttery during replay (InterpolationSystem fights with replay override), (2) local player indicator ring stays visible during replay.
+- **2026-03-02**: Fixed all online replay bugs — remote stutter (useFrameUpdate order 200), indicator ring hidden during non-playing phases, markHit network sync, host-authoritative countdown, multi-hit particle bursts + camera shake. 191 arena tests passing.

--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-013-enhanced-game-experience/done/TICKET-082-instant-replay-system.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-013-enhanced-game-experience/done/TICKET-082-instant-replay-system.md
@@ -3,7 +3,7 @@ id: TICKET-082
 epic: EPIC-013
 title: Instant replay system
 status: done
-branch: ticket-082-instant-replay-system
+branch: ticket-082-fix-replay-online-bugs
 priority: high
 created: 2026-03-02
 updated: 2026-03-02

--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-013-enhanced-game-experience/in-progress/TICKET-082-instant-replay-system.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-013-enhanced-game-experience/in-progress/TICKET-082-instant-replay-system.md
@@ -2,7 +2,7 @@
 id: TICKET-082
 epic: EPIC-013
 title: Instant replay system
-status: done
+status: in-progress
 branch: ticket-082-fix-replay-online-bugs
 priority: high
 created: 2026-03-02
@@ -55,3 +55,4 @@ players before proceeding with the normal next-round flow.
 - **2026-03-02**: Ticket created.
 - **2026-03-02**: Implementation complete — ring buffer recording, variable-speed playback, cinematic follow-cam with hit zoom, letterbox overlay, 167 tests passing.
 - **2026-03-02**: Polish rounds complete — velocity-proportional trails, self-KO bobbing text, hit impact burst, camera follows loser, particle clearing on replay entry. All 289 tests passing (105 effects + 184 arena).
+- **2026-03-02**: Reopened — two online-mode bugs: (1) remote player position stuttery during replay (InterpolationSystem fights with replay override), (2) local player indicator ring stays visible during replay.

--- a/demos/arena/src/nodes/ArenaNode.ts
+++ b/demos/arena/src/nodes/ArenaNode.ts
@@ -131,8 +131,11 @@ export function ArenaNode(props?: Readonly<ArenaNodeProps>) {
         });
     }
 
-    // Game manager — tracks knockout scores
-    useChild(GameManagerNode, online ? { online } : undefined);
+    // Game manager — tracks knockout scores, host-authoritative countdown sync
+    useChild(
+        GameManagerNode,
+        online ? { online, isHost: props!.isHost } : undefined,
+    );
 
     // Score HUD
     useChild(ScoreHudNode);

--- a/demos/arena/src/nodes/GameManagerNode.test.ts
+++ b/demos/arena/src/nodes/GameManagerNode.test.ts
@@ -9,10 +9,11 @@ describe('GameManagerNode', () => {
         expect(typeof GameManagerNode).toBe('function');
     });
 
-    it('accepts optional online prop', () => {
+    it('accepts optional online and isHost props', () => {
         // Type-level check — props are optional
-        const props: GameManagerNodeProps = { online: true };
+        const props: GameManagerNodeProps = { online: true, isHost: true };
         expect(props.online).toBe(true);
+        expect(props.isHost).toBe(true);
     });
 });
 

--- a/demos/arena/src/nodes/GameManagerNode.ts
+++ b/demos/arena/src/nodes/GameManagerNode.ts
@@ -13,7 +13,7 @@ import {
     RESET_PAUSE_DURATION,
     COUNTDOWN_DURATION,
 } from '../config/arena';
-import { KnockoutChannel } from '../config/channels';
+import { KnockoutChannel, RoundResetChannel } from '../config/channels';
 import {
     startReplay,
     isReplayActive,
@@ -49,6 +49,10 @@ export interface GameManagerNodeProps {
     /** When true, subscribes to the knockout channel for remote events
      *  and skips the paused guard (online mode cannot freeze the game). */
     online?: boolean;
+    /** Whether the local machine is the host in online mode. The host
+     *  broadcasts the "go" signal when the countdown ends; the non-host
+     *  waits for it before transitioning to `playing`. */
+    isHost?: boolean;
 }
 
 /**
@@ -66,10 +70,20 @@ export function GameManagerNode(props?: Readonly<GameManagerNodeProps>) {
     const gameState = useContext(GameCtx);
 
     // In online mode, receive knockout events from the remote machine
+    // and synchronize countdown→playing transition via RoundResetChannel.
+    let publishRoundReset: ((round: number) => void) | null = null;
+    let hostCountdownDone = false;
+
     if (props?.online) {
         useChannel(KnockoutChannel, (knockedOutPlayerId) => {
             gameState.pendingKnockout = knockedOutPlayerId;
         });
+
+        const rc = useChannel(RoundResetChannel, () => {
+            // Non-host: the host says "go" — we can transition to playing
+            hostCountdownDone = true;
+        });
+        publishRoundReset = (round) => rc.publish(round);
     }
 
     const koFlashTimer = useTimer(KO_FLASH_DURATION);
@@ -158,14 +172,31 @@ export function GameManagerNode(props?: Readonly<GameManagerNodeProps>) {
                 break;
 
             case 'countdown': {
-                if (!countdownTimer.active) {
+                const isNonHost = props?.online && !props?.isHost;
+
+                // Check if we should transition to playing:
+                // - Local mode or host: when local countdown expires
+                // - Non-host: when local countdown expires AND host signal received
+                //   OR when host signal arrives before local countdown (snap to playing)
+                const localDone = !countdownTimer.active;
+                const canTransition = localDone
+                    ? !isNonHost || hostCountdownDone
+                    : isNonHost && hostCountdownDone;
+
+                if (canTransition) {
                     gameState.phase = 'playing';
                     gameState.countdownValue = -1;
                     prevCountdown = -1;
+                    hostCountdownDone = false;
+
+                    // Host: broadcast "go" signal so non-host can transition
+                    if (props?.online && props?.isHost) {
+                        publishRoundReset!(gameState.round);
+                    }
                 } else {
-                    const value = computeCountdownValue(
-                        countdownTimer.remaining,
-                    );
+                    const value = localDone
+                        ? 0 // non-host waiting for host — hold on "GO!"
+                        : computeCountdownValue(countdownTimer.remaining);
                     if (value !== prevCountdown) {
                         if (value > 0) countdownBeepSfx.play();
                         else countdownGoSfx.play();

--- a/demos/arena/src/nodes/LocalPlayerNode.ts
+++ b/demos/arena/src/nodes/LocalPlayerNode.ts
@@ -562,33 +562,40 @@ export function LocalPlayerNode({
         }
 
         // Update indicator ring screen position (online mode only)
+        // Hidden during non-playing phases (replay, ko_flash, etc.)
         if (indicatorRing) {
-            const hw = threeRenderer.domElement.clientWidth / 2;
-            const hh = threeRenderer.domElement.clientHeight / 2;
+            if (gameState.phase !== 'playing') {
+                indicatorRing.style.display = 'none';
+            } else {
+                indicatorRing.style.display = '';
 
-            // Project player center to screen
-            projCenter
-                .set(root.position.x, root.position.y, root.position.z)
-                .project(threeCamera);
-            const sx = projCenter.x * hw + hw;
-            const sy = -projCenter.y * hh + hh;
+                const hw = threeRenderer.domElement.clientWidth / 2;
+                const hh = threeRenderer.domElement.clientHeight / 2;
 
-            // Project edge point to get screen-space radius
-            projEdge
-                .set(
-                    root.position.x + PLAYER_RADIUS * INDICATOR_RING_SCALE,
-                    root.position.y,
-                    root.position.z,
-                )
-                .project(threeCamera);
-            const edgeSx = projEdge.x * hw + hw;
-            const radius = Math.abs(edgeSx - sx);
-            const size = radius * 2;
+                // Project player center to screen
+                projCenter
+                    .set(root.position.x, root.position.y, root.position.z)
+                    .project(threeCamera);
+                const sx = projCenter.x * hw + hw;
+                const sy = -projCenter.y * hh + hh;
 
-            indicatorRing.style.width = `${size}px`;
-            indicatorRing.style.height = `${size}px`;
-            indicatorRing.style.left = `${sx - radius}px`;
-            indicatorRing.style.top = `${sy - radius}px`;
+                // Project edge point to get screen-space radius
+                projEdge
+                    .set(
+                        root.position.x + PLAYER_RADIUS * INDICATOR_RING_SCALE,
+                        root.position.y,
+                        root.position.z,
+                    )
+                    .project(threeCamera);
+                const edgeSx = projEdge.x * hw + hw;
+                const radius = Math.abs(edgeSx - sx);
+                const size = radius * 2;
+
+                indicatorRing.style.width = `${size}px`;
+                indicatorRing.style.height = `${size}px`;
+                indicatorRing.style.left = `${sx - radius}px`;
+                indicatorRing.style.top = `${sy - radius}px`;
+            }
         }
     });
 }

--- a/demos/arena/src/nodes/LocalPlayerNode.ts
+++ b/demos/arena/src/nodes/LocalPlayerNode.ts
@@ -345,6 +345,10 @@ export function LocalPlayerNode({
                 return;
             body.applyImpulse(msg.impulse[0], msg.impulse[1], msg.impulse[2]);
 
+            // Mark hit for replay — the remote machine detected the collision,
+            // so this machine should also show the proper KO replay (not "self KO").
+            markHit();
+
             // Impact feedback — particles + sound so the defender sees the hit.
             // Spawn particles on the local player's surface in the direction
             // the hit came from (opposite of the impulse direction).

--- a/demos/arena/src/nodes/RemotePlayerNode.ts
+++ b/demos/arena/src/nodes/RemotePlayerNode.ts
@@ -120,14 +120,27 @@ export function RemotePlayerNode({
         });
     }
 
-    // During replay, override mesh position from the replay buffer.
-    // Also emit velocity-proportional trail particles during gameplay.
-    useFrameUpdate((dt) => {
-        const replayPos = getReplayPosition(remotePlayerId);
-        if (replayPos) {
-            root.position.set(replayPos[0], replayPos[1], replayPos[2]);
-        }
+    // During replay, override transform.localPosition from the replay buffer
+    // AFTER InterpolationSystem (order 100) runs, so the network-smoothed
+    // position doesn't fight with the replay position. trsSync (late phase)
+    // then copies our replay position to root.position.
+    useFrameUpdate(
+        () => {
+            if (gameState.phase !== 'replay') return;
+            const replayPos = getReplayPosition(remotePlayerId);
+            if (replayPos) {
+                transform.localPosition.set(
+                    replayPos[0],
+                    replayPos[1],
+                    replayPos[2],
+                );
+            }
+        },
+        { order: 200 },
+    );
 
+    // Emit velocity-proportional trail particles during gameplay.
+    useFrameUpdate((dt) => {
         // Velocity-proportional trail particles during gameplay
         if (gameState.phase === 'playing' && dt > 0) {
             const cx = root.position.x;

--- a/demos/arena/src/nodes/ReplayNode.ts
+++ b/demos/arena/src/nodes/ReplayNode.ts
@@ -8,10 +8,12 @@ import {
     getReplayPosition,
     getReplayVelocity,
     getReplaySpeed,
-    getReplayHitProximity,
+    getReplayHitIndices,
+    getReplayCursorPos,
     hasReplayHit,
 } from '../replay';
 import { PLAYER_COLORS, TRAIL_BASE_INTERVAL } from '../config/arena';
+import { triggerCameraShake } from './CameraRigNode';
 
 /** Height of each cinematic letterbox bar as a CSS value. */
 export const LETTERBOX_HEIGHT = '8%';
@@ -181,7 +183,7 @@ export function ReplayNode() {
     let wasReplay = false;
     let flashTimer = 0;
     let trailAccum = 0;
-    let hitBurstEmitted = false;
+    const hitBurstsEmitted = new Set<number>();
     let selfKoMessagePicked = false;
 
     useFrameUpdate((dt) => {
@@ -239,21 +241,23 @@ export function ReplayNode() {
                 selfKoText.style.opacity = '0';
             }
 
-            // Hit impact burst at the collision moment
-            if (
-                hasReplayHit() &&
-                !hitBurstEmitted &&
-                getReplayHitProximity() > 0.9
-            ) {
-                const p0 = getReplayPosition(0);
-                const p1 = getReplayPosition(1);
-                if (p0 && p1) {
-                    hitImpactBurst([
-                        (p0[0] + p1[0]) / 2,
-                        (p0[1] + p1[1]) / 2,
-                        (p0[2] + p1[2]) / 2,
-                    ]);
-                    hitBurstEmitted = true;
+            // Hit impact bursts + camera shake at each collision moment
+            const cursor = getReplayCursorPos();
+            for (const hitIdx of getReplayHitIndices()) {
+                if (hitBurstsEmitted.has(hitIdx)) continue;
+                // Fire when cursor is within 1 frame of the hit
+                if (Math.abs(cursor - hitIdx) < 1) {
+                    const p0 = getReplayPosition(0);
+                    const p1 = getReplayPosition(1);
+                    if (p0 && p1) {
+                        hitImpactBurst([
+                            (p0[0] + p1[0]) / 2,
+                            (p0[1] + p1[1]) / 2,
+                            (p0[2] + p1[2]) / 2,
+                        ]);
+                        triggerCameraShake(0.4, 0.3);
+                    }
+                    hitBurstsEmitted.add(hitIdx);
                 }
             }
 
@@ -279,7 +283,7 @@ export function ReplayNode() {
         } else {
             selfKoText.style.opacity = '0';
             trailAccum = 0;
-            hitBurstEmitted = false;
+            hitBurstsEmitted.clear();
             selfKoMessagePicked = false;
         }
     });

--- a/demos/arena/src/replay.test.ts
+++ b/demos/arena/src/replay.test.ts
@@ -12,6 +12,8 @@ import {
     getSpeedAtFrame,
     getReplayVelocity,
     getReplaySpeed,
+    getReplayHitIndices,
+    getReplayCursorPos,
     hasReplayHit,
     endReplay,
     clearRecording,
@@ -273,6 +275,74 @@ describe('hasReplayHit', () => {
         expect(getReplaySpeed()).toBeCloseTo(0.8);
         // hitProximity should be 0 throughout (no hit to be near)
         expect(getReplayHitProximity()).toBe(0);
+    });
+});
+
+describe('getReplayHitIndices (multi-hit)', () => {
+    it('returns empty array when no hits recorded', () => {
+        recordFrame(0, 0, 0, 0, 0, 0);
+        startReplay(1);
+        expect(getReplayHitIndices()).toEqual([]);
+    });
+
+    it('tracks a single hit', () => {
+        recordFrame(0, 0, 0, 0, 0, 0);
+        markHit();
+        recordFrame(1, 0, 0, 0, 0, 0);
+        startReplay(1);
+        expect(getReplayHitIndices()).toEqual([1]);
+    });
+
+    it('tracks multiple hits at different frames', () => {
+        for (let i = 0; i < 20; i++) {
+            recordFrame(i, 0, 0, 0, 0, 0);
+            if (i === 5 || i === 12) markHit();
+        }
+        startReplay(1);
+        const indices = getReplayHitIndices();
+        expect(indices.length).toBe(2);
+        expect(indices[0]).toBe(6); // markHit at write count after frame 5
+        expect(indices[1]).toBe(13); // markHit at write count after frame 12
+    });
+
+    it('speed slows around all hits, not just the last', () => {
+        for (let i = 0; i < 80; i++) {
+            recordFrame(i, 0, 0, 0, 0, 0);
+            if (i === 5 || i === 60) markHit();
+        }
+        startReplay(1);
+        const indices = getReplayHitIndices();
+        // Speed should be slow near both hits
+        expect(getSpeedAtFrame(indices[0])).toBeCloseTo(0.15);
+        expect(getSpeedAtFrame(indices[1])).toBeCloseTo(0.15);
+        // Speed should be normal far from both hits (frame 35 is > 15 from both)
+        expect(getSpeedAtFrame(35)).toBeCloseTo(0.8);
+    });
+
+    it('cleared after endReplay', () => {
+        recordFrame(0, 0, 0, 0, 0, 0);
+        markHit();
+        recordFrame(1, 0, 0, 0, 0, 0);
+        startReplay(1);
+        expect(getReplayHitIndices().length).toBe(1);
+        endReplay();
+        expect(getReplayHitIndices()).toEqual([]);
+    });
+});
+
+describe('getReplayCursorPos', () => {
+    it('starts at 0', () => {
+        recordFrame(0, 0, 0, 0, 0, 0);
+        recordFrame(1, 0, 0, 0, 0, 0);
+        startReplay(1);
+        expect(getReplayCursorPos()).toBe(0);
+    });
+
+    it('advances with advanceReplay', () => {
+        for (let i = 0; i < 20; i++) recordFrame(i, 0, 0, 0, 0, 0);
+        startReplay(1);
+        advanceReplay(0.1);
+        expect(getReplayCursorPos()).toBeGreaterThan(0);
     });
 });
 

--- a/demos/arena/src/replay.ts
+++ b/demos/arena/src/replay.ts
@@ -27,7 +27,7 @@ export interface ReplayFrame {
 
 const buffer: ReplayFrame[] = [];
 let writeCount = 0;
-let lastHitWriteCount = -1;
+let hitWriteCounts: number[] = [];
 
 // ---------------------------------------------------------------------------
 // Playback state
@@ -35,7 +35,7 @@ let lastHitWriteCount = -1;
 
 let active = false;
 let playbackFrames: ReplayFrame[] = [];
-let hitIndex = -1;
+let hitIndices: number[] = [];
 let hadRealHit = false;
 let cursorPos = 0;
 let knockedOut = -1;
@@ -143,8 +143,9 @@ export function recordFrame(
 }
 
 /**
- * Mark the current frame as the "hit" moment (last collision before KO).
- * Call from the collision handler in the player node.
+ * Mark the current frame as a collision hit moment.
+ * Call from the collision handler in the player node. Multiple hits
+ * can be recorded per round — all are preserved for replay playback.
  *
  * @example
  * ```ts
@@ -152,7 +153,7 @@ export function recordFrame(
  * ```
  */
 export function markHit(): void {
-    lastHitWriteCount = writeCount;
+    hitWriteCounts.push(writeCount);
 }
 
 // ---------------------------------------------------------------------------
@@ -174,10 +175,13 @@ export function markHit(): void {
  * ```
  */
 export function getSpeedAtFrame(frameIndex: number): number {
-    if (hitIndex < 0) return REPLAY_NORMAL_SPEED;
-    const dist = Math.abs(frameIndex - hitIndex);
-    if (dist >= REPLAY_HIT_WINDOW_FRAMES) return REPLAY_NORMAL_SPEED;
-    const t = dist / REPLAY_HIT_WINDOW_FRAMES;
+    if (hitIndices.length === 0) return REPLAY_NORMAL_SPEED;
+    let minDist = Infinity;
+    for (const hi of hitIndices) {
+        minDist = Math.min(minDist, Math.abs(frameIndex - hi));
+    }
+    if (minDist >= REPLAY_HIT_WINDOW_FRAMES) return REPLAY_NORMAL_SPEED;
+    const t = minDist / REPLAY_HIT_WINDOW_FRAMES;
     return REPLAY_HIT_SPEED + (REPLAY_NORMAL_SPEED - REPLAY_HIT_SPEED) * t;
 }
 
@@ -212,15 +216,14 @@ export function startReplay(knockedOutPlayerId: number): void {
         });
     }
 
-    // Map the hit index into the playback frames array
-    if (lastHitWriteCount >= startWrite && lastHitWriteCount < writeCount) {
-        hitIndex = lastHitWriteCount - startWrite;
-        hadRealHit = true;
-    } else {
-        // No hit recorded — self-KO (player fell on their own)
-        hitIndex = -1;
-        hadRealHit = false;
+    // Map all hit write counts into playback frame indices
+    hitIndices = [];
+    for (const hwc of hitWriteCounts) {
+        if (hwc >= startWrite && hwc < writeCount) {
+            hitIndices.push(hwc - startWrite);
+        }
     }
+    hadRealHit = hitIndices.length > 0;
 
     cursorPos = 0;
     active = true;
@@ -316,11 +319,14 @@ export function getReplayKnockedOut(): number {
  * Used by the camera to zoom in during the impact.
  */
 export function getReplayHitProximity(): number {
-    if (hitIndex < 0 || playbackFrames.length === 0) return 0;
+    if (hitIndices.length === 0 || playbackFrames.length === 0) return 0;
     const idx = Math.min(cursorPos, playbackFrames.length - 1);
-    const dist = Math.abs(idx - hitIndex);
-    if (dist >= REPLAY_HIT_WINDOW_FRAMES) return 0;
-    return 1 - dist / REPLAY_HIT_WINDOW_FRAMES;
+    let minDist = Infinity;
+    for (const hi of hitIndices) {
+        minDist = Math.min(minDist, Math.abs(idx - hi));
+    }
+    if (minDist >= REPLAY_HIT_WINDOW_FRAMES) return 0;
+    return 1 - minDist / REPLAY_HIT_WINDOW_FRAMES;
 }
 
 /**
@@ -338,9 +344,11 @@ export function getReplayHitProximity(): number {
  * ```
  */
 export function getReplayPastHit(): number {
-    if (hitIndex < 0 || playbackFrames.length === 0) return 0;
+    if (hitIndices.length === 0 || playbackFrames.length === 0) return 0;
+    // Use the last hit (KO-causing) for camera follow transition
+    const lastHit = hitIndices[hitIndices.length - 1];
     const idx = Math.min(cursorPos, playbackFrames.length - 1);
-    const dist = idx - hitIndex; // signed: negative = before hit
+    const dist = idx - lastHit; // signed: negative = before hit
     if (dist <= 0) return 0;
     if (dist >= REPLAY_HIT_WINDOW_FRAMES) return 1;
     return dist / REPLAY_HIT_WINDOW_FRAMES;
@@ -421,11 +429,38 @@ export function hasReplayHit(): boolean {
     return hadRealHit;
 }
 
+/**
+ * Get the frame indices of all recorded collision hits in the current replay.
+ * Returns an empty array when no replay is active or no hits were recorded.
+ *
+ * @returns Array of hit frame indices into the playback frames.
+ *
+ * @example
+ * ```ts
+ * for (const hitIdx of getReplayHitIndices()) {
+ *     // fire particles at each hit moment
+ * }
+ * ```
+ */
+export function getReplayHitIndices(): readonly number[] {
+    return hitIndices;
+}
+
+/**
+ * Get the current replay cursor position (floating-point frame index).
+ * Returns 0 when no replay is active.
+ *
+ * @returns Current cursor position in the playback frames.
+ */
+export function getReplayCursorPos(): number {
+    return cursorPos;
+}
+
 /** End the replay and release the playback buffer. */
 export function endReplay(): void {
     active = false;
     playbackFrames = [];
-    hitIndex = -1;
+    hitIndices = [];
     hadRealHit = false;
     cursorPos = 0;
 }
@@ -444,7 +479,7 @@ export function endReplay(): void {
 export function clearRecording(): void {
     buffer.length = 0;
     writeCount = 0;
-    lastHitWriteCount = -1;
+    hitWriteCounts = [];
     staged0x = staged0y = staged0z = 0;
     staged1x = staged1y = staged1z = 0;
 }
@@ -455,7 +490,7 @@ export function clearRecording(): void {
 export function resetReplay(): void {
     buffer.length = 0;
     writeCount = 0;
-    lastHitWriteCount = -1;
+    hitWriteCounts = [];
     staged0x = staged0y = staged0z = 0;
     staged1x = staged1y = staged1z = 0;
     endReplay();


### PR DESCRIPTION
## Summary

- **Remote player stutter during replay**: Added `useFrameUpdate({ order: 200 })` in RemotePlayerNode to override replay position after InterpolationSystem (order 100)
- **Indicator ring visible during replay**: Hidden via `display: 'none'` when phase is not `playing`
- **markHit network sync**: Added `markHit()` call in knockback channel handler so both machines record the collision hit
- **Host-authoritative countdown**: Host broadcasts via `RoundResetChannel` when countdown expires; non-host waits for signal before transitioning to `playing`
- **Multi-hit replay effects**: Changed from single-hit to multi-hit tracking — all collisions now fire particle bursts + camera shake during replay, speed ramps down around every hit

## Test plan

- [x] 191 arena tests passing
- [x] Lint clean
- [ ] Manual: verify multi-hit replay shows bursts at each collision
- [ ] Manual: verify remote player smooth during online replay
- [ ] Manual: verify countdown synced between online players

🤖 Generated with [Claude Code](https://claude.com/claude-code)