### PR TITLE
Fix deferred respawn flicker and button hover glitches

### DIFF
--- a/.claude/rules/arena/deferred-respawn-guard.md
+++ b/.claude/rules/arena/deferred-respawn-guard.md
@@ -1,0 +1,77 @@
+# Deferred Respawn Guard: Guard All Condition Paths
+
+**Paths:** `demos/arena/src/nodes/LocalPlayerNode.ts`, `demos/arena/src/nodes/RemotePlayerNode.ts`
+
+## Problem
+
+When a boolean flag (e.g., `knockedOut`) suppresses re-entry into a code path, **ALL code paths that check the underlying condition must be guarded**, not just the primary or "safe" paths.
+
+### The Bug Pattern
+
+```typescript
+// Mesh hidden (respawn deferred), player still below death plane
+let knockedOut = false;
+
+useFrameUpdate(() => {
+  // Path A: Main death plane check (NOT guarded)
+  if (transform.localPosition.y < DEATH_PLANE_Y) {
+    triggerKnockout();
+    knockedOut = true;
+  }
+
+  // Path B: Safety fallback (correctly guarded)
+  if (knockedOut && transform.localPosition.y < SAFETY_FALLBACK_Y) {
+    // This is guarded, but Path A is not
+  }
+});
+```
+
+During deferred respawn (mesh hidden, position not reset):
+1. Player mesh is hidden but position remains below death plane
+2. **Path A fires every frame** — `knockedOut` is set repeatedly
+3. Each frame, `triggerKnockout()` records the knockout attempt
+4. If knockout logic records player ID to a queue: queue fills with duplicates
+5. **Cascading effect:** GameManagerNode sees duplicate entries and misinterprets game state (e.g., tie detection)
+
+## Convention
+
+Guard both the primary condition check AND all fallback paths with the same suppression flag:
+
+```typescript
+let knockedOut = false;
+
+useFrameUpdate(() => {
+  // Path A: Always guard the underlying condition check
+  if (!knockedOut && transform.localPosition.y < DEATH_PLANE_Y) {
+    triggerKnockout();
+    knockedOut = true;
+  }
+
+  // Path B: Fallback is now redundant but still guarded for safety
+  if (!knockedOut && transform.localPosition.y < SAFETY_FALLBACK_Y) {
+    fallbackKnockout();
+    knockedOut = true;
+  }
+});
+```
+
+## Why This Matters
+
+- **Suppression flags block re-entry** — once `knockedOut = true`, the flag prevents further knockouts
+- **Missing guards on secondary paths** is a subtle bug: it looks like the flag is working, but one unguarded path fires repeatedly
+- **Cascading effects** — repeated state updates (recording hits, queuing knockouts) corrupt downstream logic
+- **Deferred respawn amplifies the issue** — the condition remains true while the flag is set, causing the unguarded path to trigger every frame
+
+## When This Applies
+
+Any code pattern where:
+1. A condition (y < threshold, velocity > limit, etc.) is checked repeatedly
+2. A suppression flag (`knockedOut`, `hasActivated`, etc.) is set to prevent re-entry
+3. Multiple code paths check **the same underlying condition**
+
+Guard all paths, not just the ones you think matter.
+
+## Related
+
+- `demos/arena/src/nodes/LocalPlayerNode.ts` — death plane + safety fallback
+- `collision-cooldown-guard.md` — similar atomic guarding pattern for collision effects

--- a/demos/arena/src/lobby.ts
+++ b/demos/arena/src/lobby.ts
@@ -160,13 +160,14 @@ function showHostSetup(overlay: HTMLElement, finish: Finish) {
     const playerRow = createRow(btnP1, btnP2);
 
     const btnBack = createButton('Back', '#888');
+    const backCol = createColumn(btnBack);
 
     content.appendChild(heading);
     content.appendChild(subheading);
     content.appendChild(playerRow);
-    content.appendChild(btnBack);
+    content.appendChild(backCol);
 
-    applyStaggeredEntrance([heading, subheading, playerRow, btnBack], 100);
+    applyStaggeredEntrance([heading, subheading, playerRow, backCol], 100);
     applyButtonHoverScale(btnP1);
     applyButtonHoverScale(btnP2);
     applyButtonHoverScale(btnBack);
@@ -292,12 +293,13 @@ function showJoinSetup(overlay: HTMLElement, finish: Finish) {
 
     const status = createStatusIndicator();
     const btnBack = createButton('Back', '#888');
+    const backCol = createColumn(btnBack);
 
     content.appendChild(heading);
     content.appendChild(status.el);
-    content.appendChild(btnBack);
+    content.appendChild(backCol);
 
-    applyStaggeredEntrance([heading, status.el, btnBack], 100);
+    applyStaggeredEntrance([heading, status.el, backCol], 100);
     applyButtonHoverScale(btnBack);
 
     let ws: WebSocket | null = null;

--- a/demos/arena/src/nodes/DisconnectOverlayNode.ts
+++ b/demos/arena/src/nodes/DisconnectOverlayNode.ts
@@ -67,15 +67,24 @@ export function DisconnectOverlayNode(
         : 'Host ended the match';
     container.appendChild(text);
 
-    // Main Menu button
-    const menuBtn = document.createElement('button');
-    menuBtn.textContent = 'Main Menu';
-    Object.assign(menuBtn.style, {
+    // Wrapper for absolute positioning — entrance animates this, not the button
+    const menuWrap = document.createElement('div');
+    Object.assign(menuWrap.style, {
         position: 'absolute',
         top: '55%',
         left: '50%',
         transform: 'translateX(-50%)',
         zIndex: '5001',
+        transition: 'opacity 0.5s ease-in',
+        opacity: '0',
+        pointerEvents: 'none',
+    } as Partial<CSSStyleDeclaration>);
+    container.appendChild(menuWrap);
+
+    // Main Menu button (no positioning transform — clean for hover scale)
+    const menuBtn = document.createElement('button');
+    menuBtn.textContent = 'Main Menu';
+    Object.assign(menuBtn.style, {
         font: 'bold clamp(14px, 3.5vw, 18px) monospace',
         color: '#fff',
         backgroundColor: 'rgba(255,255,255,0.08)',
@@ -84,9 +93,7 @@ export function DisconnectOverlayNode(
         padding: '12px 32px',
         minHeight: '44px',
         cursor: 'pointer',
-        transition: 'all 0.2s ease, opacity 0.5s ease-in',
-        opacity: '0',
-        pointerEvents: 'none',
+        transition: 'all 0.2s ease',
     } as Partial<CSSStyleDeclaration>);
     menuBtn.addEventListener('pointerdown', () => {
         menuBtn.style.backgroundColor = 'rgba(255,255,255,0.15)';
@@ -106,7 +113,7 @@ export function DisconnectOverlayNode(
     menuBtn.addEventListener('click', () => {
         props.onRequestMenu?.();
     });
-    container.appendChild(menuBtn);
+    menuWrap.appendChild(menuBtn);
 
     applyButtonHoverScale(menuBtn);
 
@@ -115,12 +122,12 @@ export function DisconnectOverlayNode(
     useFrameUpdate(() => {
         backdrop.style.opacity = disconnected ? '1' : '0';
         text.style.opacity = disconnected ? '1' : '0';
-        menuBtn.style.opacity = disconnected ? '1' : '0';
+        menuWrap.style.opacity = disconnected ? '1' : '0';
         backdrop.style.pointerEvents = disconnected ? 'auto' : 'none';
-        menuBtn.style.pointerEvents = disconnected ? 'auto' : 'none';
+        menuWrap.style.pointerEvents = disconnected ? 'auto' : 'none';
 
         if (disconnected && !wasDisconnected) {
-            applyStaggeredEntrance([text, menuBtn], 300);
+            applyStaggeredEntrance([text, menuWrap], 300);
         }
         wasDisconnected = disconnected;
     });
@@ -128,6 +135,6 @@ export function DisconnectOverlayNode(
     useDestroy(() => {
         backdrop.remove();
         text.remove();
-        menuBtn.remove();
+        menuWrap.remove();
     });
 }

--- a/demos/arena/src/nodes/LocalPlayerNode.ts
+++ b/demos/arena/src/nodes/LocalPlayerNode.ts
@@ -286,6 +286,10 @@ export function LocalPlayerNode({
     // Track round number to detect round resets via shared state
     let lastRound = gameState.round;
 
+    // Tracks whether this player has been knocked out this round.
+    // While true the mesh is hidden and death-plane resets are suppressed.
+    let knockedOut = false;
+
     // Track phase to detect transition into 'playing' (fixed update + frame update)
     let lastPhase = gameState.phase;
     let lastFramePhase = gameState.phase;
@@ -545,6 +549,8 @@ export function LocalPlayerNode({
         // Round reset — teleport to spawn when GameManagerNode increments round.
         if (gameState.round !== lastRound) {
             lastRound = gameState.round;
+            knockedOut = false;
+            root.visible = true;
             transform.localPosition.set(...spawn);
             body.setLinearVelocity(0, 0, 0);
             dashTimer.cancel();
@@ -578,7 +584,7 @@ export function LocalPlayerNode({
             }
 
             // Still check death plane during freeze for safety
-            if (transform.localPosition.y < DEATH_PLANE_Y) {
+            if (!knockedOut && transform.localPosition.y < DEATH_PLANE_Y) {
                 transform.localPosition.set(...spawn);
                 body.setLinearVelocity(0, 0, 0);
             }
@@ -613,8 +619,8 @@ export function LocalPlayerNode({
             }
         }
 
-        // Death plane — respawn when falling off the arena
-        if (transform.localPosition.y < DEATH_PLANE_Y) {
+        // Death plane — hide mesh on knockout; actual respawn deferred to round reset
+        if (!knockedOut && transform.localPosition.y < DEATH_PLANE_Y) {
             knockoutBurst([
                 transform.localPosition.x,
                 transform.localPosition.y,
@@ -629,7 +635,8 @@ export function LocalPlayerNode({
                 gameState.pendingKnockout = playerId;
             }
             if (publishKnockout) publishKnockout(playerId);
-            transform.localPosition.set(...spawn);
+            knockedOut = true;
+            root.visible = false;
             body.setLinearVelocity(0, 0, 0);
             dashTimer.cancel();
             dashCD.reset();
@@ -652,11 +659,17 @@ export function LocalPlayerNode({
                   ? 1
                   : 1 - dashCD.remaining / DASH_COOLDOWN,
         );
-        // During replay, override mesh position from the replay buffer
+        // During replay, override mesh position from the replay buffer.
+        // When knocked out (between death and round reset), hide the mesh
+        // so there's no visible snap-to-spawn before the replay finishes.
         const replayPos = getReplayPosition(playerId);
         if (replayPos) {
+            root.visible = true;
             root.position.set(replayPos[0], replayPos[1], replayPos[2]);
+        } else if (knockedOut) {
+            root.visible = false;
         } else {
+            root.visible = true;
             const alpha = world.getAmbientAlpha();
             const cur = transform.localPosition;
             root.position.set(

--- a/demos/arena/src/nodes/PauseMenuNode.ts
+++ b/demos/arena/src/nodes/PauseMenuNode.ts
@@ -178,7 +178,7 @@ export function PauseMenuNode(props?: Readonly<PauseMenuNodeProps>) {
         content.style.pointerEvents = visible ? 'auto' : 'none';
 
         if (visible && !wasVisible) {
-            applyStaggeredEntrance([title, resumeBtn, exitBtn], 100);
+            applyStaggeredEntrance([title, buttonRow], 100);
         }
         wasVisible = visible;
     });

--- a/demos/arena/src/overlayAnimations.ts
+++ b/demos/arena/src/overlayAnimations.ts
@@ -94,6 +94,14 @@ export function applyScalePop(el: HTMLElement): void {
  * ```
  */
 export function applyButtonHoverScale(btn: HTMLElement): void {
+    // Skip hover scaling on touch-only devices where pointerenter fires
+    // on tap but pointerleave doesn't reliably clear, causing sticky hover.
+    if (
+        typeof window.matchMedia === 'function' &&
+        !window.matchMedia('(hover: hover)').matches
+    ) {
+        return;
+    }
     const base = btn.style.transform || '';
     btn.addEventListener('pointerenter', () => {
         btn.style.transform = `${base} scale(1.05)`.trim();


### PR DESCRIPTION
## Summary
- **Deferred respawn**: Player mesh now hides on knockout instead of teleporting to spawn, preventing the visible snap-to-spawn flicker during the tie window and replay. The actual respawn happens on round reset after replay + ko_flash.
- **False tie fix**: All death-plane checks are guarded with `knockedOut` flag so knockout only registers once per fall, preventing duplicate `pendingKnockout` entries that caused every round to be scored as a tie.
- **Button hover glitches**: Fixed entrance+hover transform conflicts in PauseMenuNode, lobby (host setup / join setup), and DisconnectOverlayNode by animating container elements instead of individual buttons that also use `applyButtonHoverScale`.
- **Mobile hover stickiness**: `applyButtonHoverScale` now checks `(hover: hover)` media query and skips on touch-only devices where `pointerenter` fires on tap but `pointerleave` doesn't reliably clear.

## Test plan
- [x] `npm test -w demos/arena --silent` — all 495 tests pass
- [x] `npx eslint demos/arena/src/` — lint clean
- [ ] Visual: knockout hides mesh immediately, replay shows recorded footage, respawn only after replay ends
- [ ] Visual: pause menu buttons no longer glitch position on repeated open/close
- [ ] Visual: lobby back buttons have clean entrance animations
- [ ] Mobile: buttons don't show hover state on tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)