### PR TITLE
TICKET-104: Update prompt and auto-reload between matches

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-017-automatic-version-updates/in-progress/TICKET-104-update-prompt-and-auto-reload.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-017-automatic-version-updates/in-progress/TICKET-104-update-prompt-and-auto-reload.md
@@ -2,7 +2,7 @@
 id: TICKET-104
 epic: EPIC-017
 title: Update prompt and auto-reload between matches
-status: todo
+status: in-progress
 priority: high
 created: 2026-03-05
 updated: 2026-03-05

--- a/demos/arena/src/main.ts
+++ b/demos/arena/src/main.ts
@@ -15,6 +15,7 @@ import { initAutoFullscreen } from './autoFullscreen';
 import { showInstallPrompt } from './installPrompt';
 import { setupPostProcessing } from './setupPostProcessing';
 import { isMobileDevice } from './isMobileDevice';
+import { startVersionPolling, isUpdateAvailable } from './versionCheck';
 
 const canvas = document.getElementById('arena') as HTMLCanvasElement;
 const container = canvas.parentElement ?? document.body;
@@ -22,6 +23,7 @@ const container = canvas.parentElement ?? document.body;
 initLandscapeEnforcer();
 initAutoFullscreen();
 showInstallPrompt();
+startVersionPolling();
 
 function createMenuWorld(): { world: World; destroy: () => void } {
     const world = new World();
@@ -243,6 +245,12 @@ async function start() {
             await startOnlineGame(lobby);
             picked = true;
         }
+    }
+
+    // If a new version was deployed while playing, reload now
+    if (isUpdateAvailable()) {
+        location.reload();
+        return;
     }
 
     // Loop back to main menu after game ends

--- a/demos/arena/src/nodes/MatchOverOverlayNode.test.ts
+++ b/demos/arena/src/nodes/MatchOverOverlayNode.test.ts
@@ -1,3 +1,15 @@
+jest.mock('../versionCheck', () => ({
+    isUpdateAvailable: jest.fn(() => false),
+}));
+
+jest.mock('../updateAutoReload', () => ({
+    createAutoReloader: jest.fn(() => ({
+        schedule: jest.fn(),
+        cancel: jest.fn(),
+        dispose: jest.fn(),
+    })),
+}));
+
 import { MatchOverOverlayNode } from './MatchOverOverlayNode';
 
 describe('MatchOverOverlayNode', () => {
@@ -6,12 +18,10 @@ describe('MatchOverOverlayNode', () => {
     });
 
     it('accepts optional onRequestMenu prop', () => {
-        // Verify the function signature accepts props without errors
         expect(MatchOverOverlayNode.length).toBeLessThanOrEqual(1);
     });
 
     it('accepts optional onRequestRematch and online props', () => {
-        // Type-level: the function accepts the extended props shape
         expect(MatchOverOverlayNode.length).toBeLessThanOrEqual(1);
     });
 });

--- a/demos/arena/src/nodes/MatchOverOverlayNode.ts
+++ b/demos/arena/src/nodes/MatchOverOverlayNode.ts
@@ -13,6 +13,8 @@ import {
     applyStaggeredEntrance,
     applyButtonHoverScale,
 } from '../overlayAnimations';
+import { isUpdateAvailable } from '../versionCheck';
+import { createAutoReloader } from '../updateAutoReload';
 
 /** Player colors: P1 = teal, P2 = coral. */
 const PLAYER_COLORS = ['#48c9b0', '#e74c3c'];
@@ -139,6 +141,32 @@ export function MatchOverOverlayNode(
     buttonCol.appendChild(menuBtn);
     applyButtonHoverScale(menuBtn);
 
+    // Update banner — shown between matches when a new version is available
+    const updateBanner = document.createElement('div');
+    updateBanner.textContent = 'New version available \u2014 updating\u2026';
+    Object.assign(updateBanner.style, {
+        position: 'absolute',
+        top: '8px',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: '4002',
+        font: 'bold clamp(12px, 2.5vw, 16px) monospace',
+        color: '#48c9b0',
+        backgroundColor: 'rgba(0,0,0,0.75)',
+        border: '1px solid rgba(72,201,176,0.4)',
+        borderRadius: '6px',
+        padding: '8px 20px',
+        opacity: '0',
+        pointerEvents: 'none',
+        transition: 'opacity 0.4s ease',
+    } as Partial<CSSStyleDeclaration>);
+    container.appendChild(updateBanner);
+
+    const reloader = createAutoReloader();
+
+    /** Whether the update banner has been shown for the current match-over. */
+    let updateBannerShown = false;
+
     // --- Online rematch protocol ---
     let rematchState: RematchState = 'idle';
     const world = useWorld();
@@ -155,11 +183,13 @@ export function MatchOverOverlayNode(
             if (msg.type === 'offer') {
                 if (rematchState === 'waiting') {
                     // Mutual agreement — both offered
+                    reloader.cancel();
                     props.onRequestRematch?.();
                 } else if (rematchState === 'idle') {
                     rematchState = 'requested';
                 }
             } else if (msg.type === 'accept') {
+                reloader.cancel();
                 props.onRequestRematch?.();
             } else if (msg.type === 'decline') {
                 rematchState = 'declined';
@@ -175,6 +205,7 @@ export function MatchOverOverlayNode(
                 flushNet();
                 rematchState = 'waiting';
             } else if (rematchState === 'requested') {
+                reloader.cancel();
                 ch.publish({ type: 'accept' });
                 flushNet();
                 props.onRequestRematch?.();
@@ -182,6 +213,7 @@ export function MatchOverOverlayNode(
         });
 
         menuBtn.addEventListener('click', () => {
+            reloader.cancel();
             if (rematchState === 'requested') {
                 ch.publish({ type: 'decline' });
                 flushNet();
@@ -191,10 +223,12 @@ export function MatchOverOverlayNode(
     } else {
         // Local/solo mode — immediate rematch
         rematchBtn.addEventListener('click', () => {
+            reloader.cancel();
             props?.onRequestRematch?.();
         });
 
         menuBtn.addEventListener('click', () => {
+            reloader.cancel();
             props?.onRequestMenu?.();
         });
     }
@@ -264,14 +298,23 @@ export function MatchOverOverlayNode(
                 // Reset rematch state on fresh match-over display
                 rematchState = 'idle';
                 applyStaggeredEntrance([text, buttonCol], 300);
+
+                // Show update banner and schedule reload if a new version landed
+                if (isUpdateAvailable() && !updateBannerShown) {
+                    updateBannerShown = true;
+                    updateBanner.style.opacity = '1';
+                    reloader.schedule();
+                }
             }
         }
         wasVisible = visible;
     });
 
     useDestroy(() => {
+        reloader.dispose();
         backdrop.remove();
         text.remove();
         buttonCol.remove();
+        updateBanner.remove();
     });
 }

--- a/demos/arena/src/updateAutoReload.test.ts
+++ b/demos/arena/src/updateAutoReload.test.ts
@@ -1,0 +1,86 @@
+import { createAutoReloader, RELOAD_DELAY } from './updateAutoReload';
+
+beforeEach(() => {
+    jest.useFakeTimers();
+});
+
+afterEach(() => {
+    jest.useRealTimers();
+});
+
+describe('createAutoReloader', () => {
+    it('calls reloadFn after RELOAD_DELAY', () => {
+        const reload = jest.fn();
+        const reloader = createAutoReloader(reload);
+
+        reloader.schedule();
+        expect(reload).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(RELOAD_DELAY);
+        expect(reload).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire if cancelled before delay', () => {
+        const reload = jest.fn();
+        const reloader = createAutoReloader(reload);
+
+        reloader.schedule();
+        jest.advanceTimersByTime(RELOAD_DELAY / 2);
+        reloader.cancel();
+
+        jest.advanceTimersByTime(RELOAD_DELAY);
+        expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('allows re-scheduling after cancel', () => {
+        const reload = jest.fn();
+        const reloader = createAutoReloader(reload);
+
+        reloader.schedule();
+        reloader.cancel();
+        reloader.schedule();
+
+        jest.advanceTimersByTime(RELOAD_DELAY);
+        expect(reload).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores duplicate schedule calls', () => {
+        const reload = jest.fn();
+        const reloader = createAutoReloader(reload);
+
+        reloader.schedule();
+        reloader.schedule(); // should be ignored
+
+        jest.advanceTimersByTime(RELOAD_DELAY);
+        expect(reload).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancel is safe to call when nothing is scheduled', () => {
+        const reload = jest.fn();
+        const reloader = createAutoReloader(reload);
+
+        expect(() => reloader.cancel()).not.toThrow();
+    });
+
+    it('dispose prevents future scheduling', () => {
+        const reload = jest.fn();
+        const reloader = createAutoReloader(reload);
+
+        reloader.dispose();
+        reloader.schedule();
+
+        jest.advanceTimersByTime(RELOAD_DELAY * 2);
+        expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('dispose cancels a pending reload', () => {
+        const reload = jest.fn();
+        const reloader = createAutoReloader(reload);
+
+        reloader.schedule();
+        reloader.dispose();
+
+        jest.advanceTimersByTime(RELOAD_DELAY);
+        expect(reload).not.toHaveBeenCalled();
+    });
+});

--- a/demos/arena/src/updateAutoReload.ts
+++ b/demos/arena/src/updateAutoReload.ts
@@ -1,0 +1,67 @@
+/**
+ * Auto-reload scheduling for version updates.
+ *
+ * Manages a deferred page reload that can be cancelled if the user starts
+ * a new match before the reload fires.
+ *
+ * @example
+ * ```ts
+ * import { createAutoReloader } from './updateAutoReload';
+ *
+ * const reloader = createAutoReloader();
+ * reloader.schedule();  // reload in ~2s
+ * reloader.cancel();    // changed mind — cancel
+ * reloader.dispose();   // cleanup
+ * ```
+ */
+
+/** Delay before the page reload fires (ms). */
+export const RELOAD_DELAY = 2000;
+
+export interface AutoReloader {
+    /** Schedule a page reload after {@link RELOAD_DELAY} ms. No-op if already scheduled. */
+    schedule(): void;
+    /** Cancel a pending reload. Safe to call when nothing is scheduled. */
+    cancel(): void;
+    /** Cancel any pending reload and prevent future scheduling. */
+    dispose(): void;
+}
+
+/**
+ * Create an auto-reloader that calls `location.reload()` after a short delay.
+ *
+ * @param reloadFn - Override for the reload action (useful for testing).
+ * @returns An {@link AutoReloader} handle.
+ *
+ * @example
+ * ```ts
+ * const reloader = createAutoReloader();
+ * reloader.schedule();
+ * ```
+ */
+export function createAutoReloader(
+    reloadFn: () => void = () => location.reload(),
+): AutoReloader {
+    let handle: ReturnType<typeof setTimeout> | null = null;
+    let disposed = false;
+
+    return {
+        schedule() {
+            if (disposed || handle !== null) return;
+            handle = setTimeout(() => {
+                handle = null;
+                reloadFn();
+            }, RELOAD_DELAY);
+        },
+        cancel() {
+            if (handle !== null) {
+                clearTimeout(handle);
+                handle = null;
+            }
+        },
+        dispose() {
+            this.cancel();
+            disposed = true;
+        },
+    };
+}


### PR DESCRIPTION
## Summary

- Show an update banner on the match-over screen when the version poller detects a new deployment, then auto-reload after ~2s
- Cancel the reload if the user starts a rematch before it fires (defers to next match end)
- Reload immediately at menu transition if an update is pending
- Start version polling at app startup

## Test plan

- [x] All 44 test suites pass (534 tests), including 7 new tests for `updateAutoReload`
- [x] Lint clean on all changed files
- [ ] Manual: deploy a new version mid-match, verify no interruption during gameplay
- [ ] Manual: verify banner appears on match-over screen after update detected
- [ ] Manual: verify clicking Rematch cancels the reload
- [ ] Manual: verify returning to menu triggers immediate reload if update pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)