### PR TITLE
TICKET-106: Scoped State Stores (defineStore / useStore)

### DIFF
--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/done/TICKET-106-scoped-state-stores.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/done/TICKET-106-scoped-state-stores.md
@@ -2,7 +2,7 @@
 id: TICKET-106
 epic: EPIC-018
 title: Scoped State Stores (defineStore / useStore)
-status: todo
+status: done
 priority: high
 branch: ticket-106-scoped-state-stores
 created: 2026-03-13
@@ -25,16 +25,17 @@ Design doc: `design-docs/approved/004-scoped-state-stores.md`
 
 ## Acceptance Criteria
 
-- [ ] `defineStore(name, initializer)` creates a store definition
-- [ ] `useStore(StoreDef)` returns `[state, setState]` tuple
-- [ ] Store is lazy-created on first `useStore` call
-- [ ] Store is singleton per world (same reference across nodes)
-- [ ] Store is automatically cleaned up on world destroy
-- [ ] `setState` accepts partial updates or updater function
-- [ ] JSDoc with examples on all public APIs
-- [ ] Unit tests for creation, access, cleanup, partial updates
-- [ ] Documentation updated
+- [x] `defineStore(name, initializer)` creates a store definition
+- [x] `useStore(StoreDef)` returns `[state, setState]` tuple
+- [x] Store is lazy-created on first `useStore` call
+- [x] Store is singleton per world (same reference across nodes)
+- [x] Store is automatically cleaned up on world destroy
+- [x] `setState` accepts partial updates or updater function
+- [x] JSDoc with examples on all public APIs
+- [x] Unit tests for creation, access, cleanup, partial updates
+- [x] Documentation updated
 
 ## Notes
 
 - **2026-03-13**: Ticket created from approved design doc #4.
+- **2026-03-13**: Implementation complete. Added `stores.ts` with `defineStore`/`useStore`, integrated `clearStores` into `World.destroy()`, 12 passing tests, state management guide added to docs.

--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/todo/TICKET-106-scoped-state-stores.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/todo/TICKET-106-scoped-state-stores.md
@@ -4,6 +4,7 @@ epic: EPIC-018
 title: Scoped State Stores (defineStore / useStore)
 status: todo
 priority: high
+branch: ticket-106-scoped-state-stores
 created: 2026-03-13
 updated: 2026-03-13
 labels:

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
         { text: 'Networking: Replication & Interpolation', link: '/guides/networking-replication' },
         { text: 'Networking: Server Broker (WebSocket)', link: '/guides/networking-server-broker' },
         { text: 'Networking: Cookbook', link: '/guides/networking-cookbook' },
+        { text: 'State Management', link: '/guides/state-management' },
       ]
     },
     search: {

--- a/apps/docs/guides/state-management.md
+++ b/apps/docs/guides/state-management.md
@@ -1,0 +1,88 @@
+# State Management
+
+Pulse provides two complementary hooks for sharing state: **useContext** for node-scoped state and **useStore** for world-scoped state.
+
+## When to use which
+
+| | `useContext` | `useStore` |
+|---|---|---|
+| **Scope** | Node tree — provided by a parent, consumed by descendants | World — singleton, any node can access |
+| **Lifecycle** | Dies with the provider node | Dies with the world |
+| **Pattern** | Dependency injection / shared config | Global shared state (setter pattern) |
+| **Creation** | Explicit: `useProvideContext(ctx, value)` in a parent | Lazy: auto-created on first `useStore` call |
+| **Use case** | Game state owned by an orchestrator node | Cross-cutting state shared across unrelated nodes |
+
+## Defining a store
+
+Use `defineStore` to declare a store with a name and factory function. The factory is called once per world on first access.
+
+```ts
+import { defineStore } from '@pulse-ts/core';
+
+const DashCooldownStore = defineStore('dashCooldown', () => ({
+    progress: [1, 1] as [number, number],
+}));
+```
+
+## Reading and writing
+
+`useStore` returns a `[state, setState]` tuple. The `state` object is a stable reference — reading a field always reflects the latest value.
+
+```ts
+import { useStore, useFixedUpdate } from '@pulse-ts/core';
+
+// Writing from one node
+function PlayerDash({ playerId }: { playerId: number }) {
+    const [, setDash] = useStore(DashCooldownStore);
+
+    useFixedUpdate(() => {
+        setDash(prev => ({
+            progress: prev.progress.map((p, i) =>
+                i === playerId ? computeProgress() : p,
+            ) as [number, number],
+        }));
+    });
+}
+
+// Reading from another node
+function DashHud({ playerId }: { playerId: number }) {
+    const [dash] = useStore(DashCooldownStore);
+
+    useFrameUpdate(() => {
+        const pct = dash.progress[playerId];
+        // draw cooldown indicator...
+    });
+}
+```
+
+## setState
+
+`setState` accepts either a partial object (shallow-merged) or an updater function:
+
+```ts
+const [, setScore] = useStore(ScoreStore);
+
+// Partial object — shallow merge
+setScore({ values: [10, 20] });
+
+// Updater function — receives previous state
+setScore(prev => ({ values: prev.values.map(v => v + 1) }));
+```
+
+## Automatic cleanup
+
+Stores are destroyed when the world is destroyed. No manual reset functions are needed.
+
+```ts
+// Before: 7 manual reset calls in GameManagerNode
+resetDashCooldown();
+resetHitImpact();
+resetPlayerVelocity();
+// ...
+
+// After: nothing. Stores die with the world.
+```
+
+## World isolation
+
+Each world gets its own store instances. The same `StoreDefinition` used in two different worlds produces independent state.

--- a/apps/docs/learn/functional-nodes.md
+++ b/apps/docs/learn/functional-nodes.md
@@ -25,6 +25,12 @@ function Player() {
 - `useFrameUpdate(fn)` runs each rendered frame for visuals.
 - Early/Late variants control ordering.
 
+## State
+
+- `useState(key, initial)` stores local state on a node.
+- `useContext` / `useProvideContext` share values through the node tree (parent → descendants).
+- `defineStore` / `useStore` share world-scoped state accessible from any node. See [State Management](/guides/state-management).
+
 ## Composition
 
 - `useChild(Fn, props)` creates child nodes.

--- a/packages/core/src/domain/fc/stores.test.ts
+++ b/packages/core/src/domain/fc/stores.test.ts
@@ -1,0 +1,256 @@
+import { World } from '../world/world';
+import { useChild } from './hooks';
+import { defineStore, useStore } from './stores';
+
+describe('stores', () => {
+    describe('defineStore', () => {
+        test('returns a store definition with a unique key', () => {
+            const storeA = defineStore('a', () => ({ x: 1 }));
+            const storeB = defineStore('b', () => ({ x: 2 }));
+            expect(storeA._key).not.toBe(storeB._key);
+        });
+
+        test('uses provided name in symbol description', () => {
+            const store = defineStore('myStore', () => ({}));
+            expect(store._key.description).toBe('myStore');
+        });
+    });
+
+    describe('useStore', () => {
+        test('returns state created by the factory', () => {
+            const w = new World();
+            const Store = defineStore('test', () => ({ count: 0 }));
+            let state: { count: number } | null = null;
+
+            function Reader() {
+                const [s] = useStore(Store);
+                state = s;
+            }
+
+            w.mount(Reader);
+            expect(state).toEqual({ count: 0 });
+        });
+
+        test('store is singleton per world — same reference across nodes', () => {
+            const w = new World();
+            const Store = defineStore('shared', () => ({ value: 42 }));
+            const refs: Array<{ value: number }> = [];
+
+            function NodeA() {
+                const [s] = useStore(Store);
+                refs.push(s);
+            }
+
+            function NodeB() {
+                const [s] = useStore(Store);
+                refs.push(s);
+            }
+
+            function Root() {
+                useChild(NodeA);
+                useChild(NodeB);
+            }
+
+            w.mount(Root);
+            expect(refs).toHaveLength(2);
+            expect(refs[0]).toBe(refs[1]); // same reference
+        });
+
+        test('factory is called only once per world (lazy creation)', () => {
+            const w = new World();
+            let factoryCallCount = 0;
+            const Store = defineStore('lazy', () => {
+                factoryCallCount++;
+                return { n: 0 };
+            });
+
+            function NodeA() {
+                useStore(Store);
+            }
+
+            function NodeB() {
+                useStore(Store);
+            }
+
+            function Root() {
+                useChild(NodeA);
+                useChild(NodeB);
+            }
+
+            w.mount(Root);
+            expect(factoryCallCount).toBe(1);
+        });
+
+        test('setState with partial object performs shallow merge', () => {
+            const w = new World();
+            const Store = defineStore('partial', () => ({ a: 1, b: 'hello' }));
+            let state: { a: number; b: string } | null = null;
+            let setter:
+                | ((u: Partial<{ a: number; b: string }>) => void)
+                | null = null;
+
+            function Writer() {
+                const [s, set] = useStore(Store);
+                state = s;
+                setter = set;
+            }
+
+            w.mount(Writer);
+            expect(state).toEqual({ a: 1, b: 'hello' });
+
+            setter!({ a: 99 });
+            expect(state).toEqual({ a: 99, b: 'hello' });
+        });
+
+        test('setState with updater function receives previous state', () => {
+            const w = new World();
+            const Store = defineStore('updater', () => ({ count: 0 }));
+            type S = { count: number };
+            let setter:
+                | ((u: Partial<S> | ((prev: S) => Partial<S>)) => void)
+                | null = null;
+            let state: S | null = null;
+
+            function Writer() {
+                const [s, set] = useStore(Store);
+                state = s;
+                setter = set;
+            }
+
+            w.mount(Writer);
+            setter!((prev) => ({ count: prev.count + 10 }));
+            expect(state!.count).toBe(10);
+
+            setter!((prev) => ({ count: prev.count + 5 }));
+            expect(state!.count).toBe(15);
+        });
+
+        test('mutations via setState are visible to all consumers', () => {
+            const w = new World();
+            const Store = defineStore('visible', () => ({ score: 0 }));
+            type S = { score: number };
+            let writerSetter: ((u: Partial<S>) => void) | null = null;
+            let readerState: S | null = null;
+
+            function Writer() {
+                const [, set] = useStore(Store);
+                writerSetter = set;
+            }
+
+            function Reader() {
+                const [s] = useStore(Store);
+                readerState = s;
+            }
+
+            function Root() {
+                useChild(Writer);
+                useChild(Reader);
+            }
+
+            w.mount(Root);
+            expect(readerState!.score).toBe(0);
+
+            writerSetter!({ score: 42 });
+            expect(readerState!.score).toBe(42); // same reference, mutation visible
+        });
+
+        test('different stores are independent', () => {
+            const w = new World();
+            const StoreA = defineStore('a', () => ({ x: 1 }));
+            const StoreB = defineStore('b', () => ({ y: 'hello' }));
+            let stateA: { x: number } | null = null;
+            let stateB: { y: string } | null = null;
+
+            function Reader() {
+                const [a] = useStore(StoreA);
+                const [b] = useStore(StoreB);
+                stateA = a;
+                stateB = b;
+            }
+
+            w.mount(Reader);
+            expect(stateA).toEqual({ x: 1 });
+            expect(stateB).toEqual({ y: 'hello' });
+        });
+
+        test('different worlds get independent store instances', () => {
+            const Store = defineStore('perWorld', () => ({ n: 0 }));
+            const w1 = new World();
+            const w2 = new World();
+            let state1: { n: number } | null = null;
+            let state2: { n: number } | null = null;
+            let setter1: ((u: Partial<{ n: number }>) => void) | null = null;
+
+            function Node1() {
+                const [s, set] = useStore(Store);
+                state1 = s;
+                setter1 = set;
+            }
+
+            function Node2() {
+                const [s] = useStore(Store);
+                state2 = s;
+            }
+
+            w1.mount(Node1);
+            w2.mount(Node2);
+
+            expect(state1).not.toBe(state2); // different instances
+            setter1!({ n: 99 });
+            expect(state1!.n).toBe(99);
+            expect(state2!.n).toBe(0); // unaffected
+        });
+    });
+
+    describe('cleanup on world destroy', () => {
+        test('stores are cleared when world is destroyed', () => {
+            const Store = defineStore('cleanup', () => ({ v: 1 }));
+            const w = new World();
+            let state1: { v: number } | null = null;
+
+            function Reader() {
+                const [s] = useStore(Store);
+                state1 = s;
+            }
+
+            w.mount(Reader);
+            expect(state1!.v).toBe(1);
+
+            w.destroy();
+
+            // Mount on a new world — should get a fresh instance
+            const w2 = new World();
+            let state2: { v: number } | null = null;
+
+            function Reader2() {
+                const [s] = useStore(Store);
+                state2 = s;
+            }
+
+            w2.mount(Reader2);
+            expect(state2).not.toBe(state1);
+            expect(state2!.v).toBe(1); // fresh from factory
+        });
+
+        test('factory is called again for a new world after previous was destroyed', () => {
+            let factoryCallCount = 0;
+            const Store = defineStore('recount', () => {
+                factoryCallCount++;
+                return { x: 0 };
+            });
+
+            const w1 = new World();
+            function N() {
+                useStore(Store);
+            }
+            w1.mount(N);
+            expect(factoryCallCount).toBe(1);
+
+            w1.destroy();
+
+            const w2 = new World();
+            w2.mount(N);
+            expect(factoryCallCount).toBe(2);
+        });
+    });
+});

--- a/packages/core/src/domain/fc/stores.ts
+++ b/packages/core/src/domain/fc/stores.ts
@@ -1,0 +1,172 @@
+import type { World } from '../world/world';
+import { current } from './runtime';
+
+// ---------------------------------------------------------------------------
+// Store registry — WeakMap keyed by World, each world stores a Map<symbol, instance>
+// ---------------------------------------------------------------------------
+
+const storeMaps = new WeakMap<World, Map<symbol, StoreInstance<unknown>>>();
+
+function getStoreMap(world: World): Map<symbol, StoreInstance<unknown>> {
+    let map = storeMaps.get(world);
+    if (!map) {
+        map = new Map();
+        storeMaps.set(world, map);
+    }
+    return map;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Internal wrapper holding the current state for a store instance.
+ * @internal
+ */
+interface StoreInstance<T> {
+    state: T;
+}
+
+/**
+ * A store definition created by {@link defineStore}. Pass this to
+ * {@link useStore} to access world-scoped shared state.
+ *
+ * @typeParam T - The type of the state held by this store.
+ */
+export interface StoreDefinition<T> {
+    /** @internal Unique symbol key for this store. */
+    readonly _key: symbol;
+    /** @internal Factory function that creates the initial state. */
+    readonly _factory: () => T;
+    /** @internal Phantom field for type inference — never set at runtime. */
+    readonly _type: T;
+}
+
+/**
+ * A setter function returned by {@link useStore}. Accepts either a partial
+ * state object (shallow-merged) or an updater function that receives the
+ * previous state and returns a partial update.
+ *
+ * @typeParam T - The type of the store state.
+ */
+export type SetStore<T> = (
+    update: Partial<T> | ((prev: T) => Partial<T>),
+) => void;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Defines a named store with a factory function that creates the initial state.
+ * The factory is called once per world on first access via {@link useStore}.
+ * The state is automatically cleaned up when the world is destroyed.
+ *
+ * Stores are complementary to contexts ({@link useContext}): contexts are
+ * node-scoped (provided by a parent, consumed by descendants), while stores
+ * are world-scoped singletons accessible from any node.
+ *
+ * @typeParam T - The type of the state this store holds.
+ * @param name - Debug name for the store (included in error messages).
+ * @param factory - Called to create the initial state for each world.
+ * @returns A {@link StoreDefinition} usable with {@link useStore}.
+ *
+ * @example
+ * ```ts
+ * import { defineStore } from '@pulse-ts/core';
+ *
+ * const DashCooldownStore = defineStore('dashCooldown', () => ({
+ *     progress: [1, 1] as [number, number],
+ * }));
+ * ```
+ */
+export function defineStore<T>(
+    name: string,
+    factory: () => T,
+): StoreDefinition<T> {
+    return {
+        _key: Symbol(name),
+        _factory: factory,
+    } as StoreDefinition<T>;
+}
+
+/**
+ * Accesses a world-scoped store. Creates the store on first access within the
+ * current world. Returns the same instance for all callers in the same world.
+ *
+ * Returns a `[state, setState]` tuple. The `state` object is a stable reference
+ * that is mutated in place by `setState`, so reading `state.field` in an update
+ * callback always reflects the latest value.
+ *
+ * `setState` accepts either:
+ * - A partial state object — shallow-merged into the current state.
+ * - An updater function `(prev) => Partial<T>` — receives the current state
+ *   and returns a partial update to shallow-merge.
+ *
+ * @typeParam T - The type of the store state.
+ * @param definition - The store definition created by {@link defineStore}.
+ * @returns A tuple of `[currentState, setState]`.
+ *
+ * @example
+ * ```ts
+ * import { defineStore, useStore } from '@pulse-ts/core';
+ *
+ * const ScoreStore = defineStore('score', () => ({
+ *     values: [0, 0] as [number, number],
+ * }));
+ *
+ * // Writing from one node
+ * function ScoreKeeper() {
+ *     const [, setScore] = useStore(ScoreStore);
+ *
+ *     useFixedUpdate(() => {
+ *         setScore(prev => ({
+ *             values: prev.values.map((v, i) => i === 0 ? v + 1 : v) as [number, number],
+ *         }));
+ *     });
+ * }
+ *
+ * // Reading from another node
+ * function ScoreHud() {
+ *     const [score] = useStore(ScoreStore);
+ *
+ *     useFrameUpdate(() => {
+ *         // score.values always reflects the latest state
+ *     });
+ * }
+ * ```
+ */
+export function useStore<T extends Record<string, unknown>>(
+    definition: StoreDefinition<T>,
+): [T, SetStore<T>] {
+    const { world } = current();
+    const map = getStoreMap(world);
+
+    let instance = map.get(definition._key) as StoreInstance<T> | undefined;
+    if (!instance) {
+        instance = { state: definition._factory() };
+        map.set(definition._key, instance as StoreInstance<unknown>);
+    }
+
+    const state = instance.state;
+
+    const setState: SetStore<T> = (update) => {
+        const partial =
+            typeof update === 'function' ? update(instance!.state) : update;
+        Object.assign(instance!.state, partial);
+    };
+
+    return [state, setState];
+}
+
+/**
+ * Clears all store instances for a world. Called internally by
+ * `world.destroy()` to ensure stores are cleaned up.
+ *
+ * @param world - The world whose stores should be cleared.
+ * @internal
+ */
+export function clearStores(world: World): void {
+    storeMaps.delete(world);
+}

--- a/packages/core/src/domain/world/world.ts
+++ b/packages/core/src/domain/world/world.ts
@@ -27,6 +27,7 @@ import { TypedEvent } from '../../utils/event';
 import type { Service } from '../ecs/base/Service';
 import { defineQuery } from '../ecs/query';
 import type { ComponentCtor } from '../ecs/base/types';
+import { clearStores } from '../fc/stores';
 
 /**
  * Options for the World class.
@@ -313,6 +314,9 @@ export class World implements WorldTimingApi, WorldTransformRegistry {
         // Detach all systems (disposes ticks, removes overlays, etc.)
         for (const s of this.systems.values()) s.detach();
         this.systems.clear();
+
+        // Clear all world-scoped stores
+        clearStores(this);
     }
 
     /**

--- a/packages/core/src/public/fc.ts
+++ b/packages/core/src/public/fc.ts
@@ -26,3 +26,5 @@ export {
 export type { Context } from '../domain/fc/context';
 export { useTimer, useCooldown } from '../domain/fc/timers';
 export type { TimerHandle, CooldownHandle } from '../domain/fc/timers';
+export { defineStore, useStore } from '../domain/fc/stores';
+export type { StoreDefinition, SetStore } from '../domain/fc/stores';


### PR DESCRIPTION
## Summary

- Add `defineStore` and `useStore` to `@pulse-ts/core` for world-scoped shared state with a `[state, setState]` setter pattern
- Stores are lazy-created on first `useStore` call, singleton per world, and automatically cleaned up on `world.destroy()`
- Complementary to existing `useContext` (node-scoped) — `useStore` fills the gap for world-level shared state (scores, game phase, settings)

## Changes

- **New:** `packages/core/src/domain/fc/stores.ts` — `defineStore`, `useStore`, `clearStores` (internal)
- **New:** `packages/core/src/domain/fc/stores.test.ts` — 12 tests covering creation, singleton access, lazy init, partial/updater setState, world isolation, cleanup
- **Modified:** `packages/core/src/domain/world/world.ts` — call `clearStores(this)` in `destroy()`
- **Modified:** `packages/core/src/public/fc.ts` — re-export `defineStore`, `useStore`, `StoreDefinition`, `SetStore`
- **New:** `apps/docs/guides/state-management.md` — state management guide covering useContext vs useStore
- **Modified:** `apps/docs/learn/functional-nodes.md` — added State section referencing stores
- **Modified:** `apps/docs/.vitepress/config.ts` — added State Management guide to sidebar

## Test plan

- [x] All 12 new store tests pass
- [x] All 100 existing core tests pass (no regressions)
- [x] Lint passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)