### PR TITLE
TICKET-107: useWatch hook for value-change detection

### DIFF
--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/done/TICKET-107-use-watch.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/done/TICKET-107-use-watch.md
@@ -2,7 +2,7 @@
 id: TICKET-107
 epic: EPIC-018
 title: useWatch Hook
-status: todo
+status: done
 priority: high
 branch: ticket-107-use-watch
 created: 2026-03-13
@@ -22,15 +22,16 @@ Design doc: `design-docs/approved/005-use-watch.md`
 
 ## Acceptance Criteria
 
-- [ ] `useWatch(selector, callback)` detects value changes via strict equality
-- [ ] Callback receives `(newValue, previousValue)`
-- [ ] Skips initial value (only fires on changes)
-- [ ] Defaults to fixed tick evaluation
-- [ ] Optional `kind` parameter for frame tick evaluation
-- [ ] JSDoc with examples on all public APIs
-- [ ] Unit tests for change detection, skip-initial, tick kinds
-- [ ] Documentation updated
+- [x] `useWatch(selector, callback)` detects value changes via strict equality
+- [x] Callback receives `(newValue, previousValue)`
+- [x] Skips initial value (only fires on changes)
+- [x] Defaults to fixed tick evaluation
+- [x] Optional `kind` parameter for frame tick evaluation
+- [x] JSDoc with examples on all public APIs
+- [x] Unit tests for change detection, skip-initial, tick kinds
+- [x] Documentation updated
 
 ## Notes
 
 - **2026-03-13**: Ticket created from approved design doc #5.
+- **2026-03-13**: Implementation complete. Added `watch.ts` with `useWatch`, 8 passing tests, docs updated.

--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/todo/TICKET-107-use-watch.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/todo/TICKET-107-use-watch.md
@@ -4,6 +4,7 @@ epic: EPIC-018
 title: useWatch Hook
 status: todo
 priority: high
+branch: ticket-107-use-watch
 created: 2026-03-13
 updated: 2026-03-13
 labels:

--- a/apps/docs/learn/functional-nodes.md
+++ b/apps/docs/learn/functional-nodes.md
@@ -31,6 +31,10 @@ function Player() {
 - `useContext` / `useProvideContext` share values through the node tree (parent → descendants).
 - `defineStore` / `useStore` share world-scoped state accessible from any node. See [State Management](/guides/state-management).
 
+## Reactive
+
+- `useWatch(selector, callback)` fires when a derived value changes (strict equality). Defaults to fixed tick. Skips the initial value.
+
 ## Composition
 
 - `useChild(Fn, props)` creates child nodes.

--- a/packages/core/src/domain/fc/watch.test.ts
+++ b/packages/core/src/domain/fc/watch.test.ts
@@ -1,0 +1,200 @@
+import { World } from '../world/world';
+import { useWatch } from './watch';
+
+// Fixed step = 10ms for easy arithmetic
+const FIXED_MS = 10;
+
+function createWorld() {
+    return new World({ fixedStepMs: FIXED_MS });
+}
+
+describe('useWatch', () => {
+    test('fires callback when watched value changes', () => {
+        const w = createWorld();
+        const state = { round: 1 };
+        const calls: Array<[number, number]> = [];
+
+        function Watcher() {
+            useWatch(
+                () => state.round,
+                (val, prev) => calls.push([val, prev]),
+            );
+        }
+
+        w.mount(Watcher);
+        expect(calls).toHaveLength(0); // skip initial
+
+        state.round = 2;
+        w.tick(FIXED_MS);
+        expect(calls).toEqual([[2, 1]]);
+
+        state.round = 5;
+        w.tick(FIXED_MS);
+        expect(calls).toEqual([
+            [2, 1],
+            [5, 2],
+        ]);
+    });
+
+    test('skips initial value — does not fire on mount', () => {
+        const w = createWorld();
+        const state = { value: 42 };
+        let fired = false;
+
+        function Watcher() {
+            useWatch(
+                () => state.value,
+                () => {
+                    fired = true;
+                },
+            );
+        }
+
+        w.mount(Watcher);
+        expect(fired).toBe(false);
+
+        // tick without change
+        w.tick(FIXED_MS);
+        expect(fired).toBe(false);
+    });
+
+    test('does not fire when value stays the same', () => {
+        const w = createWorld();
+        const state = { x: 'hello' };
+        let callCount = 0;
+
+        function Watcher() {
+            useWatch(
+                () => state.x,
+                () => {
+                    callCount++;
+                },
+            );
+        }
+
+        w.mount(Watcher);
+        w.tick(FIXED_MS);
+        w.tick(FIXED_MS);
+        w.tick(FIXED_MS);
+        expect(callCount).toBe(0);
+    });
+
+    test('uses strict equality — different object references trigger callback', () => {
+        const w = createWorld();
+        let obj = { a: 1 };
+        const calls: unknown[] = [];
+
+        function Watcher() {
+            useWatch(
+                () => obj,
+                (val) => calls.push(val),
+            );
+        }
+
+        w.mount(Watcher);
+        w.tick(FIXED_MS);
+        expect(calls).toHaveLength(0); // same reference
+
+        obj = { a: 1 }; // new reference, same shape
+        w.tick(FIXED_MS);
+        expect(calls).toHaveLength(1);
+    });
+
+    test('defaults to fixed tick evaluation', () => {
+        const w = createWorld();
+        const state = { v: 0 };
+        let fixedFired = false;
+
+        function Watcher() {
+            useWatch(
+                () => state.v,
+                () => {
+                    fixedFired = true;
+                },
+            );
+        }
+
+        w.mount(Watcher);
+        state.v = 1;
+        w.tick(FIXED_MS);
+        expect(fixedFired).toBe(true);
+    });
+
+    test('kind: frame evaluates in frame update', () => {
+        const w = createWorld();
+        const state = { v: 0 };
+        let frameFired = false;
+
+        function Watcher() {
+            useWatch(
+                () => state.v,
+                () => {
+                    frameFired = true;
+                },
+                { kind: 'frame' },
+            );
+        }
+
+        w.mount(Watcher);
+        state.v = 1;
+        w.tick(FIXED_MS);
+        expect(frameFired).toBe(true);
+    });
+
+    test('callback receives correct new and previous values across multiple changes', () => {
+        const w = createWorld();
+        const state = { phase: 'menu' as string };
+        const transitions: Array<[string, string]> = [];
+
+        function Watcher() {
+            useWatch(
+                () => state.phase,
+                (val, prev) => transitions.push([val, prev]),
+            );
+        }
+
+        w.mount(Watcher);
+
+        state.phase = 'playing';
+        w.tick(FIXED_MS);
+
+        state.phase = 'gameover';
+        w.tick(FIXED_MS);
+
+        state.phase = 'menu';
+        w.tick(FIXED_MS);
+
+        expect(transitions).toEqual([
+            ['playing', 'menu'],
+            ['gameover', 'playing'],
+            ['menu', 'gameover'],
+        ]);
+    });
+
+    test('cleanup works — watcher stops after node destroy', () => {
+        const w = createWorld();
+        const state = { v: 0 };
+        let callCount = 0;
+
+        function Watcher() {
+            useWatch(
+                () => state.v,
+                () => {
+                    callCount++;
+                },
+            );
+        }
+
+        const node = w.mount(Watcher);
+
+        state.v = 1;
+        w.tick(FIXED_MS);
+        expect(callCount).toBe(1);
+
+        node.destroy();
+
+        state.v = 2;
+        w.tick(FIXED_MS);
+        expect(callCount).toBe(1); // no more calls
+    });
+});

--- a/packages/core/src/domain/fc/watch.ts
+++ b/packages/core/src/domain/fc/watch.ts
@@ -1,0 +1,69 @@
+import { useFixedUpdate, useFrameUpdate } from './hooks';
+
+/**
+ * Watches a derived value each tick and invokes a callback when the value
+ * changes (strict equality). Skips the initial value — the callback only
+ * fires on subsequent changes.
+ *
+ * By default, evaluation happens in the fixed update loop. Pass
+ * `{ kind: 'frame' }` to evaluate in the frame update loop instead.
+ *
+ * Uses `===` for comparison. For object/array watching, the selector should
+ * return a primitive derived value (e.g., `() => state.round`, not
+ * `() => state`).
+ *
+ * @typeParam T - The type of the watched value.
+ * @param selector - A function that returns the value to watch.
+ * @param callback - Called with `(newValue, previousValue)` when the value changes.
+ * @param options - Optional configuration.
+ * @param options.kind - Tick phase: `'fixed'` (default) or `'frame'`.
+ *
+ * @example
+ * ```ts
+ * import { useWatch } from '@pulse-ts/core';
+ *
+ * // Round reset detection
+ * useWatch(() => gameState.round, () => {
+ *     transform.localPosition.set(...spawn);
+ *     body.setLinearVelocity(0, 0, 0);
+ * });
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Phase transition with previous value
+ * useWatch(() => gameState.phase, (phase, prev) => {
+ *     if (phase === 'playing' && prev !== 'playing') {
+ *         dashCD.trigger();
+ *     }
+ * });
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Frame-rate evaluation
+ * useWatch(() => animState.current, (state) => {
+ *     // respond to animation state change
+ * }, { kind: 'frame' });
+ * ```
+ */
+export function useWatch<T>(
+    selector: () => T,
+    callback: (value: T, prev: T) => void,
+    options?: { kind?: 'fixed' | 'frame' },
+): void {
+    let prev = selector();
+
+    const tick = () => {
+        const next = selector();
+        if (next !== prev) {
+            const old = prev;
+            prev = next;
+            callback(next, old);
+        }
+    };
+
+    const useUpdate =
+        options?.kind === 'frame' ? useFrameUpdate : useFixedUpdate;
+    useUpdate(tick);
+}

--- a/packages/core/src/public/fc.ts
+++ b/packages/core/src/public/fc.ts
@@ -28,3 +28,4 @@ export { useTimer, useCooldown } from '../domain/fc/timers';
 export type { TimerHandle, CooldownHandle } from '../domain/fc/timers';
 export { defineStore, useStore } from '../domain/fc/stores';
 export type { StoreDefinition, SetStore } from '../domain/fc/stores';
+export { useWatch } from '../domain/fc/watch';


### PR DESCRIPTION
## Summary

- Add `useWatch(selector, callback, options?)` to `@pulse-ts/core` for declarative value-change detection
- Uses strict equality, skips the initial value, defaults to fixed tick evaluation
- Optional `{ kind: 'frame' }` for frame-rate evaluation
- Eliminates the common "store previous value, compare each tick" boilerplate pattern

## Changes

- **New:** `packages/core/src/domain/fc/watch.ts` — `useWatch` implementation
- **New:** `packages/core/src/domain/fc/watch.test.ts` — 8 tests covering change detection, skip-initial, strict equality, tick kinds, cleanup
- **Modified:** `packages/core/src/public/fc.ts` — re-export `useWatch`
- **Modified:** `apps/docs/learn/functional-nodes.md` — added Reactive section

## Test plan

- [x] All 8 new watch tests pass
- [x] All 108 tests pass (no regressions)
- [x] Lint passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)