### PR TITLE
TICKET-111: Add 'when' guard option to update hooks

### DIFF
--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/done/TICKET-111-update-hook-when-guard.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/done/TICKET-111-update-hook-when-guard.md
@@ -2,11 +2,11 @@
 id: TICKET-111
 epic: EPIC-018
 title: Update Hook 'when' Guard
-status: todo
+status: done
 priority: medium
 branch: ticket-111-update-hook-when-guard
 created: 2026-03-13
-updated: 2026-03-13
+updated: 2026-03-14
 labels:
   - core
   - dx
@@ -22,14 +22,15 @@ Design doc: `design-docs/approved/022-update-hook-when-guard.md`
 
 ## Acceptance Criteria
 
-- [ ] `useFixedUpdate(cb, { when: () => boolean })` — callback skipped when guard is false
-- [ ] `useFrameUpdate(cb, { when: () => boolean })` — same behavior
-- [ ] Guard is evaluated each tick before the callback
-- [ ] Backward compatible — `when` is optional, existing usages unchanged
-- [ ] JSDoc with examples
-- [ ] Unit tests for guard behavior
-- [ ] Documentation updated
+- [x] `useFixedUpdate(cb, { when: () => boolean })` — callback skipped when guard is false
+- [x] `useFrameUpdate(cb, { when: () => boolean })` — same behavior
+- [x] Guard is evaluated each tick before the callback
+- [x] Backward compatible — `when` is optional, existing usages unchanged
+- [x] JSDoc with examples
+- [x] Unit tests for guard behavior
+- [x] Documentation updated
 
 ## Notes
 
 - **2026-03-13**: Ticket created from approved design doc #22.
+- **2026-03-14**: Implementation complete. Added `when` to all 6 update hook variants via shared `reg` function. 4 new tests.

--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/todo/TICKET-111-update-hook-when-guard.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/todo/TICKET-111-update-hook-when-guard.md
@@ -4,6 +4,7 @@ epic: EPIC-018
 title: Update Hook 'when' Guard
 status: todo
 priority: medium
+branch: ticket-111-update-hook-when-guard
 created: 2026-03-13
 updated: 2026-03-13
 labels:

--- a/packages/core/src/domain/fc/hooks.test.ts
+++ b/packages/core/src/domain/fc/hooks.test.ts
@@ -1,7 +1,15 @@
 import { Transform } from '../components/spatial/Transform';
 import { Service } from '../ecs/base/Service';
 import { World } from '../world/world';
-import { useChild, useComponent, useInit, useService, useState } from './hooks';
+import {
+    useChild,
+    useComponent,
+    useFixedUpdate,
+    useFrameUpdate,
+    useInit,
+    useService,
+    useState,
+} from './hooks';
 
 class DemoService extends Service {
     n = 42;
@@ -78,5 +86,95 @@ describe('FC hooks', () => {
         }
         w.mount(Reader);
         expect(value).toBe(42);
+    });
+
+    describe('when guard', () => {
+        const FIXED_MS = 10;
+
+        function createWorld() {
+            return new World({ fixedStepMs: FIXED_MS });
+        }
+
+        test('useFixedUpdate skips callback when guard returns false', () => {
+            const w = createWorld();
+            const state = { active: false };
+            let callCount = 0;
+
+            w.mount(() => {
+                useFixedUpdate(
+                    () => {
+                        callCount++;
+                    },
+                    { when: () => state.active },
+                );
+            });
+
+            w.tick(FIXED_MS);
+            expect(callCount).toBe(0);
+
+            state.active = true;
+            w.tick(FIXED_MS);
+            expect(callCount).toBe(1);
+
+            state.active = false;
+            w.tick(FIXED_MS);
+            expect(callCount).toBe(1); // still 1
+        });
+
+        test('useFrameUpdate skips callback when guard returns false', () => {
+            const w = createWorld();
+            const state = { active: false };
+            let callCount = 0;
+
+            w.mount(() => {
+                useFrameUpdate(
+                    () => {
+                        callCount++;
+                    },
+                    { when: () => state.active },
+                );
+            });
+
+            w.tick(FIXED_MS);
+            expect(callCount).toBe(0);
+
+            state.active = true;
+            w.tick(FIXED_MS);
+            expect(callCount).toBe(1);
+        });
+
+        test('guard is evaluated each tick', () => {
+            const w = createWorld();
+            let guardCalls = 0;
+
+            w.mount(() => {
+                useFixedUpdate(() => {}, {
+                    when: () => {
+                        guardCalls++;
+                        return false;
+                    },
+                });
+            });
+
+            w.tick(FIXED_MS);
+            w.tick(FIXED_MS);
+            w.tick(FIXED_MS);
+            expect(guardCalls).toBe(3);
+        });
+
+        test('backward compatible — no when option means always runs', () => {
+            const w = createWorld();
+            let callCount = 0;
+
+            w.mount(() => {
+                useFixedUpdate(() => {
+                    callCount++;
+                });
+            });
+
+            w.tick(FIXED_MS);
+            w.tick(FIXED_MS);
+            expect(callCount).toBe(2);
+        });
     });
 });

--- a/packages/core/src/domain/fc/hooks.ts
+++ b/packages/core/src/domain/fc/hooks.ts
@@ -106,8 +106,12 @@ export function useComponent<T extends Component>(Component: new () => T): T {
 
 /**
  * Options for scheduling a tick.
+ *
+ * @param order - Lower `order` runs earlier within the same phase (default 0).
+ * @param when - Optional guard function evaluated each tick. When provided,
+ *   the callback is only invoked if the guard returns `true`.
  */
-type TickOpts = { order?: number };
+type TickOpts = { order?: number; when?: () => boolean };
 
 /**
  * Internal helper to register a tick with automatic cleanup.
@@ -117,13 +121,19 @@ function reg(
     phase: 'early' | 'update' | 'late',
     fn: (dt: number) => void,
     order = 0,
+    when?: () => boolean,
 ) {
     const { node, world } = current();
     if (!world)
         throw new Error(
             'Node must be added to a World before registering ticks.',
         );
-    const reg = world.registerTick(node, kind, phase, fn, order);
+    const wrapped = when
+        ? (dt: number) => {
+              if (when()) fn(dt);
+          }
+        : fn;
+    const reg = world.registerTick(node, kind, phase, wrapped, order);
     const dispose = () => reg.dispose();
     current().disposers.push(dispose);
     useDestroy(dispose);
@@ -139,7 +149,7 @@ function reg(
  * @param opts Optional scheduling options (lower `order` runs earlier; default 0).
  */
 export function useFixedEarly(fn: (dt: number) => void, opts: TickOpts = {}) {
-    reg('fixed', 'early', fn, opts.order ?? 0);
+    reg('fixed', 'early', fn, opts.order ?? 0, opts.when);
 }
 
 /**
@@ -149,10 +159,21 @@ export function useFixedEarly(fn: (dt: number) => void, opts: TickOpts = {}) {
  * - Use for core simulation/physics.
  *
  * @param fn Callback invoked with `dt` in seconds for the fixed step.
- * @param opts Optional scheduling options (lower `order` runs earlier; default 0).
+ * @param opts Optional scheduling options.
+ * @param opts.order - Lower values run earlier within the same phase (default 0).
+ * @param opts.when - Guard function evaluated each tick. When provided, the
+ *   callback is only invoked if the guard returns `true`.
+ *
+ * @example
+ * ```ts
+ * // Only run movement logic during the 'playing' phase
+ * useFixedUpdate((dt) => {
+ *     body.applyImpulse(x * MOVE_IMPULSE, 0, -y * MOVE_IMPULSE);
+ * }, { when: () => gameState.phase === 'playing' });
+ * ```
  */
 export function useFixedUpdate(fn: (dt: number) => void, opts: TickOpts = {}) {
-    reg('fixed', 'update', fn, opts.order ?? 0);
+    reg('fixed', 'update', fn, opts.order ?? 0, opts.when);
 }
 
 /**
@@ -165,7 +186,7 @@ export function useFixedUpdate(fn: (dt: number) => void, opts: TickOpts = {}) {
  * @param opts Optional scheduling options (lower `order` runs earlier; default 0).
  */
 export function useFixedLate(fn: (dt: number) => void, opts: TickOpts = {}) {
-    reg('fixed', 'late', fn, opts.order ?? 0);
+    reg('fixed', 'late', fn, opts.order ?? 0, opts.when);
 }
 
 /**
@@ -178,7 +199,7 @@ export function useFixedLate(fn: (dt: number) => void, opts: TickOpts = {}) {
  * @param opts Optional scheduling options (lower `order` runs earlier; default 0).
  */
 export function useFrameEarly(fn: (dt: number) => void, opts: TickOpts = {}) {
-    reg('frame', 'early', fn, opts.order ?? 0);
+    reg('frame', 'early', fn, opts.order ?? 0, opts.when);
 }
 
 /**
@@ -188,7 +209,10 @@ export function useFrameEarly(fn: (dt: number) => void, opts: TickOpts = {}) {
  * - Use for animation and per-frame logic.
  *
  * @param fn Callback invoked with `dt` in seconds for the variable frame step.
- * @param opts Optional scheduling options (lower `order` runs earlier; default 0).
+ * @param opts Optional scheduling options.
+ * @param opts.order - Lower values run earlier within the same phase (default 0).
+ * @param opts.when - Guard function evaluated each tick. When provided, the
+ *   callback is only invoked if the guard returns `true`.
  *
  * @example
  * ```ts
@@ -200,9 +224,17 @@ export function useFrameEarly(fn: (dt: number) => void, opts: TickOpts = {}) {
  * }
  * new World().mount(Rotator);
  * ```
+ *
+ * @example
+ * ```ts
+ * // Only animate during certain phases
+ * useFrameUpdate((dt) => {
+ *     // camera logic...
+ * }, { when: () => ['playing', 'countdown'].includes(gameState.phase) });
+ * ```
  */
 export function useFrameUpdate(fn: (dt: number) => void, opts: TickOpts = {}) {
-    reg('frame', 'update', fn, opts.order ?? 0);
+    reg('frame', 'update', fn, opts.order ?? 0, opts.when);
 }
 
 /**
@@ -215,7 +247,7 @@ export function useFrameUpdate(fn: (dt: number) => void, opts: TickOpts = {}) {
  * @param opts Optional scheduling options (lower `order` runs earlier; default 0).
  */
 export function useFrameLate(fn: (dt: number) => void, opts: TickOpts = {}) {
-    reg('frame', 'late', fn, opts.order ?? 0);
+    reg('frame', 'late', fn, opts.order ?? 0, opts.when);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add optional `when` guard to all 6 update hooks (`useFixedUpdate`, `useFrameUpdate`, and their Early/Late variants)
- When provided, callback is only invoked if the guard function returns `true`
- Backward compatible — `when` is optional, existing usages unchanged
- Eliminates the ubiquitous `if (gameState.phase !== 'playing') return;` boilerplate

## Changes

- **Modified:** `packages/core/src/domain/fc/hooks.ts` — added `when` to `TickOpts` type and `reg()` helper
- **Modified:** `packages/core/src/domain/fc/hooks.test.ts` — 4 new tests for guard behavior

## Test plan

- [x] All 4 new guard tests pass
- [x] All 151 tests pass (no regressions)
- [x] Lint passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)