### PR TITLE
TICKET-110: Color Utility

### DIFF
--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/done/TICKET-110-color-utility.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/done/TICKET-110-color-utility.md
@@ -2,7 +2,7 @@
 id: TICKET-110
 epic: EPIC-018
 title: Color Utility
-status: in-progress
+status: done
 priority: low
 branch: ticket-110-color-utility
 created: 2026-03-13
@@ -22,17 +22,18 @@ Design doc: `design-docs/approved/021-color-utility.md`
 
 ## Acceptance Criteria
 
-- [ ] `color(0x48c9b0)` returns an object with format accessors
-- [ ] `.hex` returns CSS hex string (`'#48c9b0'`)
-- [ ] `.num` returns original number
-- [ ] `.rgb` returns CSS rgb string
-- [ ] `.rgba(alpha)` returns CSS rgba string
-- [ ] `.r`, `.g`, `.b` return 0–255 channel values
-- [ ] JSDoc with examples
-- [ ] Unit tests for all format conversions
-- [ ] Documentation updated
+- [x] `color(0x48c9b0)` returns an object with format accessors
+- [x] `.hex` returns CSS hex string (`'#48c9b0'`)
+- [x] `.num` returns original number
+- [x] `.rgb` returns CSS rgb string
+- [x] `.rgba(alpha)` returns CSS rgba string
+- [x] `.r`, `.g`, `.b` return 0–255 channel values
+- [x] JSDoc with examples
+- [x] Unit tests for all format conversions
+- [x] Documentation updated
 
 ## Notes
 
 - **2026-03-13**: Ticket created from approved design doc #21.
 - **2026-03-14**: Starting implementation.
+- **2026-03-14**: Implementation complete. 9 tests covering all formats plus edge cases (black, white, leading zeros, pure channels). Exported `color` function and `Color` type from public math API.

--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/in-progress/TICKET-110-color-utility.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/in-progress/TICKET-110-color-utility.md
@@ -2,10 +2,11 @@
 id: TICKET-110
 epic: EPIC-018
 title: Color Utility
-status: todo
+status: in-progress
 priority: low
+branch: ticket-110-color-utility
 created: 2026-03-13
-updated: 2026-03-13
+updated: 2026-03-14
 labels:
   - core
   - utility
@@ -34,3 +35,4 @@ Design doc: `design-docs/approved/021-color-utility.md`
 ## Notes
 
 - **2026-03-13**: Ticket created from approved design doc #21.
+- **2026-03-14**: Starting implementation.

--- a/packages/core/src/public/math.ts
+++ b/packages/core/src/public/math.ts
@@ -8,3 +8,5 @@ export {
     clamp,
     remap,
 } from '../utils/math/interpolation';
+export { color } from '../utils/math/color';
+export type { Color } from '../utils/math/color';

--- a/packages/core/src/utils/math/color.test.ts
+++ b/packages/core/src/utils/math/color.test.ts
@@ -1,0 +1,63 @@
+import { color } from './color';
+
+describe('color', () => {
+    const c = color(0x48c9b0);
+
+    test('.num returns the original hex number', () => {
+        expect(c.num).toBe(0x48c9b0);
+    });
+
+    test('.hex returns a CSS hex string', () => {
+        expect(c.hex).toBe('#48c9b0');
+    });
+
+    test('.rgb returns a CSS rgb string', () => {
+        expect(c.rgb).toBe('rgb(72, 201, 176)');
+    });
+
+    test('.rgba(alpha) returns a CSS rgba string', () => {
+        expect(c.rgba(0.5)).toBe('rgba(72, 201, 176, 0.5)');
+        expect(c.rgba(1)).toBe('rgba(72, 201, 176, 1)');
+        expect(c.rgba(0)).toBe('rgba(72, 201, 176, 0)');
+    });
+
+    test('.r, .g, .b return 0–255 channel values', () => {
+        expect(c.r).toBe(72);
+        expect(c.g).toBe(201);
+        expect(c.b).toBe(176);
+    });
+
+    test('handles black (0x000000)', () => {
+        const black = color(0x000000);
+        expect(black.hex).toBe('#000000');
+        expect(black.rgb).toBe('rgb(0, 0, 0)');
+        expect(black.r).toBe(0);
+        expect(black.g).toBe(0);
+        expect(black.b).toBe(0);
+    });
+
+    test('handles white (0xffffff)', () => {
+        const white = color(0xffffff);
+        expect(white.hex).toBe('#ffffff');
+        expect(white.rgb).toBe('rgb(255, 255, 255)');
+        expect(white.r).toBe(255);
+        expect(white.g).toBe(255);
+        expect(white.b).toBe(255);
+    });
+
+    test('handles colors with leading zeros (0x00ff00)', () => {
+        const green = color(0x00ff00);
+        expect(green.hex).toBe('#00ff00');
+        expect(green.r).toBe(0);
+        expect(green.g).toBe(255);
+        expect(green.b).toBe(0);
+    });
+
+    test('handles pure red (0xff0000)', () => {
+        const red = color(0xff0000);
+        expect(red.hex).toBe('#ff0000');
+        expect(red.r).toBe(255);
+        expect(red.g).toBe(0);
+        expect(red.b).toBe(0);
+    });
+});

--- a/packages/core/src/utils/math/color.ts
+++ b/packages/core/src/utils/math/color.ts
@@ -1,0 +1,83 @@
+/**
+ * A color value with automatic format conversion.
+ *
+ * Created via {@link color}. Provides access to the same color in
+ * multiple common formats: hex number, CSS hex string, CSS rgb/rgba
+ * strings, and individual channel values.
+ */
+export interface Color {
+    /** Original hex number (e.g., `0x48c9b0`). */
+    readonly num: number;
+    /** CSS hex string (e.g., `'#48c9b0'`). */
+    readonly hex: string;
+    /** CSS rgb string (e.g., `'rgb(72, 201, 176)'`). */
+    readonly rgb: string;
+    /** Red component (0–255). */
+    readonly r: number;
+    /** Green component (0–255). */
+    readonly g: number;
+    /** Blue component (0–255). */
+    readonly b: number;
+    /**
+     * CSS rgba string with the specified alpha.
+     *
+     * @param alpha - Opacity value (0–1).
+     * @returns CSS rgba string (e.g., `'rgba(72, 201, 176, 0.5)'`).
+     */
+    rgba(alpha: number): string;
+}
+
+/**
+ * Create a color from a hex number with automatic format conversion.
+ *
+ * Takes a hex number (the format used by Three.js) and returns a
+ * {@link Color} object that provides all common format conversions:
+ * CSS hex string, rgb/rgba strings, and individual channel values.
+ *
+ * @param hex - Color as a hex number (e.g., `0x48c9b0`).
+ * @returns A {@link Color} object with all common format conversions.
+ *
+ * @example
+ * ```ts
+ * import { color } from '@pulse-ts/core';
+ *
+ * const p1 = color(0x48c9b0);
+ * p1.hex;       // '#48c9b0'
+ * p1.num;       // 0x48c9b0
+ * p1.rgb;       // 'rgb(72, 201, 176)'
+ * p1.rgba(0.5); // 'rgba(72, 201, 176, 0.5)'
+ * p1.r;         // 72
+ * p1.g;         // 201
+ * p1.b;         // 176
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Centralize colors in a constants file
+ * export const PLAYER_COLORS = [color(0x48c9b0), color(0xe74c3c)];
+ *
+ * // Use anywhere — pick the format you need
+ * const meshColor = PLAYER_COLORS[playerId].num;       // Three.js
+ * const cssColor = PLAYER_COLORS[playerId].hex;        // DOM styling
+ * const fadeColor = PLAYER_COLORS[playerId].rgba(0.5); // Overlay flash
+ * ```
+ */
+export function color(hex: number): Color {
+    const r = (hex >> 16) & 0xff;
+    const g = (hex >> 8) & 0xff;
+    const b = hex & 0xff;
+    const hexStr = `#${hex.toString(16).padStart(6, '0')}`;
+    const rgbStr = `rgb(${r}, ${g}, ${b})`;
+
+    return {
+        num: hex,
+        hex: hexStr,
+        rgb: rgbStr,
+        r,
+        g,
+        b,
+        rgba(alpha: number): string {
+            return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+        },
+    };
+}


### PR DESCRIPTION
## Summary
- Add `color(hex)` utility that converts a hex number to all common color formats
- Returns object with `.hex`, `.num`, `.rgb`, `.rgba(alpha)`, `.r`, `.g`, `.b` accessors
- Exported from `@pulse-ts/core` public math API alongside lerp, clamp, etc.

## Test plan
- [x] 9 unit tests covering all format conversions and edge cases (black, white, leading zeros, pure channels)
- [x] Lint passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)