### PR TITLE
TICKET-113: Conditional Child Mounting (useConditionalChild)

### DIFF
--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/done/TICKET-113-conditional-child-mounting.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/done/TICKET-113-conditional-child-mounting.md
@@ -2,7 +2,7 @@
 id: TICKET-113
 epic: EPIC-018
 title: Conditional Child Mounting (useConditionalChild)
-status: in-progress
+status: done
 priority: medium
 branch: ticket-113-conditional-child-mounting
 created: 2026-03-13
@@ -22,16 +22,17 @@ Design doc: `design-docs/approved/044-conditional-child-mounting.md`
 
 ## Acceptance Criteria
 
-- [ ] `useConditionalChild(guard, fc, props)` mounts child when guard becomes true
-- [ ] Child is destroyed when guard becomes false
-- [ ] Guard is evaluated each fixed tick
-- [ ] Child is cleaned up when parent node is destroyed
-- [ ] Props are passed to the FC on mount
-- [ ] JSDoc with examples
-- [ ] Unit tests for mount/unmount transitions, cleanup
-- [ ] Documentation updated
+- [x] `useConditionalChild(guard, fc, props)` mounts child when guard becomes true
+- [x] Child is destroyed when guard becomes false
+- [x] Guard is evaluated each fixed tick
+- [x] Child is cleaned up when parent node is destroyed
+- [x] Props are passed to the FC on mount
+- [x] JSDoc with examples
+- [x] Unit tests for mount/unmount transitions, cleanup
+- [x] Documentation updated
 
 ## Notes
 
 - **2026-03-13**: Ticket created from approved design doc #44.
 - **2026-03-14**: Starting implementation.
+- **2026-03-14**: Implementation complete. 7 new tests covering mount/unmount transitions, re-mounting, parent cleanup, props passing, guard evaluation, and idempotency. Exported from public FC API.

--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/in-progress/TICKET-113-conditional-child-mounting.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-018-core-engine-dx-pass/in-progress/TICKET-113-conditional-child-mounting.md
@@ -2,10 +2,11 @@
 id: TICKET-113
 epic: EPIC-018
 title: Conditional Child Mounting (useConditionalChild)
-status: todo
+status: in-progress
 priority: medium
+branch: ticket-113-conditional-child-mounting
 created: 2026-03-13
-updated: 2026-03-13
+updated: 2026-03-14
 labels:
   - core
   - dx
@@ -33,3 +34,4 @@ Design doc: `design-docs/approved/044-conditional-child-mounting.md`
 ## Notes
 
 - **2026-03-13**: Ticket created from approved design doc #44.
+- **2026-03-14**: Starting implementation.

--- a/packages/core/src/domain/fc/hooks.test.ts
+++ b/packages/core/src/domain/fc/hooks.test.ts
@@ -3,7 +3,9 @@ import { Service } from '../ecs/base/Service';
 import { World } from '../world/world';
 import {
     useChild,
+    useConditionalChild,
     useComponent,
+    useDestroy,
     useFixedUpdate,
     useFrameUpdate,
     useInit,
@@ -175,6 +177,173 @@ describe('FC hooks', () => {
             w.tick(FIXED_MS);
             w.tick(FIXED_MS);
             expect(callCount).toBe(2);
+        });
+    });
+
+    describe('useConditionalChild', () => {
+        const FIXED_MS = 10;
+
+        function createWorld() {
+            return new World({ fixedStepMs: FIXED_MS });
+        }
+
+        test('mounts child when guard becomes true', () => {
+            const w = createWorld();
+            const state = { active: false };
+            let childInits = 0;
+
+            function Child() {
+                useInit(() => {
+                    childInits++;
+                });
+            }
+
+            const parent = w.mount(() => {
+                useConditionalChild(() => state.active, Child);
+            });
+
+            // Guard is false — no child yet
+            w.tick(FIXED_MS);
+            expect(parent.children.length).toBe(0);
+            expect(childInits).toBe(0);
+
+            // Guard becomes true — child mounted
+            state.active = true;
+            w.tick(FIXED_MS);
+            expect(parent.children.length).toBe(1);
+            expect(childInits).toBe(1);
+        });
+
+        test('destroys child when guard becomes false', () => {
+            const w = createWorld();
+            const state = { active: true };
+            let childDestroys = 0;
+
+            function Child() {
+                useDestroy(() => {
+                    childDestroys++;
+                });
+            }
+
+            const parent = w.mount(() => {
+                useConditionalChild(() => state.active, Child);
+            });
+
+            // Mount child
+            w.tick(FIXED_MS);
+            expect(parent.children.length).toBe(1);
+
+            // Guard becomes false — child destroyed
+            state.active = false;
+            w.tick(FIXED_MS);
+            expect(parent.children.length).toBe(0);
+            expect(childDestroys).toBe(1);
+        });
+
+        test('re-mounts child after guard cycles false → true again', () => {
+            const w = createWorld();
+            const state = { active: true };
+            let childInits = 0;
+
+            function Child() {
+                useInit(() => {
+                    childInits++;
+                });
+            }
+
+            const parent = w.mount(() => {
+                useConditionalChild(() => state.active, Child);
+            });
+
+            w.tick(FIXED_MS); // mount
+            expect(childInits).toBe(1);
+
+            state.active = false;
+            w.tick(FIXED_MS); // destroy
+            expect(parent.children.length).toBe(0);
+
+            state.active = true;
+            w.tick(FIXED_MS); // re-mount
+            expect(parent.children.length).toBe(1);
+            expect(childInits).toBe(2);
+        });
+
+        test('child is cleaned up when parent is destroyed', () => {
+            const w = createWorld();
+            const state = { active: true };
+            let childDestroys = 0;
+
+            function Child() {
+                useDestroy(() => {
+                    childDestroys++;
+                });
+            }
+
+            const parent = w.mount(() => {
+                useConditionalChild(() => state.active, Child);
+            });
+
+            w.tick(FIXED_MS); // mount child
+            expect(parent.children.length).toBe(1);
+
+            parent.destroy();
+            expect(childDestroys).toBe(1);
+        });
+
+        test('passes props to child FC', () => {
+            const w = createWorld();
+            let receivedProps: { value: number } | null = null;
+
+            function Child(props: { value: number }) {
+                receivedProps = { ...props };
+            }
+
+            w.mount(() => {
+                useConditionalChild(() => true, Child, { value: 42 });
+            });
+
+            w.tick(FIXED_MS);
+            expect(receivedProps).toEqual({ value: 42 });
+        });
+
+        test('guard is evaluated each fixed tick', () => {
+            const w = createWorld();
+            let guardCalls = 0;
+
+            w.mount(() => {
+                useConditionalChild(
+                    () => {
+                        guardCalls++;
+                        return false;
+                    },
+                    () => {},
+                );
+            });
+
+            w.tick(FIXED_MS);
+            w.tick(FIXED_MS);
+            w.tick(FIXED_MS);
+            expect(guardCalls).toBe(3);
+        });
+
+        test('does not remount when guard stays true', () => {
+            const w = createWorld();
+            let childInits = 0;
+
+            function Child() {
+                useInit(() => {
+                    childInits++;
+                });
+            }
+
+            w.mount(() => {
+                useConditionalChild(() => true, Child);
+            });
+
+            w.tick(FIXED_MS);
+            w.tick(FIXED_MS);
+            w.tick(FIXED_MS);
+            expect(childInits).toBe(1);
         });
     });
 });

--- a/packages/core/src/domain/fc/hooks.ts
+++ b/packages/core/src/domain/fc/hooks.ts
@@ -276,6 +276,73 @@ export function useChild<P>(fc: (props: Readonly<P>) => void, props?: P): Node {
 }
 
 /**
+ * Conditionally mount/unmount a child node based on a reactive guard.
+ *
+ * The guard is evaluated each fixed tick. When it transitions:
+ * - `false → true`: the child FC is mounted as a child of the current node.
+ * - `true → false`: the child node is destroyed.
+ *
+ * The child is also destroyed automatically when the parent node is destroyed.
+ *
+ * @param guard - Evaluated each tick to determine mount state.
+ * @param fc - The function component to mount.
+ * @param props - Props passed to the FC on mount.
+ *
+ * @example
+ * ```ts
+ * import { useConditionalChild } from '@pulse-ts/core';
+ *
+ * // Mount overlay only when disconnected
+ * useConditionalChild(
+ *     () => !isConnected,
+ *     DisconnectOverlayNode,
+ *     { isHost: props.isHost },
+ * );
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Dynamic enemy spawning — reactive to game state
+ * useConditionalChild(
+ *     () => gameState.phase === 'playing' && waveActive,
+ *     EnemyNode,
+ *     { difficulty: currentWave },
+ * );
+ * ```
+ */
+export function useConditionalChild<P>(
+    guard: () => boolean,
+    fc: (props: Readonly<P>) => void,
+    props?: P,
+): void {
+    const { world, node } = current();
+    let childNode: Node | null = null;
+    let mounted = false;
+
+    useFixedUpdate(() => {
+        const shouldMount = guard();
+        if (shouldMount && !mounted) {
+            childNode = world.mount(fc, props, { parent: node });
+            mounted = true;
+        } else if (!shouldMount && mounted) {
+            childNode?.destroy();
+            childNode = null;
+            mounted = false;
+        }
+    });
+
+    useDestroy(() => {
+        // Child is already destroyed recursively by Node.destroy() when the
+        // parent is destroyed, so only clean up if still in the world.
+        if (mounted && childNode?.parent) {
+            childNode.destroy();
+        }
+        childNode = null;
+        mounted = false;
+    });
+}
+
+/**
  * Persistent state hook for Pulse FCs (no re-render model).
  *
  * - Values are stored in the node's `State` component (JSON-serializable recommended).

--- a/packages/core/src/public/fc.ts
+++ b/packages/core/src/public/fc.ts
@@ -13,6 +13,7 @@ export {
     useFrameUpdate,
     useFrameLate,
     useChild,
+    useConditionalChild,
     useState,
     useStableId,
     useService,


### PR DESCRIPTION
## Summary
- Add `useConditionalChild(guard, fc, props)` hook that reactively mounts/unmounts child nodes
- Guard evaluated each fixed tick; child mounts on false→true, destroys on true→false
- Automatic cleanup when parent node is destroyed
- Same signature as `useChild` with an added guard parameter

## Test plan
- [x] 7 new tests: mount/unmount transitions, re-mounting, parent cleanup, props passing, guard evaluation, idempotency
- [x] All 15 hooks tests pass
- [x] Lint passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)