### PR TITLE
TICKET-115: useScreenProjection Hook

### DIFF
--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-019-three-js-rendering-dx-pass/done/TICKET-115-use-screen-projection.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-019-three-js-rendering-dx-pass/done/TICKET-115-use-screen-projection.md
@@ -2,7 +2,7 @@
 id: TICKET-115
 epic: EPIC-019
 title: useScreenProjection Hook
-status: todo
+status: done
 priority: medium
 branch: ticket-115-use-screen-projection
 created: 2026-03-13
@@ -22,14 +22,16 @@ Design doc: `design-docs/approved/007-use-screen-projection.md`
 
 ## Acceptance Criteria
 
-- [ ] `useScreenProjection()` returns a `project(position)` function
-- [ ] Returns `{ x, y, depth, visible }` in screen pixels
-- [ ] Reuses internal Vector3 (no allocations per call)
-- [ ] Works with current camera and renderer dimensions
-- [ ] JSDoc with examples
-- [ ] Unit tests
-- [ ] Documentation updated
+- [x] `useScreenProjection()` returns a `project(position)` function
+- [x] Returns `{ x, y, depth, visible }` in screen pixels
+- [x] Reuses internal Vector3 (no allocations per call)
+- [x] Works with current camera and renderer dimensions
+- [x] JSDoc with examples
+- [x] Unit tests
+- [x] Documentation updated
 
 ## Notes
 
 - **2026-03-13**: Ticket created from approved design doc #7.
+- **2026-03-14**: Starting implementation.
+- **2026-03-14**: Implementation complete. Hook, tests (11 passing), JSDoc, and docs added.

--- a/.claude/ticket-tracker/swimlanes/todo/EPIC-019-three-js-rendering-dx-pass/todo/TICKET-115-use-screen-projection.md
+++ b/.claude/ticket-tracker/swimlanes/todo/EPIC-019-three-js-rendering-dx-pass/todo/TICKET-115-use-screen-projection.md
@@ -4,8 +4,9 @@ epic: EPIC-019
 title: useScreenProjection Hook
 status: todo
 priority: medium
+branch: ticket-115-use-screen-projection
 created: 2026-03-13
-updated: 2026-03-13
+updated: 2026-03-14
 labels:
   - three
   - dx

--- a/apps/docs/api/three/src/README.md
+++ b/apps/docs/api/three/src/README.md
@@ -16,12 +16,15 @@
 
 ## Interfaces
 
+- [ScreenPoint](interfaces/ScreenPoint.md)
 - [StatsOverlayOptions](interfaces/StatsOverlayOptions.md)
 - [ThreeOptions](interfaces/ThreeOptions.md)
+- [WorldPoint](interfaces/WorldPoint.md)
 
 ## Functions
 
 - [installThree](functions/installThree.md)
 - [useObject3D](functions/useObject3D.md)
+- [useScreenProjection](functions/useScreenProjection.md)
 - [useThreeContext](functions/useThreeContext.md)
 - [useThreeRoot](functions/useThreeRoot.md)

--- a/apps/docs/api/three/src/functions/useScreenProjection.md
+++ b/apps/docs/api/three/src/functions/useScreenProjection.md
@@ -1,0 +1,57 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [three/src](../README.md) / useScreenProjection
+
+# Function: useScreenProjection()
+
+> **useScreenProjection**(): (`position`: [`WorldPoint`](../interfaces/WorldPoint.md)) => [`ScreenPoint`](../interfaces/ScreenPoint.md)
+
+Defined in: packages/three/src/public/useScreenProjection.ts
+
+Returns a projection function that converts world-space positions to
+screen-space pixel coordinates.
+
+Uses the active Three.js camera and renderer dimensions. Reuses an
+internal `Vector3` so no allocations occur per call. The returned
+`ScreenPoint` object is also reused — callers should consume values
+immediately rather than storing across frames.
+
+## Returns
+
+A function that projects a `WorldPoint` to a `ScreenPoint`.
+
+## Examples
+
+```ts
+import { useScreenProjection } from '@pulse-ts/three';
+import { useFrameUpdate } from '@pulse-ts/core';
+
+function HealthBarNode() {
+  const project = useScreenProjection();
+
+  useFrameUpdate(() => {
+    const { x, y, visible } = project(root.position);
+    if (visible) {
+      indicator.style.left = `${x}px`;
+      indicator.style.top = `${y}px`;
+    }
+  });
+}
+```
+
+```ts
+// Computing a screen-space radius from a world-space offset
+const project = useScreenProjection();
+
+useFrameUpdate(() => {
+  const center = project(root.position);
+  const edge = project({
+    x: root.position.x + RADIUS,
+    y: root.position.y,
+    z: root.position.z,
+  });
+  const screenRadius = Math.abs(edge.x - center.x);
+});
+```

--- a/apps/docs/api/three/src/interfaces/ScreenPoint.md
+++ b/apps/docs/api/three/src/interfaces/ScreenPoint.md
@@ -1,0 +1,43 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [three/src](../README.md) / ScreenPoint
+
+# Interface: ScreenPoint
+
+Defined in: packages/three/src/public/useScreenProjection.ts
+
+A projected point in screen space.
+
+## Properties
+
+### x
+
+> **x**: `number`
+
+Screen-space X in pixels (0 = left edge).
+
+***
+
+### y
+
+> **y**: `number`
+
+Screen-space Y in pixels (0 = top edge).
+
+***
+
+### depth
+
+> **depth**: `number`
+
+Normalized depth (0 = near, 1 = far). Useful for z-sorting overlays.
+
+***
+
+### visible
+
+> **visible**: `boolean`
+
+Whether the point is in front of the camera.

--- a/apps/docs/api/three/src/interfaces/WorldPoint.md
+++ b/apps/docs/api/three/src/interfaces/WorldPoint.md
@@ -1,0 +1,35 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [three/src](../README.md) / WorldPoint
+
+# Interface: WorldPoint
+
+Defined in: packages/three/src/public/useScreenProjection.ts
+
+A point in 3D world space.
+
+## Properties
+
+### x
+
+> **x**: `number`
+
+X coordinate.
+
+***
+
+### y
+
+> **y**: `number`
+
+Y coordinate.
+
+***
+
+### z
+
+> **z**: `number`
+
+Z coordinate.

--- a/packages/three/src/public/index.ts
+++ b/packages/three/src/public/index.ts
@@ -29,6 +29,11 @@ export {
     type FollowCameraResult,
 } from './useFollowCamera';
 export {
+    useScreenProjection,
+    type WorldPoint,
+    type ScreenPoint,
+} from './useScreenProjection';
+export {
     useAmbientLight,
     useDirectionalLight,
     usePointLight,

--- a/packages/three/src/public/useScreenProjection.test.ts
+++ b/packages/three/src/public/useScreenProjection.test.ts
@@ -1,0 +1,277 @@
+/** @jest-environment jsdom */
+import { World } from '@pulse-ts/core';
+import { ThreeService } from '../domain/services/Three';
+import { useScreenProjection } from './useScreenProjection';
+import type { ScreenPoint, WorldPoint } from './useScreenProjection';
+
+// ---------------------------------------------------------------------------
+// Lightweight Three.js mock
+// ---------------------------------------------------------------------------
+
+let mockProject: jest.Mock;
+
+jest.mock('three', () => {
+    class Vector3 {
+        x = 0;
+        y = 0;
+        z = 0;
+        set(x: number, y: number, z: number) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            return this;
+        }
+        copy(v: Vector3) {
+            this.x = v.x;
+            this.y = v.y;
+            this.z = v.z;
+        }
+        multiply(v: Vector3) {
+            this.x *= v.x;
+            this.y *= v.y;
+            this.z *= v.z;
+        }
+        project(camera: any) {
+            if (mockProject) {
+                const result = mockProject(this.x, this.y, this.z, camera);
+                this.x = result.x;
+                this.y = result.y;
+                this.z = result.z;
+            }
+            return this;
+        }
+    }
+    class Quaternion {
+        x = 0;
+        y = 0;
+        z = 0;
+        w = 1;
+        set(x: number, y: number, z: number, w: number) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.w = w;
+        }
+        copy(q: Quaternion) {
+            this.x = q.x;
+            this.y = q.y;
+            this.z = q.z;
+            this.w = q.w;
+        }
+    }
+    class Object3D {
+        parent: Object3D | null = null;
+        children: Object3D[] = [];
+        position = new Vector3();
+        quaternion = new Quaternion();
+        scale = new Vector3(1, 1, 1);
+        visible = true;
+        castShadow = false;
+        receiveShadow = false;
+        matrixAutoUpdate = true;
+        matrixWorldNeedsUpdate = false as boolean;
+        add(child: Object3D) {
+            if (child.parent) child.parent.remove(child);
+            this.children.push(child);
+            child.parent = this;
+        }
+        remove(child: Object3D) {
+            const i = this.children.indexOf(child);
+            if (i >= 0) this.children.splice(i, 1);
+            if (child.parent === this) child.parent = null;
+        }
+        updateMatrix() {}
+    }
+    class Group extends Object3D {}
+    class Scene extends Object3D {}
+    class Matrix4 {
+        elements = Array.from({ length: 16 }, () => 0);
+    }
+    class PerspectiveCamera extends Object3D {
+        aspect = 1;
+        projectionMatrix = new Matrix4();
+        matrixWorldInverse = new Matrix4();
+        updateProjectionMatrix() {}
+        updateMatrixWorld() {}
+    }
+    class Color {
+        constructor() {}
+    }
+    class WebGLRenderer {
+        domElement: HTMLCanvasElement;
+        setPixelRatio = jest.fn();
+        setSize = jest.fn();
+        render = jest.fn();
+        constructor(opts: { canvas: HTMLCanvasElement }) {
+            this.domElement = opts.canvas;
+        }
+    }
+
+    return {
+        Vector3,
+        Quaternion,
+        Object3D,
+        Group,
+        Scene,
+        Matrix4,
+        PerspectiveCamera,
+        Color,
+        WebGLRenderer,
+    };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createCanvas(width = 800, height = 600) {
+    const canvas = document.createElement('canvas');
+    Object.defineProperty(canvas, 'clientWidth', { value: width });
+    Object.defineProperty(canvas, 'clientHeight', { value: height });
+    return canvas as HTMLCanvasElement;
+}
+
+beforeAll(() => {
+    (global as any).ResizeObserver = class {
+        observe() {}
+        disconnect() {}
+    };
+});
+
+function mountProjection(world: World): (position: WorldPoint) => ScreenPoint {
+    let project!: (position: WorldPoint) => ScreenPoint;
+    function TestFC() {
+        project = useScreenProjection();
+    }
+    world.mount(TestFC);
+    return project;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useScreenProjection', () => {
+    let world: World;
+
+    beforeEach(() => {
+        world = new World();
+        world.provideService(
+            new ThreeService({ canvas: createCanvas(), enableCulling: false }),
+        );
+        // Default mock: identity projection (NDC coords returned as-is)
+        mockProject = jest.fn((x, y, z) => ({ x, y, z }));
+    });
+
+    test('returns a function', () => {
+        const project = mountProjection(world);
+        expect(typeof project).toBe('function');
+    });
+
+    test('projects center of screen (NDC 0,0) to canvas center', () => {
+        // NDC (0,0,0) → center of 800×600 canvas
+        mockProject = jest.fn(() => ({ x: 0, y: 0, z: 0 }));
+        const project = mountProjection(world);
+
+        const result = project({ x: 0, y: 0, z: 0 });
+        expect(result.x).toBe(400);
+        expect(result.y).toBe(300);
+    });
+
+    test('projects top-left corner (NDC -1,1) to (0,0)', () => {
+        mockProject = jest.fn(() => ({ x: -1, y: 1, z: 0 }));
+        const project = mountProjection(world);
+
+        const result = project({ x: 0, y: 0, z: 0 });
+        expect(result.x).toBe(0);
+        expect(result.y).toBe(0);
+    });
+
+    test('projects bottom-right corner (NDC 1,-1) to (800,600)', () => {
+        mockProject = jest.fn(() => ({ x: 1, y: -1, z: 0 }));
+        const project = mountProjection(world);
+
+        const result = project({ x: 0, y: 0, z: 0 });
+        expect(result.x).toBe(800);
+        expect(result.y).toBe(600);
+    });
+
+    test('depth is normalized 0-1 from NDC z', () => {
+        // NDC z=-1 (near) → depth 0
+        mockProject = jest.fn(() => ({ x: 0, y: 0, z: -1 }));
+        const project = mountProjection(world);
+
+        const near = project({ x: 0, y: 0, z: 0 });
+        expect(near.depth).toBe(0);
+
+        // NDC z=1 (far) → depth 1
+        mockProject = jest.fn(() => ({ x: 0, y: 0, z: 1 }));
+        const far = project({ x: 0, y: 0, z: 0 });
+        expect(far.depth).toBe(1);
+    });
+
+    test('visible is true when z is within [-1, 1]', () => {
+        mockProject = jest.fn(() => ({ x: 0, y: 0, z: 0 }));
+        const project = mountProjection(world);
+
+        expect(project({ x: 0, y: 0, z: 0 }).visible).toBe(true);
+    });
+
+    test('visible is true at NDC z boundaries', () => {
+        const project = mountProjection(world);
+
+        mockProject = jest.fn(() => ({ x: 0, y: 0, z: -1 }));
+        expect(project({ x: 0, y: 0, z: 0 }).visible).toBe(true);
+
+        mockProject = jest.fn(() => ({ x: 0, y: 0, z: 1 }));
+        expect(project({ x: 0, y: 0, z: 0 }).visible).toBe(true);
+    });
+
+    test('visible is false when behind camera (z < -1)', () => {
+        mockProject = jest.fn(() => ({ x: 0, y: 0, z: -1.5 }));
+        const project = mountProjection(world);
+
+        expect(project({ x: 0, y: 0, z: 0 }).visible).toBe(false);
+    });
+
+    test('visible is false when beyond far plane (z > 1)', () => {
+        mockProject = jest.fn(() => ({ x: 0, y: 0, z: 1.5 }));
+        const project = mountProjection(world);
+
+        expect(project({ x: 0, y: 0, z: 0 }).visible).toBe(false);
+    });
+
+    test('reuses the same ScreenPoint object', () => {
+        mockProject = jest.fn(() => ({ x: 0, y: 0, z: 0 }));
+        const project = mountProjection(world);
+
+        const a = project({ x: 0, y: 0, z: 0 });
+        const b = project({ x: 1, y: 1, z: 1 });
+        expect(a).toBe(b);
+    });
+
+    test('passes world position to Vector3.set', () => {
+        mockProject = jest.fn((x, y, z) => ({ x, y, z }));
+        const project = mountProjection(world);
+
+        project({ x: 5, y: 10, z: 15 });
+        expect(mockProject).toHaveBeenCalledWith(5, 10, 15, expect.anything());
+    });
+
+    test('works with different canvas sizes', () => {
+        const smallWorld = new World();
+        smallWorld.provideService(
+            new ThreeService({
+                canvas: createCanvas(200, 100),
+                enableCulling: false,
+            }),
+        );
+
+        mockProject = jest.fn(() => ({ x: 0, y: 0, z: 0 }));
+        const project = mountProjection(smallWorld);
+
+        const result = project({ x: 0, y: 0, z: 0 });
+        expect(result.x).toBe(100);
+        expect(result.y).toBe(50);
+    });
+});

--- a/packages/three/src/public/useScreenProjection.ts
+++ b/packages/three/src/public/useScreenProjection.ts
@@ -1,0 +1,99 @@
+import * as THREE from 'three';
+import { useThreeContext } from './hooks';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A point in 3D world space. */
+export interface WorldPoint {
+    /** X coordinate. */
+    x: number;
+    /** Y coordinate. */
+    y: number;
+    /** Z coordinate. */
+    z: number;
+}
+
+/** A projected point in screen space. */
+export interface ScreenPoint {
+    /** Screen-space X in pixels (0 = left edge). */
+    x: number;
+    /** Screen-space Y in pixels (0 = top edge). */
+    y: number;
+    /** Normalized depth (0 = near, 1 = far). Useful for z-sorting overlays. */
+    depth: number;
+    /** Whether the point is in front of the camera. */
+    visible: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a projection function that converts world-space positions to
+ * screen-space pixel coordinates.
+ *
+ * Uses the active Three.js camera and renderer dimensions. Reuses an
+ * internal `Vector3` so no allocations occur per call. The returned
+ * `ScreenPoint` object is also reused — callers should consume values
+ * immediately rather than storing across frames.
+ *
+ * @returns A function that projects a {@link WorldPoint} to a {@link ScreenPoint}.
+ *
+ * @example
+ * ```ts
+ * import { useScreenProjection } from '@pulse-ts/three';
+ * import { useFrameUpdate } from '@pulse-ts/core';
+ *
+ * function HealthBarNode() {
+ *   const project = useScreenProjection();
+ *
+ *   useFrameUpdate(() => {
+ *     const { x, y, visible } = project(root.position);
+ *     if (visible) {
+ *       indicator.style.left = `${x}px`;
+ *       indicator.style.top = `${y}px`;
+ *     }
+ *   });
+ * }
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Computing a screen-space radius from a world-space offset
+ * const project = useScreenProjection();
+ *
+ * useFrameUpdate(() => {
+ *   const center = project(root.position);
+ *   const edge = project({
+ *     x: root.position.x + RADIUS,
+ *     y: root.position.y,
+ *     z: root.position.z,
+ *   });
+ *   const screenRadius = Math.abs(edge.x - center.x);
+ * });
+ * ```
+ */
+export function useScreenProjection(): (position: WorldPoint) => ScreenPoint {
+    const { camera, renderer } = useThreeContext();
+
+    const _vec = new THREE.Vector3();
+    const _result: ScreenPoint = { x: 0, y: 0, depth: 0, visible: false };
+
+    return (position: WorldPoint): ScreenPoint => {
+        _vec.set(position.x, position.y, position.z);
+        _vec.project(camera as THREE.PerspectiveCamera);
+
+        const halfWidth = renderer.domElement.clientWidth / 2;
+        const halfHeight = renderer.domElement.clientHeight / 2;
+
+        _result.x = _vec.x * halfWidth + halfWidth;
+        _result.y = -_vec.y * halfHeight + halfHeight;
+        _result.depth = (_vec.z + 1) / 2;
+        _result.visible = _vec.z >= -1 && _vec.z <= 1;
+
+        return _result;
+    };
+}


### PR DESCRIPTION
## Summary
- Add `useScreenProjection` hook to `@pulse-ts/three` that returns a projection function for converting world-space positions to screen-space pixel coordinates
- Reuses internal `Vector3` and `ScreenPoint` objects for zero-allocation per-frame usage
- Returns `{ x, y, depth, visible }` in screen pixels, using the active camera and renderer dimensions

## Test plan
- [x] Unit tests for screen center, corners, depth normalization, visibility bounds
- [x] Verifies ScreenPoint object reuse (no allocations)
- [x] Tests with different canvas sizes
- [x] All 57 tests pass across the three package
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)