### PR TITLE
TICKET-119: Procedural Texture Factory (createTexture)

### DIFF
--- a/.claude/ticket-tracker/swimlanes/done/EPIC-019-three-js-rendering-dx-pass/TICKET-119-procedural-texture-factory.md
+++ b/.claude/ticket-tracker/swimlanes/done/EPIC-019-three-js-rendering-dx-pass/TICKET-119-procedural-texture-factory.md
@@ -2,7 +2,7 @@
 id: TICKET-119
 epic: EPIC-019
 title: Procedural Texture Factory (createTexture)
-status: in-progress
+status: done
 priority: medium
 created: 2026-03-13
 updated: 2026-03-14
@@ -22,17 +22,18 @@ Design doc: `design-docs/approved/041-procedural-texture-factory.md`
 
 ## Acceptance Criteria
 
-- [ ] `createTexture(size, rasterize, options?)` creates a square DataTexture
-- [ ] `createTexture1D(width, rasterize, options?)` creates a 1×width DataTexture
-- [ ] Pixel callback returns `[R, G, B, A]` (0–255)
-- [ ] Options: wrap ('repeat'/'clamp'/'mirror'), filter ('linear'/'nearest'), format ('rgba'/'rgb')
-- [ ] String enums mapped to Three.js constants
-- [ ] Texture `needsUpdate` set automatically
-- [ ] JSDoc with examples
-- [ ] Unit tests for buffer creation, wrap/filter configuration
-- [ ] Documentation updated
+- [x] `createTexture(size, rasterize, options?)` creates a square DataTexture
+- [x] `createTexture1D(width, rasterize, options?)` creates a 1×width DataTexture
+- [x] Pixel callback returns `[R, G, B, A]` (0–255)
+- [x] Options: wrap ('repeat'/'clamp'/'mirror'), filter ('linear'/'nearest'), format ('rgba'/'rgb')
+- [x] String enums mapped to Three.js constants
+- [x] Texture `needsUpdate` set automatically
+- [x] JSDoc with examples
+- [x] Unit tests for buffer creation, wrap/filter configuration
+- [x] Documentation updated
 
 ## Notes
 
 - **2026-03-13**: Ticket created from approved design doc #41.
 - **2026-03-14**: Moved to in-progress. Beginning implementation.
+- **2026-03-14**: Implementation complete. All 15 tests pass, lint clean.

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-019-three-js-rendering-dx-pass/TICKET-119-procedural-texture-factory.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-019-three-js-rendering-dx-pass/TICKET-119-procedural-texture-factory.md
@@ -2,10 +2,11 @@
 id: TICKET-119
 epic: EPIC-019
 title: Procedural Texture Factory (createTexture)
-status: todo
+status: in-progress
 priority: medium
 created: 2026-03-13
-updated: 2026-03-13
+updated: 2026-03-14
+branch: ticket-119-procedural-texture-factory
 labels:
   - three
   - utility
@@ -34,3 +35,4 @@ Design doc: `design-docs/approved/041-procedural-texture-factory.md`
 ## Notes
 
 - **2026-03-13**: Ticket created from approved design doc #41.
+- **2026-03-14**: Moved to in-progress. Beginning implementation.

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
         { text: 'Networking: Server Broker (WebSocket)', link: '/guides/networking-server-broker' },
         { text: 'Networking: Cookbook', link: '/guides/networking-cookbook' },
         { text: 'State Management', link: '/guides/state-management' },
+        { text: 'Procedural Textures', link: '/guides/procedural-textures' },
       ]
     },
     search: {

--- a/apps/docs/guides/procedural-textures.md
+++ b/apps/docs/guides/procedural-textures.md
@@ -1,0 +1,85 @@
+# Procedural Textures
+
+`createTexture` and `createTexture1D` generate `THREE.DataTexture` instances from
+per-pixel rasterization callbacks. They handle buffer allocation, texture creation,
+and wrap/filter setup so you can focus on the pixel logic.
+
+## Overview
+
+| Function | Purpose |
+|---|---|
+| `createTexture(size, rasterize, options?)` | Square texture (size × size) |
+| `createTexture1D(width, rasterize, options?)` | 1D texture (width × 1) for gradients |
+
+Both are pure utility functions exported from `@pulse-ts/three`.
+
+## Quick Start
+
+```ts
+import { createTexture, createTexture1D } from '@pulse-ts/three';
+
+// Grid emissive map
+const emissiveMap = createTexture(256, (x, y) => {
+    const spacing = 32;
+    const onLine = x % spacing <= 1 || y % spacing <= 1;
+    return onLine ? [50, 180, 220, 255] : [0, 0, 0, 255];
+}, { wrap: 'repeat', filter: 'linear' });
+
+// Gradient ramp
+const gradient = createTexture1D(64, (x, width) => {
+    const t = x / width;
+    return [255 * t, 100, 255 * (1 - t), 255];
+});
+```
+
+## Pixel Callback
+
+The rasterize function is called once per pixel and must return an `[R, G, B, A]`
+tuple with values in the 0–255 range.
+
+**2D callback:** `(x, y, size) => [R, G, B, A]`
+
+**1D callback:** `(x, width) => [R, G, B, A]`
+
+## Options
+
+| Option | Values | Default | Description |
+|---|---|---|---|
+| `wrap` | `'repeat'` \| `'clamp'` \| `'mirror'` | `'clamp'` | Wrap mode for both S and T axes |
+| `filter` | `'linear'` \| `'nearest'` | `'linear'` | Min and mag filter mode |
+| `format` | `'rgba'` \| `'rgb'` | `'rgba'` | Pixel format (3 or 4 channels) |
+
+String values are mapped to Three.js constants automatically:
+
+- `'repeat'` → `THREE.RepeatWrapping`
+- `'clamp'` → `THREE.ClaimToEdgeWrapping`
+- `'mirror'` → `THREE.MirroredRepeatWrapping`
+- `'linear'` → `THREE.LinearFilter`
+- `'nearest'` → `THREE.NearestFilter`
+
+## Examples
+
+### Normal Map
+
+```ts
+const normalMap = createTexture(256, (x, y, size) => {
+    const cx = (x / size - 0.5) * 2;
+    const cy = (y / size - 0.5) * 2;
+    return [cx * 127 + 128, cy * 127 + 128, 255, 255];
+}, { wrap: 'repeat', filter: 'linear' });
+```
+
+### RGB Format (No Alpha)
+
+```ts
+const rgbTexture = createTexture(128, (x, y) => {
+    return [x * 2, y * 2, 128, 0]; // alpha ignored in rgb mode
+}, { format: 'rgb' });
+```
+
+## Limitations
+
+- Textures are generated synchronously on the CPU. For very large textures
+  (1024+), consider generating them off the main thread.
+- The callback is invoked once during creation. For animated textures,
+  regenerate the texture each frame or manipulate the buffer directly.

--- a/packages/three/src/public/createTexture.test.ts
+++ b/packages/three/src/public/createTexture.test.ts
@@ -1,0 +1,225 @@
+/** @jest-environment jsdom */
+import { createTexture, createTexture1D } from './createTexture';
+
+// ---------------------------------------------------------------------------
+// Three.js mock — DataTexture and format constants
+// ---------------------------------------------------------------------------
+jest.mock('three', () => ({
+    DataTexture: jest.fn().mockImplementation(function (
+        this: Record<string, unknown>,
+        data: Uint8Array,
+        width: number,
+        height: number,
+        format: number,
+    ) {
+        this.image = { data, width, height };
+        this.format = format;
+        this.wrapS = 0;
+        this.wrapT = 0;
+        this.minFilter = 0;
+        this.magFilter = 0;
+        this.needsUpdate = false;
+    }),
+    RGBAFormat: 1023,
+    RGBFormat: 1022,
+    RepeatWrapping: 1000,
+    ClampToEdgeWrapping: 1001,
+    MirroredRepeatWrapping: 1002,
+    LinearFilter: 1006,
+    NearestFilter: 1003,
+}));
+
+// ---------------------------------------------------------------------------
+// createTexture
+// ---------------------------------------------------------------------------
+describe('createTexture', () => {
+    it('creates a square RGBA DataTexture with correct buffer size', () => {
+        const tex = createTexture(4, (x, y) => [
+            x * 10,
+            y * 10,
+            128,
+            255,
+        ]) as unknown as Record<string, unknown>;
+        const img = tex.image as {
+            data: Uint8Array;
+            width: number;
+            height: number;
+        };
+
+        expect(img.width).toBe(4);
+        expect(img.height).toBe(4);
+        expect(img.data.length).toBe(4 * 4 * 4); // 4×4 pixels × 4 channels
+    });
+
+    it('populates pixel data from the rasterize callback', () => {
+        const tex = createTexture(2, (x, y) => [
+            x * 100,
+            y * 100,
+            50,
+            200,
+        ]) as unknown as Record<string, unknown>;
+        const data = (tex.image as { data: Uint8Array }).data;
+
+        // Pixel (0,0): [0, 0, 50, 200]
+        expect(data[0]).toBe(0);
+        expect(data[1]).toBe(0);
+        expect(data[2]).toBe(50);
+        expect(data[3]).toBe(200);
+
+        // Pixel (1,0): [100, 0, 50, 200]
+        expect(data[4]).toBe(100);
+        expect(data[5]).toBe(0);
+        expect(data[6]).toBe(50);
+        expect(data[7]).toBe(200);
+
+        // Pixel (0,1): [0, 100, 50, 200]
+        expect(data[8]).toBe(0);
+        expect(data[9]).toBe(100);
+        expect(data[10]).toBe(50);
+        expect(data[11]).toBe(200);
+    });
+
+    it('sets needsUpdate to true', () => {
+        const tex = createTexture(2, () => [0, 0, 0, 255]) as unknown as Record<
+            string,
+            unknown
+        >;
+        expect(tex.needsUpdate).toBe(true);
+    });
+
+    it('applies default wrap (clamp) and filter (linear)', () => {
+        const tex = createTexture(2, () => [0, 0, 0, 255]) as unknown as Record<
+            string,
+            unknown
+        >;
+        expect(tex.wrapS).toBe(1001); // ClampToEdgeWrapping
+        expect(tex.wrapT).toBe(1001);
+        expect(tex.minFilter).toBe(1006); // LinearFilter
+        expect(tex.magFilter).toBe(1006);
+    });
+
+    it('maps wrap "repeat" to RepeatWrapping', () => {
+        const tex = createTexture(2, () => [0, 0, 0, 255], {
+            wrap: 'repeat',
+        }) as unknown as Record<string, unknown>;
+        expect(tex.wrapS).toBe(1000);
+        expect(tex.wrapT).toBe(1000);
+    });
+
+    it('maps wrap "mirror" to MirroredRepeatWrapping', () => {
+        const tex = createTexture(2, () => [0, 0, 0, 255], {
+            wrap: 'mirror',
+        }) as unknown as Record<string, unknown>;
+        expect(tex.wrapS).toBe(1002);
+        expect(tex.wrapT).toBe(1002);
+    });
+
+    it('maps filter "nearest" to NearestFilter', () => {
+        const tex = createTexture(2, () => [0, 0, 0, 255], {
+            filter: 'nearest',
+        }) as unknown as Record<string, unknown>;
+        expect(tex.minFilter).toBe(1003);
+        expect(tex.magFilter).toBe(1003);
+    });
+
+    it('supports RGB format with 3-channel buffer', () => {
+        const tex = createTexture(2, () => [10, 20, 30, 255], {
+            format: 'rgb',
+        }) as unknown as Record<string, unknown>;
+        const img = tex.image as { data: Uint8Array };
+        expect(img.data.length).toBe(2 * 2 * 3); // 3 channels
+        // Alpha channel should not be written
+        expect(img.data[0]).toBe(10);
+        expect(img.data[1]).toBe(20);
+        expect(img.data[2]).toBe(30);
+        expect(tex.format).toBe(1022); // RGBFormat
+    });
+
+    it('passes size parameter to the rasterize callback', () => {
+        const rasterize = jest.fn().mockReturnValue([0, 0, 0, 255]);
+        createTexture(3, rasterize);
+        // Should be called 9 times (3×3)
+        expect(rasterize).toHaveBeenCalledTimes(9);
+        // First call should receive (0, 0, 3)
+        expect(rasterize).toHaveBeenCalledWith(0, 0, 3);
+        // Last call should receive (2, 2, 3)
+        expect(rasterize).toHaveBeenCalledWith(2, 2, 3);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// createTexture1D
+// ---------------------------------------------------------------------------
+describe('createTexture1D', () => {
+    it('creates a 1-pixel-tall DataTexture', () => {
+        const tex = createTexture1D(8, (x) => [
+            x * 30,
+            0,
+            0,
+            255,
+        ]) as unknown as Record<string, unknown>;
+        const img = tex.image as {
+            data: Uint8Array;
+            width: number;
+            height: number;
+        };
+        expect(img.width).toBe(8);
+        expect(img.height).toBe(1);
+        expect(img.data.length).toBe(8 * 4);
+    });
+
+    it('populates pixel data correctly', () => {
+        const tex = createTexture1D(3, (x, width) => [
+            x * 100,
+            width,
+            50,
+            200,
+        ]) as unknown as Record<string, unknown>;
+        const data = (tex.image as { data: Uint8Array }).data;
+
+        // Pixel 0: [0, 3, 50, 200]
+        expect(data[0]).toBe(0);
+        expect(data[1]).toBe(3);
+        expect(data[2]).toBe(50);
+        expect(data[3]).toBe(200);
+
+        // Pixel 2: [200, 3, 50, 200]
+        expect(data[8]).toBe(200);
+        expect(data[9]).toBe(3);
+    });
+
+    it('sets needsUpdate to true', () => {
+        const tex = createTexture1D(4, () => [
+            0, 0, 0, 255,
+        ]) as unknown as Record<string, unknown>;
+        expect(tex.needsUpdate).toBe(true);
+    });
+
+    it('applies wrap and filter options', () => {
+        const tex = createTexture1D(4, () => [0, 0, 0, 255], {
+            wrap: 'repeat',
+            filter: 'nearest',
+        }) as unknown as Record<string, unknown>;
+        expect(tex.wrapS).toBe(1000);
+        expect(tex.wrapT).toBe(1000);
+        expect(tex.minFilter).toBe(1003);
+        expect(tex.magFilter).toBe(1003);
+    });
+
+    it('supports RGB format', () => {
+        const tex = createTexture1D(4, () => [10, 20, 30, 255], {
+            format: 'rgb',
+        }) as unknown as Record<string, unknown>;
+        const img = tex.image as { data: Uint8Array };
+        expect(img.data.length).toBe(4 * 3);
+        expect(tex.format).toBe(1022);
+    });
+
+    it('passes width parameter to the rasterize callback', () => {
+        const rasterize = jest.fn().mockReturnValue([0, 0, 0, 255]);
+        createTexture1D(5, rasterize);
+        expect(rasterize).toHaveBeenCalledTimes(5);
+        expect(rasterize).toHaveBeenCalledWith(0, 5);
+        expect(rasterize).toHaveBeenCalledWith(4, 5);
+    });
+});

--- a/packages/three/src/public/createTexture.ts
+++ b/packages/three/src/public/createTexture.ts
@@ -1,0 +1,181 @@
+import * as THREE from 'three';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Per-pixel rasterization callback for 2D textures. Returns `[R, G, B, A]` (0–255). */
+export type PixelFn = (
+    x: number,
+    y: number,
+    size: number,
+) => [number, number, number, number];
+
+/** Per-pixel rasterization callback for 1D textures. Returns `[R, G, B, A]` (0–255). */
+export type PixelFn1D = (
+    x: number,
+    width: number,
+) => [number, number, number, number];
+
+/** Texture wrap mode. */
+export type WrapMode = 'repeat' | 'clamp' | 'mirror';
+
+/** Texture filter mode. */
+export type FilterMode = 'linear' | 'nearest';
+
+/** Texture format. */
+export type TextureFormat = 'rgba' | 'rgb';
+
+/** Options for procedural texture creation. */
+export interface TextureOptions {
+    /** Wrap mode applied to both S and T axes. @default 'clamp' */
+    wrap?: WrapMode;
+    /** Min and mag filter mode. @default 'linear' */
+    filter?: FilterMode;
+    /** Pixel format. @default 'rgba' */
+    format?: TextureFormat;
+}
+
+// ---------------------------------------------------------------------------
+// String enum → Three.js constant mappings
+// ---------------------------------------------------------------------------
+
+const WRAP_MAP: Record<WrapMode, THREE.Wrapping> = {
+    repeat: THREE.RepeatWrapping,
+    clamp: THREE.ClampToEdgeWrapping,
+    mirror: THREE.MirroredRepeatWrapping,
+};
+
+const FILTER_MAP: Record<FilterMode, THREE.TextureFilter> = {
+    linear: THREE.LinearFilter,
+    nearest: THREE.NearestFilter,
+};
+
+const FORMAT_MAP: Record<TextureFormat, THREE.PixelFormat> = {
+    rgba: THREE.RGBAFormat,
+    rgb: THREE.RGBFormat,
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function channelsForFormat(format: TextureFormat): number {
+    return format === 'rgb' ? 3 : 4;
+}
+
+function applyOptions(
+    texture: THREE.DataTexture,
+    options: TextureOptions,
+): void {
+    const wrap = WRAP_MAP[options.wrap ?? 'clamp'];
+    const filter = FILTER_MAP[options.filter ?? 'linear'];
+
+    texture.wrapS = wrap;
+    texture.wrapT = wrap;
+    texture.minFilter = filter;
+    texture.magFilter = filter;
+    texture.needsUpdate = true;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a procedural square `DataTexture` by rasterizing a per-pixel function.
+ *
+ * Handles buffer allocation, DataTexture creation, and filter/wrap setup.
+ *
+ * @param size - Texture width and height in pixels (square).
+ * @param rasterize - Called for each pixel with `(x, y, size)`; returns `[R, G, B, A]` (0–255).
+ * @param options - Wrap mode, filter mode, and pixel format.
+ * @returns A ready-to-use `DataTexture` with `needsUpdate` already set.
+ *
+ * @example
+ * ```ts
+ * const normalMap = createTexture(256, (x, y, size) => {
+ *     const cx = (x / size - 0.5) * 2;
+ *     const cy = (y / size - 0.5) * 2;
+ *     return [cx * 127 + 128, cy * 127 + 128, 255, 255];
+ * }, { wrap: 'repeat', filter: 'linear' });
+ * ```
+ *
+ * @example
+ * ```ts
+ * const emissiveMap = createTexture(256, (x, y, size) => {
+ *     const spacing = 32;
+ *     const onLine = x % spacing <= 1 || y % spacing <= 1;
+ *     return onLine ? [50, 180, 220, 255] : [0, 0, 0, 255];
+ * }, { wrap: 'repeat', filter: 'linear' });
+ * ```
+ */
+export function createTexture(
+    size: number,
+    rasterize: PixelFn,
+    options: TextureOptions = {},
+): THREE.DataTexture {
+    const format = options.format ?? 'rgba';
+    const channels = channelsForFormat(format);
+    const data = new Uint8Array(size * size * channels);
+
+    for (let y = 0; y < size; y++) {
+        for (let x = 0; x < size; x++) {
+            const pixel = rasterize(x, y, size);
+            const i = (y * size + x) * channels;
+            data[i] = pixel[0];
+            data[i + 1] = pixel[1];
+            data[i + 2] = pixel[2];
+            if (channels === 4) {
+                data[i + 3] = pixel[3];
+            }
+        }
+    }
+
+    const texture = new THREE.DataTexture(data, size, size, FORMAT_MAP[format]);
+    applyOptions(texture, options);
+    return texture;
+}
+
+/**
+ * Create a procedural 1D `DataTexture` (height = 1) by rasterizing a per-pixel function.
+ *
+ * Ideal for gradient textures and color ramps.
+ *
+ * @param width - Texture width in pixels.
+ * @param rasterize - Called for each pixel with `(x, width)`; returns `[R, G, B, A]` (0–255).
+ * @param options - Wrap mode, filter mode, and pixel format.
+ * @returns A 1-pixel-tall `DataTexture` with `needsUpdate` already set.
+ *
+ * @example
+ * ```ts
+ * const gradient = createTexture1D(64, (x, width) => {
+ *     const t = x / width;
+ *     return [255 * t, 100, 255 * (1 - t), 255];
+ * });
+ * ```
+ */
+export function createTexture1D(
+    width: number,
+    rasterize: PixelFn1D,
+    options: TextureOptions = {},
+): THREE.DataTexture {
+    const format = options.format ?? 'rgba';
+    const channels = channelsForFormat(format);
+    const data = new Uint8Array(width * channels);
+
+    for (let x = 0; x < width; x++) {
+        const pixel = rasterize(x, width);
+        const i = x * channels;
+        data[i] = pixel[0];
+        data[i + 1] = pixel[1];
+        data[i + 2] = pixel[2];
+        if (channels === 4) {
+            data[i + 3] = pixel[3];
+        }
+    }
+
+    const texture = new THREE.DataTexture(data, width, 1, FORMAT_MAP[format]);
+    applyOptions(texture, options);
+    return texture;
+}

--- a/packages/three/src/public/index.ts
+++ b/packages/three/src/public/index.ts
@@ -52,3 +52,13 @@ export {
     StatsOverlaySystem,
     type StatsOverlayOptions,
 } from '../domain/systems/statsOverlay';
+export {
+    createTexture,
+    createTexture1D,
+    type PixelFn,
+    type PixelFn1D,
+    type WrapMode,
+    type FilterMode,
+    type TextureFormat,
+    type TextureOptions,
+} from './createTexture';


### PR DESCRIPTION
## Summary

- Add `createTexture(size, rasterize, options?)` for generating square `THREE.DataTexture` from per-pixel callbacks
- Add `createTexture1D(width, rasterize, options?)` for 1D gradient/ramp textures
- String enum options (`wrap`, `filter`, `format`) mapped to Three.js constants
- `needsUpdate` set automatically on created textures
- Full JSDoc with examples, 15 unit tests, documentation guide added

## Test plan

- [x] All 15 createTexture tests pass (`npm test -w packages/three`)
- [x] Lint passes (`npx nx lint three`)
- [ ] Manual verification: use `createTexture` in a demo to confirm DataTexture renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)