### PR TITLE
TICKET-124: Input Binding Shorthand

### DIFF
--- a/.claude/ticket-tracker/swimlanes/done/EPIC-022-input-and-platform-dx-pass/TICKET-124-input-binding-shorthand.md
+++ b/.claude/ticket-tracker/swimlanes/done/EPIC-022-input-and-platform-dx-pass/TICKET-124-input-binding-shorthand.md
@@ -2,7 +2,7 @@
 id: TICKET-124
 epic: EPIC-022
 title: Input Binding Shorthand (Axis2D.keys / wasd / arrows)
-status: in-progress
+status: done
 priority: low
 created: 2026-03-13
 updated: 2026-03-14
@@ -22,16 +22,17 @@ Design doc: `design-docs/approved/037-input-binding-shorthand.md`
 
 ## Acceptance Criteria
 
-- [ ] `Axis2D.keys(left, right, down, up)` creates a 2D axis from four key codes
-- [ ] `Axis2D.wasd()` preset for WASD keys
-- [ ] `Axis2D.arrows()` preset for arrow keys
-- [ ] Parameter order: left, right, down, up (X-axis first, then Y-axis)
-- [ ] Full form `Axis2D({ x: Axis1D(...), y: Axis1D(...) })` still available
-- [ ] JSDoc with examples
-- [ ] Unit tests for all shorthands
-- [ ] Documentation updated
+- [x] `Axis2D.keys(left, right, down, up)` creates a 2D axis from four key codes
+- [x] `Axis2D.wasd()` preset for WASD keys
+- [x] `Axis2D.arrows()` preset for arrow keys
+- [x] Parameter order: left, right, down, up (X-axis first, then Y-axis)
+- [x] Full form `Axis2D({ x: Axis1D(...), y: Axis1D(...) })` still available
+- [x] JSDoc with examples
+- [x] Unit tests for all shorthands
+- [x] Documentation updated
 
 ## Notes
 
 - **2026-03-13**: Ticket created from approved design doc #37.
 - **2026-03-14**: Moved to in-progress. Starting implementation.
+- **2026-03-14**: Implementation complete. All shorthands added with tests and docs. Moved to done.

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-022-input-and-platform-dx-pass/TICKET-124-input-binding-shorthand.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-022-input-and-platform-dx-pass/TICKET-124-input-binding-shorthand.md
@@ -2,10 +2,11 @@
 id: TICKET-124
 epic: EPIC-022
 title: Input Binding Shorthand (Axis2D.keys / wasd / arrows)
-status: todo
+status: in-progress
 priority: low
 created: 2026-03-13
-updated: 2026-03-13
+updated: 2026-03-14
+branch: ticket-124-input-binding-shorthand
 labels:
   - input
   - dx
@@ -33,3 +34,4 @@ Design doc: `design-docs/approved/037-input-binding-shorthand.md`
 ## Notes
 
 - **2026-03-13**: Ticket created from approved design doc #37.
+- **2026-03-14**: Moved to in-progress. Starting implementation.

--- a/apps/docs/guides/input-bindings.md
+++ b/apps/docs/guides/input-bindings.md
@@ -15,10 +15,13 @@ installInput(world, {
     jump: Chord([Key('Space')]),
     dash: Sequence([Key('KeyD'), Key('KeyS')], { maxGapFrames: 10 }),
 
-    // Axes
+    // Axes — shorthand presets
+    move: Axis2D.wasd(),
+    p2Move: Axis2D.arrows(),
+
+    // Axes — explicit form still available
     moveX: Axis1D({ pos: Key('D'), neg: Key('A') }),
     moveY: Axis1D({ pos: Key('W'), neg: Key('S') }),
-    move: Axis2D({ x: { pos: Key('D'), neg: Key('A') }, y: { pos: Key('W'), neg: Key('S') } }),
 
     // Pointer
     look: PointerMovement({ scaleX: 0.1, scaleY: 0.1 }),
@@ -85,11 +88,32 @@ const off = input.actionEvent.on(({ name, state }) => {
 off();
 ```
 
+## Axis2D shorthands
+
+For the most common 2D axis bindings, use the shorthand methods instead of the full nested form:
+
+```ts
+// WASD preset
+move: Axis2D.wasd(),
+
+// Arrow keys preset
+p2Move: Axis2D.arrows(),
+
+// Custom four-key layout (left, right, down, up)
+ijklMove: Axis2D.keys('KeyJ', 'KeyL', 'KeyK', 'KeyI'),
+```
+
+The full form remains available for custom configurations (e.g., mixed keyboard + gamepad axes):
+
+```ts
+move: Axis2D({ x: { pos: Key('D'), neg: Key('A') }, y: { pos: Key('W'), neg: Key('S') } }),
+```
+
 ## Tips
 
 - Set `preventDefault` to avoid scrolling/back/forward during gameplay.
 - Enable `pointerLock` to capture mouse for FPS-style look.
-- Use `Axis2D` for combined WASD vectors and `Axis1D` for single axes.
+- Use `Axis2D.wasd()` or `Axis2D.arrows()` for quick movement bindings, or `Axis2D.keys()` for custom layouts.
 - Use `Chord` for simultaneous keys and `Sequence` for combos.
 
 Note: `preventDefault` and `pointerLock` default to `false` unless specified in `installInput` options.

--- a/packages/input/src/domain/bindings/expr.test.ts
+++ b/packages/input/src/domain/bindings/expr.test.ts
@@ -23,4 +23,73 @@ describe('expr helpers', () => {
         expect((a2 as any).invertX).toBeUndefined();
         expect((a2 as any).invertY).toBeUndefined();
     });
+
+    describe('Axis2D.keys', () => {
+        test('creates a 2D axis from four key codes (left, right, down, up)', () => {
+            const a = Axis2D.keys('KeyJ', 'KeyL', 'KeyK', 'KeyI');
+            expect(a.type).toBe('axis2d');
+            expect(a.axes.x.neg[0].code).toBe('KeyJ');
+            expect(a.axes.x.pos[0].code).toBe('KeyL');
+            expect(a.axes.y.neg[0].code).toBe('KeyK');
+            expect(a.axes.y.pos[0].code).toBe('KeyI');
+        });
+
+        test('normalizes shorthand key codes', () => {
+            const a = Axis2D.keys('a', 'd', 's', 'w');
+            expect(a.axes.x.neg[0].code).toBe('KeyA');
+            expect(a.axes.x.pos[0].code).toBe('KeyD');
+            expect(a.axes.y.neg[0].code).toBe('KeyS');
+            expect(a.axes.y.pos[0].code).toBe('KeyW');
+        });
+    });
+
+    describe('Axis2D.wasd', () => {
+        test('creates WASD preset with correct key codes', () => {
+            const a = Axis2D.wasd();
+            expect(a.type).toBe('axis2d');
+            expect(a.axes.x.neg[0].code).toBe('KeyA');
+            expect(a.axes.x.pos[0].code).toBe('KeyD');
+            expect(a.axes.y.neg[0].code).toBe('KeyS');
+            expect(a.axes.y.pos[0].code).toBe('KeyW');
+        });
+
+        test('returns the same structure as the full form', () => {
+            const shorthand = Axis2D.wasd();
+            const full = Axis2D({
+                x: { neg: Key('KeyA'), pos: Key('KeyD') },
+                y: { neg: Key('KeyS'), pos: Key('KeyW') },
+            });
+            expect(shorthand).toEqual(full);
+        });
+    });
+
+    describe('Axis2D.arrows', () => {
+        test('creates arrow keys preset with correct key codes', () => {
+            const a = Axis2D.arrows();
+            expect(a.type).toBe('axis2d');
+            expect(a.axes.x.neg[0].code).toBe('ArrowLeft');
+            expect(a.axes.x.pos[0].code).toBe('ArrowRight');
+            expect(a.axes.y.neg[0].code).toBe('ArrowDown');
+            expect(a.axes.y.pos[0].code).toBe('ArrowUp');
+        });
+
+        test('returns the same structure as the full form', () => {
+            const shorthand = Axis2D.arrows();
+            const full = Axis2D({
+                x: { neg: Key('ArrowLeft'), pos: Key('ArrowRight') },
+                y: { neg: Key('ArrowDown'), pos: Key('ArrowUp') },
+            });
+            expect(shorthand).toEqual(full);
+        });
+    });
+
+    test('full form Axis2D still works alongside shorthands', () => {
+        const full = Axis2D({
+            x: { pos: Key('D'), neg: Key('A') },
+            y: { pos: Key('W'), neg: Key('S') },
+        });
+        expect(full.type).toBe('axis2d');
+        expect(full.axes.x).toBeDefined();
+        expect(full.axes.y).toBeDefined();
+    });
 });

--- a/packages/input/src/domain/bindings/expr.ts
+++ b/packages/input/src/domain/bindings/expr.ts
@@ -104,6 +104,91 @@ export function Axis2D(
     } as Axis2DBinding;
 }
 
+// ─── Axis2D shorthand methods ───────────────────────────────────────────────
+
+/**
+ * Namespace for `Axis2D` shorthand factory methods.
+ *
+ * @remarks
+ * These methods provide convenient shortcuts for common 2D axis binding
+ * patterns. The full form `Axis2D({ x: {...}, y: {...} })` remains available
+ * for custom configurations.
+ */
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Axis2D {
+    /**
+     * Create a 2D axis from four key codes: left, right, down, up.
+     *
+     * Equivalent to:
+     * ```ts
+     * Axis2D({
+     *   x: { neg: Key(left), pos: Key(right) },
+     *   y: { neg: Key(down), pos: Key(up) },
+     * })
+     * ```
+     *
+     * @param left - Key code for the negative X direction.
+     * @param right - Key code for the positive X direction.
+     * @param down - Key code for the negative Y direction.
+     * @param up - Key code for the positive Y direction.
+     * @returns An {@link Axis2DBinding} with `x` and `y` axes.
+     *
+     * @example
+     * ```ts
+     * import { Axis2D } from '@pulse-ts/input';
+     *
+     * const ijklMove = Axis2D.keys('KeyJ', 'KeyL', 'KeyK', 'KeyI');
+     * ```
+     */
+    export function keys(
+        left: string,
+        right: string,
+        down: string,
+        up: string,
+    ): Axis2DBinding {
+        return Axis2D({
+            x: { neg: Key(left), pos: Key(right) },
+            y: { neg: Key(down), pos: Key(up) },
+        });
+    }
+
+    /**
+     * Create a 2D axis preset for WASD keys.
+     *
+     * Equivalent to `Axis2D.keys('KeyA', 'KeyD', 'KeyS', 'KeyW')`.
+     *
+     * @returns An {@link Axis2DBinding} bound to WASD.
+     *
+     * @example
+     * ```ts
+     * import { Axis2D } from '@pulse-ts/input';
+     *
+     * const move = Axis2D.wasd();
+     * ```
+     */
+    export function wasd(): Axis2DBinding {
+        return keys('KeyA', 'KeyD', 'KeyS', 'KeyW');
+    }
+
+    /**
+     * Create a 2D axis preset for arrow keys.
+     *
+     * Equivalent to `Axis2D.keys('ArrowLeft', 'ArrowRight', 'ArrowDown', 'ArrowUp')`.
+     *
+     * @returns An {@link Axis2DBinding} bound to arrow keys.
+     *
+     * @example
+     * ```ts
+     * import { Axis2D } from '@pulse-ts/input';
+     *
+     * const move = Axis2D.arrows();
+     * ```
+     */
+    export function arrows(): Axis2DBinding {
+        return keys('ArrowLeft', 'ArrowRight', 'ArrowDown', 'ArrowUp');
+    }
+}
+
 /**
  * Create a pointer movement binding (maps mouse/touch delta to a 2D axis).
  * @param opts Pointer options (invert/scale per-axis).


### PR DESCRIPTION
## Summary

- Add `Axis2D.keys(left, right, down, up)` shorthand for creating 2D axis bindings from four key codes
- Add `Axis2D.wasd()` and `Axis2D.arrows()` presets for the most common movement bindings
- Full form `Axis2D({ x: {...}, y: {...} })` remains available for custom configurations

## Changes

- `packages/input/src/domain/bindings/expr.ts` — Added `Axis2D` namespace with `keys`, `wasd`, and `arrows` static methods
- `packages/input/src/domain/bindings/expr.test.ts` — Added unit tests for all shorthands including equivalence with full form
- `apps/docs/guides/input-bindings.md` — Updated guide with shorthand examples and new "Axis2D shorthands" section

## Test plan

- [x] `Axis2D.keys()` creates correct axis bindings with proper key code mapping
- [x] `Axis2D.keys()` normalizes shorthand key codes (e.g., 'a' -> 'KeyA')
- [x] `Axis2D.wasd()` produces same structure as equivalent full form
- [x] `Axis2D.arrows()` produces same structure as equivalent full form
- [x] Full form `Axis2D({...})` still works alongside shorthands
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)