### PR TITLE
TICKET-119: Procedural Texture Factory (createTexture)

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-019-three-js-rendering-dx-pass/done/TICKET-119-procedural-texture-factory.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-019-three-js-rendering-dx-pass/done/TICKET-119-procedural-texture-factory.md
@@ -2,7 +2,7 @@
 id: TICKET-119
 epic: EPIC-019
 title: Procedural Texture Factory (createTexture)
-status: in-progress
+status: done
 priority: medium
 created: 2026-03-13
 updated: 2026-03-14
@@ -21,15 +21,15 @@ Design doc: `design-docs/approved/041-procedural-texture-factory.md`
 
 ## Acceptance Criteria
 
-- [ ] `createTexture(size, rasterize, options?)` creates a square DataTexture
-- [ ] `createTexture1D(width, rasterize, options?)` creates a 1×width DataTexture
-- [ ] Pixel callback returns `[R, G, B, A]` (0–255)
-- [ ] Options: wrap ('repeat'/'clamp'/'mirror'), filter ('linear'/'nearest'), format ('rgba'/'rgb')
-- [ ] String enums mapped to Three.js constants
-- [ ] Texture `needsUpdate` set automatically
-- [ ] JSDoc with examples
-- [ ] Unit tests for buffer creation, wrap/filter configuration
-- [ ] Documentation updated
+- [x] `createTexture(size, rasterize, options?)` creates a square DataTexture
+- [x] `createTexture1D(width, rasterize, options?)` creates a 1×width DataTexture
+- [x] Pixel callback returns `[R, G, B, A]` (0–255)
+- [x] Options: wrap ('repeat'/'clamp'/'mirror'), filter ('linear'/'nearest'), format ('rgba'/'rgb')
+- [x] String enums mapped to Three.js constants
+- [x] Texture `needsUpdate` set automatically
+- [x] JSDoc with examples
+- [x] Unit tests for buffer creation, wrap/filter configuration
+- [x] Documentation updated
 
 ## Notes
 

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-019-three-js-rendering-dx-pass/in-progress/TICKET-119-procedural-texture-factory.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-019-three-js-rendering-dx-pass/in-progress/TICKET-119-procedural-texture-factory.md
@@ -2,10 +2,10 @@
 id: TICKET-119
 epic: EPIC-019
 title: Procedural Texture Factory (createTexture)
-status: todo
+status: in-progress
 priority: medium
 created: 2026-03-13
-updated: 2026-03-13
+updated: 2026-03-14
 labels:
   - three
   - utility

--- a/apps/docs/api/three/src/README.md
+++ b/apps/docs/api/three/src/README.md
@@ -19,11 +19,19 @@
 - [InterpolatedPositionOptions](interfaces/InterpolatedPositionOptions.md)
 - [ScreenPoint](interfaces/ScreenPoint.md)
 - [StatsOverlayOptions](interfaces/StatsOverlayOptions.md)
+- [TextureOptions](interfaces/TextureOptions.md)
 - [ThreeOptions](interfaces/ThreeOptions.md)
 - [WorldPoint](interfaces/WorldPoint.md)
 
+## Type Aliases
+
+- [PixelFn](type-aliases/PixelFn.md)
+- [PixelFn1D](type-aliases/PixelFn1D.md)
+
 ## Functions
 
+- [createTexture](functions/createTexture.md)
+- [createTexture1D](functions/createTexture1D.md)
 - [installThree](functions/installThree.md)
 - [useInterpolatedPosition](functions/useInterpolatedPosition.md)
 - [useObject3D](functions/useObject3D.md)

--- a/apps/docs/api/three/src/functions/createTexture.md
+++ b/apps/docs/api/three/src/functions/createTexture.md
@@ -1,0 +1,48 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [three/src](../README.md) / createTexture
+
+# Function: createTexture()
+
+> **createTexture**(`size`: `number`, `rasterize`: [`PixelFn`](../type-aliases/PixelFn.md), `options?`: [`TextureOptions`](../interfaces/TextureOptions.md)): `THREE.DataTexture`
+
+Defined in: packages/three/src/public/createTexture.ts
+
+Create a procedural square `DataTexture` by rasterizing a per-pixel function.
+Handles buffer allocation, DataTexture creation, and filter/wrap setup.
+
+## Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `size` | `number` | Texture width and height in pixels (square). |
+| `rasterize` | [`PixelFn`](../type-aliases/PixelFn.md) | Called for each pixel; returns `[R, G, B, A]` (0–255). |
+| `options?` | [`TextureOptions`](../interfaces/TextureOptions.md) | Wrap mode, filter mode, and format. |
+
+## Returns
+
+A ready-to-use `DataTexture` with `needsUpdate` already set.
+
+## Examples
+
+```ts
+import { createTexture } from '@pulse-ts/three';
+
+const normalMap = createTexture(256, (x, y, size) => {
+    const cx = (x / size - 0.5) * 2;
+    const cy = (y / size - 0.5) * 2;
+    return [cx * 127 + 128, cy * 127 + 128, 255, 255];
+}, { wrap: 'repeat', filter: 'linear' });
+```
+
+```ts
+import { createTexture } from '@pulse-ts/three';
+
+const emissiveMap = createTexture(256, (x, y, size) => {
+    const spacing = 32;
+    const onLine = x % spacing <= 1 || y % spacing <= 1;
+    return onLine ? [50, 180, 220, 255] : [0, 0, 0, 255];
+}, { wrap: 'repeat', filter: 'linear' });
+```

--- a/apps/docs/api/three/src/functions/createTexture1D.md
+++ b/apps/docs/api/three/src/functions/createTexture1D.md
@@ -1,0 +1,37 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [three/src](../README.md) / createTexture1D
+
+# Function: createTexture1D()
+
+> **createTexture1D**(`width`: `number`, `rasterize`: [`PixelFn1D`](../type-aliases/PixelFn1D.md), `options?`: [`TextureOptions`](../interfaces/TextureOptions.md)): `THREE.DataTexture`
+
+Defined in: packages/three/src/public/createTexture.ts
+
+Create a 1D procedural `DataTexture` (height = 1) by rasterizing a per-pixel function.
+Useful for gradient textures and color ramps.
+
+## Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `width` | `number` | Texture width in pixels. |
+| `rasterize` | [`PixelFn1D`](../type-aliases/PixelFn1D.md) | Called for each pixel; returns `[R, G, B, A]` (0–255). |
+| `options?` | [`TextureOptions`](../interfaces/TextureOptions.md) | Wrap mode, filter mode, and format. |
+
+## Returns
+
+A 1-pixel-tall `DataTexture` with `needsUpdate` already set.
+
+## Example
+
+```ts
+import { createTexture1D } from '@pulse-ts/three';
+
+const gradient = createTexture1D(64, (x, width) => {
+    const t = x / width;
+    return [255 * t, 100, 255 * (1 - t), 255];
+});
+```

--- a/apps/docs/api/three/src/interfaces/TextureOptions.md
+++ b/apps/docs/api/three/src/interfaces/TextureOptions.md
@@ -1,0 +1,19 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [three/src](../README.md) / TextureOptions
+
+# Interface: TextureOptions
+
+Defined in: packages/three/src/public/createTexture.ts
+
+Options for procedural texture creation.
+
+## Properties
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `wrap?` | `'repeat'` \| `'clamp'` \| `'mirror'` | `'repeat'` | Wrap mode applied to both axes. |
+| `filter?` | `'linear'` \| `'nearest'` | `'linear'` | Texture filtering mode applied to both min and mag filters. |
+| `format?` | `'rgba'` \| `'rgb'` | `'rgba'` | Pixel format. |

--- a/apps/docs/api/three/src/type-aliases/PixelFn.md
+++ b/apps/docs/api/three/src/type-aliases/PixelFn.md
@@ -1,0 +1,13 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [three/src](../README.md) / PixelFn
+
+# Type Alias: PixelFn
+
+> **PixelFn** = (`x`: `number`, `y`: `number`, `size`: `number`) => [`number`, `number`, `number`, `number`]
+
+Defined in: packages/three/src/public/createTexture.ts
+
+Per-pixel rasterization callback. Returns `[R, G, B, A]` (0–255).

--- a/apps/docs/api/three/src/type-aliases/PixelFn1D.md
+++ b/apps/docs/api/three/src/type-aliases/PixelFn1D.md
@@ -1,0 +1,13 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [three/src](../README.md) / PixelFn1D
+
+# Type Alias: PixelFn1D
+
+> **PixelFn1D** = (`x`: `number`, `width`: `number`) => [`number`, `number`, `number`, `number`]
+
+Defined in: packages/three/src/public/createTexture.ts
+
+Per-pixel rasterization callback for 1D textures. Returns `[R, G, B, A]` (0–255).

--- a/packages/three/src/public/createTexture.test.ts
+++ b/packages/three/src/public/createTexture.test.ts
@@ -1,0 +1,191 @@
+/** @jest-environment jsdom */
+
+// ---------------------------------------------------------------------------
+// Lightweight Three.js mock — only what createTexture needs
+// ---------------------------------------------------------------------------
+jest.mock('three', () => ({
+    DataTexture: jest.fn().mockImplementation(function (
+        this: Record<string, unknown>,
+        data: Uint8Array,
+        width: number,
+        height: number,
+        format: number,
+    ) {
+        this.image = { data, width, height };
+        this.format = format;
+        this.wrapS = 0;
+        this.wrapT = 0;
+        this.minFilter = 0;
+        this.magFilter = 0;
+        this.needsUpdate = false;
+    }),
+    RepeatWrapping: 1000,
+    ClampToEdgeWrapping: 1001,
+    MirroredRepeatWrapping: 1002,
+    LinearFilter: 1006,
+    NearestFilter: 1003,
+    RGBAFormat: 1023,
+    RGBFormat: 1022,
+}));
+
+import { createTexture, createTexture1D } from './createTexture';
+
+// ---------------------------------------------------------------------------
+// createTexture (2D)
+// ---------------------------------------------------------------------------
+describe('createTexture', () => {
+    it('creates a square DataTexture with correct buffer size', () => {
+        const tex = createTexture(4, () => [255, 0, 0, 255]);
+        const img = (
+            tex as unknown as {
+                image: { data: Uint8Array; width: number; height: number };
+            }
+        ).image;
+
+        expect(img.width).toBe(4);
+        expect(img.height).toBe(4);
+        expect(img.data.length).toBe(4 * 4 * 4); // 4x4 pixels, 4 channels
+    });
+
+    it('writes pixel data from the rasterize callback', () => {
+        const tex = createTexture(2, (x, y) => [x * 100, y * 100, 50, 200]);
+        const data = (tex as unknown as { image: { data: Uint8Array } }).image
+            .data;
+
+        // pixel (0,0) => [0, 0, 50, 200]
+        expect(data[0]).toBe(0);
+        expect(data[1]).toBe(0);
+        expect(data[2]).toBe(50);
+        expect(data[3]).toBe(200);
+
+        // pixel (1,0) => [100, 0, 50, 200]
+        expect(data[4]).toBe(100);
+        expect(data[5]).toBe(0);
+        expect(data[6]).toBe(50);
+        expect(data[7]).toBe(200);
+
+        // pixel (0,1) => [0, 100, 50, 200]
+        expect(data[8]).toBe(0);
+        expect(data[9]).toBe(100);
+        expect(data[10]).toBe(50);
+        expect(data[11]).toBe(200);
+    });
+
+    it('passes size to the rasterize callback', () => {
+        const sizes: number[] = [];
+        createTexture(8, (_x, _y, size) => {
+            sizes.push(size);
+            return [0, 0, 0, 0];
+        });
+        expect(sizes.every((s) => s === 8)).toBe(true);
+        expect(sizes.length).toBe(64);
+    });
+
+    it('sets needsUpdate to true', () => {
+        const tex = createTexture(2, () => [0, 0, 0, 0]);
+        expect(tex.needsUpdate).toBe(true);
+    });
+
+    it('defaults to repeat wrap and linear filter', () => {
+        const tex = createTexture(2, () => [0, 0, 0, 0]);
+        expect(tex.wrapS).toBe(1000); // RepeatWrapping
+        expect(tex.wrapT).toBe(1000);
+        expect(tex.minFilter).toBe(1006); // LinearFilter
+        expect(tex.magFilter).toBe(1006);
+    });
+
+    it('maps clamp wrap mode', () => {
+        const tex = createTexture(2, () => [0, 0, 0, 0], { wrap: 'clamp' });
+        expect(tex.wrapS).toBe(1001); // ClampToEdgeWrapping
+        expect(tex.wrapT).toBe(1001);
+    });
+
+    it('maps mirror wrap mode', () => {
+        const tex = createTexture(2, () => [0, 0, 0, 0], { wrap: 'mirror' });
+        expect(tex.wrapS).toBe(1002); // MirroredRepeatWrapping
+        expect(tex.wrapT).toBe(1002);
+    });
+
+    it('maps nearest filter mode', () => {
+        const tex = createTexture(2, () => [0, 0, 0, 0], { filter: 'nearest' });
+        expect(tex.minFilter).toBe(1003); // NearestFilter
+        expect(tex.magFilter).toBe(1003);
+    });
+
+    it('supports rgb format with 3 channels', () => {
+        const tex = createTexture(2, () => [10, 20, 30, 255], {
+            format: 'rgb',
+        });
+        const img = (tex as unknown as { image: { data: Uint8Array } }).image;
+
+        expect(img.data.length).toBe(2 * 2 * 3); // 3 channels
+        // pixel (0,0) => [10, 20, 30]
+        expect(img.data[0]).toBe(10);
+        expect(img.data[1]).toBe(20);
+        expect(img.data[2]).toBe(30);
+        // no alpha byte at index 3 — next pixel starts there
+        expect(img.data[3]).toBe(10); // pixel (1,0) R
+    });
+
+    it('passes RGBFormat to DataTexture when format is rgb', () => {
+        const tex = createTexture(2, () => [0, 0, 0, 0], { format: 'rgb' });
+        expect((tex as unknown as { format: number }).format).toBe(1022); // RGBFormat
+    });
+});
+
+// ---------------------------------------------------------------------------
+// createTexture1D
+// ---------------------------------------------------------------------------
+describe('createTexture1D', () => {
+    it('creates a 1-pixel-tall DataTexture', () => {
+        const tex = createTexture1D(8, () => [0, 0, 0, 255]);
+        const img = (
+            tex as unknown as {
+                image: { data: Uint8Array; width: number; height: number };
+            }
+        ).image;
+
+        expect(img.width).toBe(8);
+        expect(img.height).toBe(1);
+        expect(img.data.length).toBe(8 * 4);
+    });
+
+    it('writes pixel data from the rasterize callback', () => {
+        const tex = createTexture1D(4, (x, width) => [x * 50, width, 0, 255]);
+        const data = (tex as unknown as { image: { data: Uint8Array } }).image
+            .data;
+
+        // pixel 0 => [0, 4, 0, 255]
+        expect(data[0]).toBe(0);
+        expect(data[1]).toBe(4);
+
+        // pixel 2 => [100, 4, 0, 255]
+        expect(data[8]).toBe(100);
+        expect(data[9]).toBe(4);
+    });
+
+    it('sets needsUpdate to true', () => {
+        const tex = createTexture1D(4, () => [0, 0, 0, 0]);
+        expect(tex.needsUpdate).toBe(true);
+    });
+
+    it('applies wrap and filter options', () => {
+        const tex = createTexture1D(4, () => [0, 0, 0, 0], {
+            wrap: 'mirror',
+            filter: 'nearest',
+        });
+        expect(tex.wrapS).toBe(1002);
+        expect(tex.wrapT).toBe(1002);
+        expect(tex.minFilter).toBe(1003);
+        expect(tex.magFilter).toBe(1003);
+    });
+
+    it('supports rgb format', () => {
+        const tex = createTexture1D(4, () => [10, 20, 30, 255], {
+            format: 'rgb',
+        });
+        const data = (tex as unknown as { image: { data: Uint8Array } }).image
+            .data;
+        expect(data.length).toBe(4 * 3);
+    });
+});

--- a/packages/three/src/public/createTexture.ts
+++ b/packages/three/src/public/createTexture.ts
@@ -1,0 +1,185 @@
+import * as THREE from 'three';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Per-pixel rasterization callback. Returns `[R, G, B, A]` (0–255). */
+export type PixelFn = (
+    x: number,
+    y: number,
+    size: number,
+) => [number, number, number, number];
+
+/** Per-pixel rasterization callback for 1D textures. Returns `[R, G, B, A]` (0–255). */
+export type PixelFn1D = (
+    x: number,
+    width: number,
+) => [number, number, number, number];
+
+/** Options for procedural texture creation. */
+export interface TextureOptions {
+    /**
+     * Wrap mode applied to both axes.
+     * @default 'repeat'
+     */
+    wrap?: 'repeat' | 'clamp' | 'mirror';
+    /**
+     * Texture filtering mode applied to both min and mag filters.
+     * @default 'linear'
+     */
+    filter?: 'linear' | 'nearest';
+    /**
+     * Pixel format.
+     * @default 'rgba'
+     */
+    format?: 'rgba' | 'rgb';
+}
+
+// ---------------------------------------------------------------------------
+// Enum mappings
+// ---------------------------------------------------------------------------
+
+const WRAP_MAP: Record<NonNullable<TextureOptions['wrap']>, THREE.Wrapping> = {
+    repeat: THREE.RepeatWrapping,
+    clamp: THREE.ClampToEdgeWrapping,
+    mirror: THREE.MirroredRepeatWrapping,
+};
+
+const FILTER_MAP: Record<
+    NonNullable<TextureOptions['filter']>,
+    THREE.TextureFilter
+> = {
+    linear: THREE.LinearFilter,
+    nearest: THREE.NearestFilter,
+};
+
+const FORMAT_MAP: Record<
+    NonNullable<TextureOptions['format']>,
+    THREE.PixelFormat
+> = {
+    rgba: THREE.RGBAFormat,
+    rgb: THREE.RGBFormat,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function channelsFor(format: NonNullable<TextureOptions['format']>): number {
+    return format === 'rgb' ? 3 : 4;
+}
+
+function applyOptions(
+    texture: THREE.DataTexture,
+    options: TextureOptions,
+): void {
+    const wrap = options.wrap ?? 'repeat';
+    const filter = options.filter ?? 'linear';
+
+    texture.wrapS = WRAP_MAP[wrap];
+    texture.wrapT = WRAP_MAP[wrap];
+    texture.minFilter = FILTER_MAP[filter];
+    texture.magFilter = FILTER_MAP[filter];
+    texture.needsUpdate = true;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a procedural square `DataTexture` by rasterizing a per-pixel function.
+ * Handles buffer allocation, DataTexture creation, and filter/wrap setup.
+ *
+ * @param size - Texture width and height in pixels (square).
+ * @param rasterize - Called for each pixel; returns `[R, G, B, A]` (0–255).
+ * @param options - Wrap mode, filter mode, and format.
+ * @returns A ready-to-use `DataTexture` with `needsUpdate` already set.
+ *
+ * @example
+ * ```ts
+ * const normalMap = createTexture(256, (x, y, size) => {
+ *     const cx = (x / size - 0.5) * 2;
+ *     const cy = (y / size - 0.5) * 2;
+ *     return [cx * 127 + 128, cy * 127 + 128, 255, 255];
+ * }, { wrap: 'repeat', filter: 'linear' });
+ * ```
+ *
+ * @example
+ * ```ts
+ * const emissiveMap = createTexture(256, (x, y, size) => {
+ *     const spacing = 32;
+ *     const onLine = x % spacing <= 1 || y % spacing <= 1;
+ *     return onLine ? [50, 180, 220, 255] : [0, 0, 0, 255];
+ * }, { wrap: 'repeat', filter: 'linear' });
+ * ```
+ */
+export function createTexture(
+    size: number,
+    rasterize: PixelFn,
+    options: TextureOptions = {},
+): THREE.DataTexture {
+    const fmt = options.format ?? 'rgba';
+    const channels = channelsFor(fmt);
+    const data = new Uint8Array(size * size * channels);
+
+    for (let y = 0; y < size; y++) {
+        for (let x = 0; x < size; x++) {
+            const pixel = rasterize(x, y, size);
+            const i = (y * size + x) * channels;
+            data[i] = pixel[0];
+            data[i + 1] = pixel[1];
+            data[i + 2] = pixel[2];
+            if (channels === 4) {
+                data[i + 3] = pixel[3];
+            }
+        }
+    }
+
+    const texture = new THREE.DataTexture(data, size, size, FORMAT_MAP[fmt]);
+    applyOptions(texture, options);
+    return texture;
+}
+
+/**
+ * Create a 1D procedural `DataTexture` (height = 1) by rasterizing a per-pixel function.
+ * Useful for gradient textures and color ramps.
+ *
+ * @param width - Texture width in pixels.
+ * @param rasterize - Called for each pixel; returns `[R, G, B, A]` (0–255).
+ * @param options - Wrap mode, filter mode, and format.
+ * @returns A 1-pixel-tall `DataTexture` with `needsUpdate` already set.
+ *
+ * @example
+ * ```ts
+ * const gradient = createTexture1D(64, (x, width) => {
+ *     const t = x / width;
+ *     return [255 * t, 100, 255 * (1 - t), 255];
+ * });
+ * ```
+ */
+export function createTexture1D(
+    width: number,
+    rasterize: PixelFn1D,
+    options: TextureOptions = {},
+): THREE.DataTexture {
+    const fmt = options.format ?? 'rgba';
+    const channels = channelsFor(fmt);
+    const data = new Uint8Array(width * channels);
+
+    for (let x = 0; x < width; x++) {
+        const pixel = rasterize(x, width);
+        const i = x * channels;
+        data[i] = pixel[0];
+        data[i + 1] = pixel[1];
+        data[i + 2] = pixel[2];
+        if (channels === 4) {
+            data[i + 3] = pixel[3];
+        }
+    }
+
+    const texture = new THREE.DataTexture(data, width, 1, FORMAT_MAP[fmt]);
+    applyOptions(texture, options);
+    return texture;
+}

--- a/packages/three/src/public/index.ts
+++ b/packages/three/src/public/index.ts
@@ -52,3 +52,10 @@ export {
     StatsOverlaySystem,
     type StatsOverlayOptions,
 } from '../domain/systems/statsOverlay';
+export {
+    createTexture,
+    createTexture1D,
+    type PixelFn,
+    type PixelFn1D,
+    type TextureOptions,
+} from './createTexture';


### PR DESCRIPTION
## Summary
- Add `createTexture(size, rasterize, options?)` for generating square `DataTexture` from per-pixel callbacks
- Add `createTexture1D(width, rasterize, options?)` for 1D gradient textures
- String enum options for wrap (`repeat`/`clamp`/`mirror`), filter (`linear`/`nearest`), and format (`rgba`/`rgb`)
- Automatic `needsUpdate` and buffer allocation

## Test plan
- [x] 15 unit tests covering buffer creation, pixel data, callback args, wrap/filter/format mapping
- [x] Tests pass: `npm test -w packages/three --silent`
- [x] Lint passes: `npx nx lint three`

🤖 Generated with [Claude Code](https://claude.com/claude-code)