### PR TITLE
TICKET-118: useCustomMesh Hook

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-019-three-js-rendering-dx-pass/done/TICKET-118-use-custom-mesh.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-019-three-js-rendering-dx-pass/done/TICKET-118-use-custom-mesh.md
@@ -2,7 +2,7 @@
 id: TICKET-118
 epic: EPIC-019
 title: useCustomMesh Hook
-status: in-progress
+status: done
 priority: high
 created: 2026-03-13
 updated: 2026-03-14
@@ -22,17 +22,18 @@ Design doc: `design-docs/approved/038-use-custom-mesh.md`
 
 ## Acceptance Criteria
 
-- [ ] `useCustomMesh({ geometry, material, type? })` creates custom geometry + material
-- [ ] Factory functions for geometry and material (hook owns lifecycle)
-- [ ] Automatic disposal of geometry and material on node destroy
-- [ ] Type parameter: 'mesh' (default), 'points', 'line', 'lineSegments'
-- [ ] Shadow options (castShadow, receiveShadow) for mesh type only
-- [ ] Returns `{ root, object, material, geometry }` for runtime manipulation
-- [ ] JSDoc with examples
-- [ ] Unit tests for creation, disposal, all object types
-- [ ] Documentation updated
+- [x] `useCustomMesh({ geometry, material, type? })` creates custom geometry + material
+- [x] Factory functions for geometry and material (hook owns lifecycle)
+- [x] Automatic disposal of geometry and material on node destroy
+- [x] Type parameter: 'mesh' (default), 'points', 'line', 'lineSegments'
+- [x] Shadow options (castShadow, receiveShadow) for mesh type only
+- [x] Returns `{ root, object, material, geometry }` for runtime manipulation
+- [x] JSDoc with examples
+- [x] Unit tests for creation, disposal, all object types
+- [x] Documentation updated
 
 ## Notes
 
 - **2026-03-13**: Ticket created from approved design doc #38.
 - **2026-03-14**: Starting implementation
+- **2026-03-14**: Implementation complete

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-019-three-js-rendering-dx-pass/in-progress/TICKET-118-use-custom-mesh.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-019-three-js-rendering-dx-pass/in-progress/TICKET-118-use-custom-mesh.md
@@ -2,10 +2,11 @@
 id: TICKET-118
 epic: EPIC-019
 title: useCustomMesh Hook
-status: todo
+status: in-progress
 priority: high
 created: 2026-03-13
-updated: 2026-03-13
+updated: 2026-03-14
+branch: ticket-118-use-custom-mesh
 labels:
   - three
   - dx
@@ -34,3 +35,4 @@ Design doc: `design-docs/approved/038-use-custom-mesh.md`
 ## Notes
 
 - **2026-03-13**: Ticket created from approved design doc #38.
+- **2026-03-14**: Starting implementation

--- a/apps/docs/api/three/src/README.md
+++ b/apps/docs/api/three/src/README.md
@@ -16,6 +16,8 @@
 
 ## Interfaces
 
+- [CustomMeshOptions](interfaces/CustomMeshOptions.md)
+- [CustomMeshResult](interfaces/CustomMeshResult.md)
 - [InterpolatedPositionOptions](interfaces/InterpolatedPositionOptions.md)
 - [ScreenPoint](interfaces/ScreenPoint.md)
 - [StatsOverlayOptions](interfaces/StatsOverlayOptions.md)
@@ -25,6 +27,7 @@
 ## Functions
 
 - [installThree](functions/installThree.md)
+- [useCustomMesh](functions/useCustomMesh.md)
 - [useInterpolatedPosition](functions/useInterpolatedPosition.md)
 - [useObject3D](functions/useObject3D.md)
 - [useScreenProjection](functions/useScreenProjection.md)

--- a/apps/docs/api/three/src/functions/useCustomMesh.md
+++ b/apps/docs/api/three/src/functions/useCustomMesh.md
@@ -1,0 +1,68 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [three/src](../README.md) / useCustomMesh
+
+# Function: useCustomMesh()
+
+> **useCustomMesh**(`options`): [`CustomMeshResult`](../interfaces/CustomMeshResult.md)
+
+Defined in: packages/three/src/public/useCustomMesh.ts
+
+Creates a custom geometry + material combination with full lifecycle management.
+
+Geometry and material are created from the provided factory functions and
+disposed automatically when the node is destroyed. The resulting object is
+added to and removed from the scene graph via `useThreeRoot` / `useObject3D`.
+
+## Parameters
+
+### options
+
+[`CustomMeshOptions`](../interfaces/CustomMeshOptions.md)
+
+Geometry factory, material factory, object type, and shadow flags.
+
+## Returns
+
+[`CustomMeshResult`](../interfaces/CustomMeshResult.md)
+
+References to the created `{ root, object, material, geometry }`.
+
+## Examples
+
+```ts
+import * as THREE from 'three';
+import { useCustomMesh } from '@pulse-ts/three';
+
+// Custom Points (starfield)
+function StarfieldNode() {
+  const { root, material } = useCustomMesh({
+    geometry: () => {
+      const geo = new THREE.BufferGeometry();
+      const positions = new Float32Array(1000 * 3);
+      // ... fill positions
+      geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+      return geo;
+    },
+    material: () => new THREE.PointsMaterial({ size: 0.1 }),
+    type: 'points',
+  });
+}
+```
+
+```ts
+import * as THREE from 'three';
+import { useCustomMesh } from '@pulse-ts/three';
+
+// Procedural mesh with shadows
+function TerrainNode() {
+  const { root } = useCustomMesh({
+    geometry: () => new THREE.PlaneGeometry(100, 100, 64, 64),
+    material: () => new THREE.MeshStandardMaterial({ color: 0x228b22 }),
+    castShadow: true,
+    receiveShadow: true,
+  });
+}
+```

--- a/apps/docs/api/three/src/interfaces/CustomMeshOptions.md
+++ b/apps/docs/api/three/src/interfaces/CustomMeshOptions.md
@@ -1,0 +1,55 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [three/src](../README.md) / CustomMeshOptions
+
+# Interface: CustomMeshOptions
+
+Defined in: packages/three/src/public/useCustomMesh.ts
+
+Configuration for `useCustomMesh`.
+
+## Properties
+
+### geometry
+
+> **geometry**: () => `BufferGeometry`
+
+Factory function that creates the geometry. The hook owns disposal.
+
+### material
+
+> **material**: () => `Material`
+
+Factory function that creates the material. The hook owns disposal.
+
+### type?
+
+> `optional` **type**: `'mesh'` \| `'points'` \| `'line'` \| `'lineSegments'`
+
+The type of Three.js object to create.
+
+#### Default Value
+
+`'mesh'`
+
+### castShadow?
+
+> `optional` **castShadow**: `boolean`
+
+Whether the object casts shadows. Only applies when `type` is `'mesh'`.
+
+#### Default Value
+
+`false`
+
+### receiveShadow?
+
+> `optional` **receiveShadow**: `boolean`
+
+Whether the object receives shadows. Only applies when `type` is `'mesh'`.
+
+#### Default Value
+
+`false`

--- a/apps/docs/api/three/src/interfaces/CustomMeshResult.md
+++ b/apps/docs/api/three/src/interfaces/CustomMeshResult.md
@@ -1,0 +1,37 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [three/src](../README.md) / CustomMeshResult
+
+# Interface: CustomMeshResult
+
+Defined in: packages/three/src/public/useCustomMesh.ts
+
+Object returned by `useCustomMesh`.
+
+## Properties
+
+### root
+
+> **root**: `Object3D`
+
+The Object3D root managed by `useThreeRoot`.
+
+### object
+
+> **object**: `Mesh` \| `Points` \| `Line` \| `LineSegments`
+
+The created object (Mesh, Points, Line, or LineSegments).
+
+### material
+
+> **material**: `Material`
+
+The material instance created by the factory.
+
+### geometry
+
+> **geometry**: `BufferGeometry`
+
+The geometry instance created by the factory.

--- a/packages/three/src/public/index.ts
+++ b/packages/three/src/public/index.ts
@@ -24,6 +24,11 @@ export {
     type UseMeshResult,
 } from './useMesh';
 export {
+    useCustomMesh,
+    type CustomMeshOptions,
+    type CustomMeshResult,
+} from './useCustomMesh';
+export {
     useFollowCamera,
     type FollowCameraOptions,
     type FollowCameraResult,

--- a/packages/three/src/public/useCustomMesh.test.ts
+++ b/packages/three/src/public/useCustomMesh.test.ts
@@ -1,0 +1,378 @@
+/** @jest-environment jsdom */
+import { World, Node } from '@pulse-ts/core';
+import { ThreeService } from '../domain/services/Three';
+import { useCustomMesh } from './useCustomMesh';
+import type { CustomMeshResult } from './useCustomMesh';
+
+// ---------------------------------------------------------------------------
+// Three.js mock — matches useMesh.test.ts pattern, adds Points/Line/LineSegments
+// ---------------------------------------------------------------------------
+jest.mock('three', () => {
+    class Vector3 {
+        x = 0;
+        y = 0;
+        z = 0;
+        set(x: number, y: number, z: number) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+        copy(v: Vector3) {
+            this.x = v.x;
+            this.y = v.y;
+            this.z = v.z;
+        }
+        multiply(v: Vector3) {
+            this.x *= v.x;
+            this.y *= v.y;
+            this.z *= v.z;
+        }
+    }
+    class Quaternion {
+        x = 0;
+        y = 0;
+        z = 0;
+        w = 1;
+        set(x: number, y: number, z: number, w: number) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.w = w;
+        }
+        copy(q: Quaternion) {
+            this.x = q.x;
+            this.y = q.y;
+            this.z = q.z;
+            this.w = q.w;
+        }
+    }
+    class Object3D {
+        parent: Object3D | null = null;
+        children: Object3D[] = [];
+        position = new Vector3();
+        quaternion = new Quaternion();
+        scale = new Vector3(1, 1, 1);
+        visible = true;
+        castShadow = false;
+        receiveShadow = false;
+        matrixAutoUpdate = true;
+        matrixWorldNeedsUpdate = false as boolean;
+        add(child: Object3D) {
+            if (child.parent) child.parent.remove(child);
+            this.children.push(child);
+            child.parent = this;
+        }
+        remove(child: Object3D) {
+            const i = this.children.indexOf(child);
+            if (i >= 0) this.children.splice(i, 1);
+            if (child.parent === this) child.parent = null;
+        }
+        updateMatrix() {}
+    }
+    class Group extends Object3D {}
+    class Scene extends Object3D {}
+    class Matrix4 {
+        elements = Array.from({ length: 16 }, () => 0);
+    }
+    class PerspectiveCamera extends Object3D {
+        aspect = 1;
+        projectionMatrix = new Matrix4();
+        matrixWorldInverse = new Matrix4();
+        updateProjectionMatrix() {}
+        updateMatrixWorld() {}
+    }
+    class Color {
+        constructor() {}
+    }
+    class WebGLRenderer {
+        domElement: HTMLCanvasElement;
+        setPixelRatio = jest.fn();
+        setSize = jest.fn();
+        render = jest.fn();
+        constructor(opts: { canvas: HTMLCanvasElement }) {
+            this.domElement = opts.canvas;
+        }
+    }
+
+    class BufferGeometry {
+        _type = 'BufferGeometry';
+        dispose = jest.fn();
+    }
+
+    class Material {
+        _type = 'Material';
+        dispose = jest.fn();
+    }
+
+    class Mesh extends Object3D {
+        _objectType = 'Mesh';
+        geometry: BufferGeometry;
+        material: Material;
+        constructor(geometry: BufferGeometry, material: Material) {
+            super();
+            this.geometry = geometry;
+            this.material = material;
+        }
+    }
+
+    class Points extends Object3D {
+        _objectType = 'Points';
+        geometry: BufferGeometry;
+        material: Material;
+        constructor(geometry: BufferGeometry, material: Material) {
+            super();
+            this.geometry = geometry;
+            this.material = material;
+        }
+    }
+
+    class Line extends Object3D {
+        _objectType = 'Line';
+        geometry: BufferGeometry;
+        material: Material;
+        constructor(geometry: BufferGeometry, material: Material) {
+            super();
+            this.geometry = geometry;
+            this.material = material;
+        }
+    }
+
+    class LineSegments extends Object3D {
+        _objectType = 'LineSegments';
+        geometry: BufferGeometry;
+        material: Material;
+        constructor(geometry: BufferGeometry, material: Material) {
+            super();
+            this.geometry = geometry;
+            this.material = material;
+        }
+    }
+
+    return {
+        Vector3,
+        Quaternion,
+        Object3D,
+        Group,
+        Scene,
+        Matrix4,
+        PerspectiveCamera,
+        Color,
+        WebGLRenderer,
+        BufferGeometry,
+        Material,
+        Mesh,
+        Points,
+        Line,
+        LineSegments,
+    };
+});
+
+function createCanvas() {
+    const canvas = document.createElement('canvas');
+    Object.defineProperty(canvas, 'clientWidth', { value: 320 });
+    Object.defineProperty(canvas, 'clientHeight', { value: 200 });
+    return canvas as HTMLCanvasElement;
+}
+
+beforeAll(() => {
+    (global as any).ResizeObserver = class {
+        observe() {}
+        disconnect() {}
+    };
+});
+
+/** Helper: mounts a FC that calls useCustomMesh and captures the result. */
+function mountUseCustomMesh(
+    world: World,
+    ...args: Parameters<typeof useCustomMesh>
+): { result: CustomMeshResult; node: Node } {
+    let result!: CustomMeshResult;
+    function TestFC() {
+        result = useCustomMesh(...args);
+    }
+    const node = world.mount(TestFC);
+    return { result, node };
+}
+
+describe('useCustomMesh', () => {
+    let world: World;
+    let svc: ThreeService;
+
+    beforeEach(() => {
+        world = new World();
+        svc = world.provideService(
+            new ThreeService({ canvas: createCanvas(), enableCulling: false }),
+        );
+    });
+
+    // ----- Object creation -----
+
+    test('creates a Mesh by default', () => {
+        const { result } = mountUseCustomMesh(world, {
+            geometry: () => new (jest.requireMock('three').BufferGeometry)(),
+            material: () => new (jest.requireMock('three').Material)(),
+        });
+        expect((result.object as any)._objectType).toBe('Mesh');
+    });
+
+    test('creates a Mesh when type is "mesh"', () => {
+        const { result } = mountUseCustomMesh(world, {
+            geometry: () => new (jest.requireMock('three').BufferGeometry)(),
+            material: () => new (jest.requireMock('three').Material)(),
+            type: 'mesh',
+        });
+        expect((result.object as any)._objectType).toBe('Mesh');
+    });
+
+    test('creates Points when type is "points"', () => {
+        const { result } = mountUseCustomMesh(world, {
+            geometry: () => new (jest.requireMock('three').BufferGeometry)(),
+            material: () => new (jest.requireMock('three').Material)(),
+            type: 'points',
+        });
+        expect((result.object as any)._objectType).toBe('Points');
+    });
+
+    test('creates a Line when type is "line"', () => {
+        const { result } = mountUseCustomMesh(world, {
+            geometry: () => new (jest.requireMock('three').BufferGeometry)(),
+            material: () => new (jest.requireMock('three').Material)(),
+            type: 'line',
+        });
+        expect((result.object as any)._objectType).toBe('Line');
+    });
+
+    test('creates LineSegments when type is "lineSegments"', () => {
+        const { result } = mountUseCustomMesh(world, {
+            geometry: () => new (jest.requireMock('three').BufferGeometry)(),
+            material: () => new (jest.requireMock('three').Material)(),
+            type: 'lineSegments',
+        });
+        expect((result.object as any)._objectType).toBe('LineSegments');
+    });
+
+    // ----- Factory invocation -----
+
+    test('invokes geometry and material factory functions', () => {
+        const geoFactory = jest.fn(
+            () => new (jest.requireMock('three').BufferGeometry)(),
+        );
+        const matFactory = jest.fn(
+            () => new (jest.requireMock('three').Material)(),
+        );
+
+        mountUseCustomMesh(world, {
+            geometry: geoFactory,
+            material: matFactory,
+        });
+
+        expect(geoFactory).toHaveBeenCalledTimes(1);
+        expect(matFactory).toHaveBeenCalledTimes(1);
+    });
+
+    // ----- Return values -----
+
+    test('returns root, object, material, and geometry', () => {
+        const { result } = mountUseCustomMesh(world, {
+            geometry: () => new (jest.requireMock('three').BufferGeometry)(),
+            material: () => new (jest.requireMock('three').Material)(),
+        });
+        expect(result.root).toBeDefined();
+        expect(result.object).toBeDefined();
+        expect(result.material).toBeDefined();
+        expect(result.geometry).toBeDefined();
+    });
+
+    // ----- Shadow options -----
+
+    test('applies castShadow and receiveShadow for mesh type', () => {
+        const { result } = mountUseCustomMesh(world, {
+            geometry: () => new (jest.requireMock('three').BufferGeometry)(),
+            material: () => new (jest.requireMock('three').Material)(),
+            type: 'mesh',
+            castShadow: true,
+            receiveShadow: true,
+        });
+        expect(result.object.castShadow).toBe(true);
+        expect(result.object.receiveShadow).toBe(true);
+    });
+
+    test('shadow options default to false for mesh type', () => {
+        const { result } = mountUseCustomMesh(world, {
+            geometry: () => new (jest.requireMock('three').BufferGeometry)(),
+            material: () => new (jest.requireMock('three').Material)(),
+            type: 'mesh',
+        });
+        expect(result.object.castShadow).toBe(false);
+        expect(result.object.receiveShadow).toBe(false);
+    });
+
+    test('shadow options are ignored for points type', () => {
+        const { result } = mountUseCustomMesh(world, {
+            geometry: () => new (jest.requireMock('three').BufferGeometry)(),
+            material: () => new (jest.requireMock('three').Material)(),
+            type: 'points',
+            castShadow: true,
+            receiveShadow: true,
+        });
+        // Points inherit Object3D defaults (false)
+        expect(result.object.castShadow).toBe(false);
+        expect(result.object.receiveShadow).toBe(false);
+    });
+
+    test('shadow options are ignored for line type', () => {
+        const { result } = mountUseCustomMesh(world, {
+            geometry: () => new (jest.requireMock('three').BufferGeometry)(),
+            material: () => new (jest.requireMock('three').Material)(),
+            type: 'line',
+            castShadow: true,
+            receiveShadow: true,
+        });
+        expect(result.object.castShadow).toBe(false);
+        expect(result.object.receiveShadow).toBe(false);
+    });
+
+    // ----- Scene graph integration -----
+
+    test('returns a root parented to the scene', () => {
+        const { result } = mountUseCustomMesh(world, {
+            geometry: () => new (jest.requireMock('three').BufferGeometry)(),
+            material: () => new (jest.requireMock('three').Material)(),
+        });
+        expect(result.root.parent).toBe(svc.scene);
+    });
+
+    test('object is a child of the root', () => {
+        const { result } = mountUseCustomMesh(world, {
+            geometry: () => new (jest.requireMock('three').BufferGeometry)(),
+            material: () => new (jest.requireMock('three').Material)(),
+        });
+        expect(result.root.children).toContain(result.object);
+    });
+
+    // ----- Disposal -----
+
+    test('destroying the node removes the root from the scene', () => {
+        const { result, node } = mountUseCustomMesh(world, {
+            geometry: () => new (jest.requireMock('three').BufferGeometry)(),
+            material: () => new (jest.requireMock('three').Material)(),
+        });
+        expect(svc.scene.children).toContain(result.root);
+
+        node.destroy();
+
+        expect(svc.scene.children).not.toContain(result.root);
+    });
+
+    test('destroying the node disposes geometry and material', () => {
+        const { result, node } = mountUseCustomMesh(world, {
+            geometry: () => new (jest.requireMock('three').BufferGeometry)(),
+            material: () => new (jest.requireMock('three').Material)(),
+        });
+
+        node.destroy();
+
+        expect(result.geometry.dispose).toHaveBeenCalledTimes(1);
+        expect(result.material.dispose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/three/src/public/useCustomMesh.ts
+++ b/packages/three/src/public/useCustomMesh.ts
@@ -1,0 +1,139 @@
+import * as THREE from 'three';
+import { __fcCurrent } from '@pulse-ts/core';
+import { useThreeRoot, useObject3D } from './hooks';
+
+// ---------------------------------------------------------------------------
+// Option / result types
+// ---------------------------------------------------------------------------
+
+/** Configuration for {@link useCustomMesh}. */
+export interface CustomMeshOptions {
+    /** Factory function that creates the geometry. The hook owns disposal. */
+    geometry: () => THREE.BufferGeometry;
+    /** Factory function that creates the material. The hook owns disposal. */
+    material: () => THREE.Material;
+    /**
+     * The type of Three.js object to create.
+     * @default 'mesh'
+     */
+    type?: 'mesh' | 'points' | 'line' | 'lineSegments';
+    /**
+     * Whether the object casts shadows. Only applies when `type` is `'mesh'`.
+     * @default false
+     */
+    castShadow?: boolean;
+    /**
+     * Whether the object receives shadows. Only applies when `type` is `'mesh'`.
+     * @default false
+     */
+    receiveShadow?: boolean;
+}
+
+/** Object returned by {@link useCustomMesh}. */
+export interface CustomMeshResult {
+    /** The Object3D root managed by `useThreeRoot`. */
+    root: THREE.Object3D;
+    /** The created object (Mesh, Points, Line, or LineSegments). */
+    object: THREE.Mesh | THREE.Points | THREE.Line | THREE.LineSegments;
+    /** The material instance created by the factory. */
+    material: THREE.Material;
+    /** The geometry instance created by the factory. */
+    geometry: THREE.BufferGeometry;
+}
+
+// ---------------------------------------------------------------------------
+// Object factory
+// ---------------------------------------------------------------------------
+
+function createObject(
+    type: CustomMeshOptions['type'],
+    geometry: THREE.BufferGeometry,
+    material: THREE.Material,
+): THREE.Mesh | THREE.Points | THREE.Line | THREE.LineSegments {
+    switch (type) {
+        case 'points':
+            return new THREE.Points(geometry, material);
+        case 'line':
+            return new THREE.Line(geometry, material);
+        case 'lineSegments':
+            return new THREE.LineSegments(geometry, material);
+        case 'mesh':
+        default:
+            return new THREE.Mesh(geometry, material);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a custom geometry + material combination with full lifecycle management.
+ *
+ * Geometry and material are created from the provided factory functions and
+ * disposed automatically when the node is destroyed. The resulting object is
+ * added to and removed from the scene graph via `useThreeRoot` / `useObject3D`.
+ *
+ * @param options - Geometry factory, material factory, object type, and shadow flags.
+ * @returns References to the created `{ root, object, material, geometry }`.
+ *
+ * @example
+ * ```ts
+ * import * as THREE from 'three';
+ * import { useCustomMesh } from '@pulse-ts/three';
+ *
+ * // Custom Points (starfield)
+ * function StarfieldNode() {
+ *   const { root, material } = useCustomMesh({
+ *     geometry: () => {
+ *       const geo = new THREE.BufferGeometry();
+ *       const positions = new Float32Array(1000 * 3);
+ *       // ... fill positions
+ *       geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+ *       return geo;
+ *     },
+ *     material: () => new THREE.PointsMaterial({ size: 0.1 }),
+ *     type: 'points',
+ *   });
+ * }
+ * ```
+ *
+ * @example
+ * ```ts
+ * import * as THREE from 'three';
+ * import { useCustomMesh } from '@pulse-ts/three';
+ *
+ * // Procedural mesh with shadows
+ * function TerrainNode() {
+ *   const { root } = useCustomMesh({
+ *     geometry: () => new THREE.PlaneGeometry(100, 100, 64, 64),
+ *     material: () => new THREE.MeshStandardMaterial({ color: 0x228b22 }),
+ *     castShadow: true,
+ *     receiveShadow: true,
+ *   });
+ * }
+ * ```
+ */
+export function useCustomMesh(options: CustomMeshOptions): CustomMeshResult {
+    const root = useThreeRoot();
+    const { destroy } = __fcCurrent();
+
+    const geometry = options.geometry();
+    const material = options.material();
+
+    const object = createObject(options.type, geometry, material);
+
+    if (options.type === 'mesh' || options.type === undefined) {
+        (object as THREE.Mesh).castShadow = options.castShadow ?? false;
+        (object as THREE.Mesh).receiveShadow = options.receiveShadow ?? false;
+    }
+
+    useObject3D(object);
+
+    destroy?.push(() => {
+        geometry.dispose();
+        material.dispose();
+    });
+
+    return { root, object, material, geometry };
+}


### PR DESCRIPTION
## Summary

- Implements `useCustomMesh` hook in `@pulse-ts/three` that accepts user-provided geometry and material factory functions
- Supports `Mesh`, `Points`, `Line`, and `LineSegments` object types via `type` parameter
- Automatic disposal of geometry and material on node destroy; shadow config for mesh type only
- Returns `{ root, object, material, geometry }` for runtime manipulation

## Test plan

- [x] Unit tests for all 4 object types (mesh, points, line, lineSegments)
- [x] Tests for factory function invocation
- [x] Tests for shadow options (applied for mesh, ignored for others)
- [x] Tests for scene graph integration (root parented to scene, object child of root)
- [x] Tests for disposal (geometry.dispose + material.dispose called on node destroy)
- [x] All 79 tests pass (`npm test -w packages/three`)
- [x] Lint passes (`npx nx lint three`)

## Files changed

- `packages/three/src/public/useCustomMesh.ts` — hook implementation
- `packages/three/src/public/useCustomMesh.test.ts` — 15 unit tests
- `packages/three/src/public/index.ts` — re-export
- `apps/docs/api/three/src/` — API documentation