### PR TITLE
TICKET-117: useMesh Material Extensions

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-019-three-js-rendering-dx-pass/done/TICKET-117-use-mesh-material-extensions.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-019-three-js-rendering-dx-pass/done/TICKET-117-use-mesh-material-extensions.md
@@ -2,7 +2,7 @@
 id: TICKET-117
 epic: EPIC-019
 title: useMesh Material Extensions
-status: in-progress
+status: done
 priority: high
 created: 2026-03-13
 updated: 2026-03-14
@@ -23,17 +23,18 @@ Design doc: `design-docs/approved/033-use-mesh-material-extensions.md`
 
 ## Acceptance Criteria
 
-- [ ] Texture map options: map, normalMap, normalScale, emissiveMap, roughnessMap, metalnessMap, alphaMap, envMap
-- [ ] Render state options: side ('front'/'back'/'double'), depthWrite, blending ('normal'/'additive'/'multiply')
-- [ ] Material type option: materialType ('standard'/'basic'/'phong')
-- [ ] String enums for Three.js constants (not raw THREE.* values)
-- [ ] normalScale as `[number, number]` tuple
-- [ ] Backward compatible — all new options are optional
-- [ ] JSDoc with examples
-- [ ] Unit tests for new material options
-- [ ] Documentation updated
+- [x] Texture map options: map, normalMap, normalScale, emissiveMap, roughnessMap, metalnessMap, alphaMap, envMap
+- [x] Render state options: side ('front'/'back'/'double'), depthWrite, blending ('normal'/'additive'/'multiply')
+- [x] Material type option: materialType ('standard'/'basic'/'phong')
+- [x] String enums for Three.js constants (not raw THREE.* values)
+- [x] normalScale as `[number, number]` tuple
+- [x] Backward compatible — all new options are optional
+- [x] JSDoc with examples
+- [x] Unit tests for new material options
+- [x] Documentation updated
 
 ## Notes
 
 - **2026-03-13**: Ticket created from approved design doc #33.
 - **2026-03-14**: Starting implementation
+- **2026-03-14**: Implementation complete

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-019-three-js-rendering-dx-pass/in-progress/TICKET-117-use-mesh-material-extensions.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-019-three-js-rendering-dx-pass/in-progress/TICKET-117-use-mesh-material-extensions.md
@@ -2,10 +2,11 @@
 id: TICKET-117
 epic: EPIC-019
 title: useMesh Material Extensions
-status: todo
+status: in-progress
 priority: high
 created: 2026-03-13
-updated: 2026-03-13
+updated: 2026-03-14
+branch: ticket-117-use-mesh-material-extensions
 labels:
   - three
   - dx
@@ -35,3 +36,4 @@ Design doc: `design-docs/approved/033-use-mesh-material-extensions.md`
 ## Notes
 
 - **2026-03-13**: Ticket created from approved design doc #33.
+- **2026-03-14**: Starting implementation

--- a/apps/docs/api/three/src/README.md
+++ b/apps/docs/api/three/src/README.md
@@ -19,14 +19,18 @@
 - [CustomMeshOptions](interfaces/CustomMeshOptions.md)
 - [CustomMeshResult](interfaces/CustomMeshResult.md)
 - [InterpolatedPositionOptions](interfaces/InterpolatedPositionOptions.md)
+- [MeshMaterialOptions](interfaces/MeshMaterialOptions.md)
 - [ScreenPoint](interfaces/ScreenPoint.md)
 - [StatsOverlayOptions](interfaces/StatsOverlayOptions.md)
 - [TextureOptions](interfaces/TextureOptions.md)
 - [ThreeOptions](interfaces/ThreeOptions.md)
+- [UseMeshResult](interfaces/UseMeshResult.md)
 - [WorldPoint](interfaces/WorldPoint.md)
 
 ## Type Aliases
 
+- [GeometryType](type-aliases/GeometryType.md)
+- [MaterialType](type-aliases/MaterialType.md)
 - [PixelFn](type-aliases/PixelFn.md)
 - [PixelFn1D](type-aliases/PixelFn1D.md)
 
@@ -37,6 +41,7 @@
 - [installThree](functions/installThree.md)
 - [useCustomMesh](functions/useCustomMesh.md)
 - [useInterpolatedPosition](functions/useInterpolatedPosition.md)
+- [useMesh](functions/useMesh.md)
 - [useObject3D](functions/useObject3D.md)
 - [useScreenProjection](functions/useScreenProjection.md)
 - [useThreeContext](functions/useThreeContext.md)

--- a/apps/docs/api/three/src/functions/useMesh.md
+++ b/apps/docs/api/three/src/functions/useMesh.md
@@ -1,0 +1,131 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [three/src](../README.md) / useMesh
+
+# Function: useMesh()
+
+> **useMesh**\<`T`\>(`type`: `T`, `options`: `UseMeshOptions<T>`): `UseMeshResult`
+
+Defined in: packages/three/src/public/useMesh.ts
+
+Creates a `THREE.Mesh` with the specified geometry, material, and shadow
+settings, and attaches it to the current node's Three.js root.
+
+Combines `useThreeRoot()`, geometry creation, material setup, shadow
+configuration, and `useObject3D()` into a single declarative call.
+Returns all internals so callers can still modify them after creation.
+
+## Type Parameters
+
+### T
+
+> `T` *extends* `GeometryType`
+
+The geometry type string (e.g. `'box'`, `'sphere'`, `'capsule'`).
+
+## Parameters
+
+### type
+
+> `T`
+
+The geometry type to create.
+
+### options
+
+> `UseMeshOptions<T>`
+
+Geometry dimensions, material properties, shadow flags, texture maps,
+render state, and material type selection. All material options are optional.
+
+## Returns
+
+`UseMeshResult` — An object containing `{ root, mesh, material, geometry }`.
+
+## Material Types
+
+The `materialType` option selects which Three.js material class to use:
+
+- `'standard'` (default) — `MeshStandardMaterial` (PBR)
+- `'basic'` — `MeshBasicMaterial` (unlit, no lighting calculations)
+- `'phong'` — `MeshPhongMaterial` (Blinn-Phong shading)
+
+## Texture Maps
+
+Texture maps can be applied via options: `map`, `normalMap`, `emissiveMap`,
+`roughnessMap`, `metalnessMap`, `alphaMap`, `envMap`. The `normalScale`
+option accepts a `[number, number]` tuple (converted to `THREE.Vector2`
+internally).
+
+## Render State
+
+String enums are used for Three.js constants:
+
+- `side`: `'front'` | `'back'` | `'double'`
+- `blending`: `'normal'` | `'additive'` | `'multiply'`
+- `depthWrite`: `boolean`
+
+## Examples
+
+```ts
+import { useMesh } from '@pulse-ts/three';
+
+function PlatformNode() {
+  const { root } = useMesh('box', {
+    size: [4, 0.5, 3],
+    color: 0x4a6670,
+    roughness: 0.8,
+    castShadow: true,
+    receiveShadow: true,
+  });
+}
+```
+
+```ts
+// Using render state options
+import { useMesh } from '@pulse-ts/three';
+
+function GlassPanel() {
+  const { mesh } = useMesh('plane', {
+    width: 2,
+    height: 3,
+    color: 0xffffff,
+    transparent: true,
+    opacity: 0.3,
+    side: 'double',
+    depthWrite: false,
+    blending: 'normal',
+  });
+}
+```
+
+```ts
+// Using an alternative material type
+import { useMesh } from '@pulse-ts/three';
+
+function UnlitMarker() {
+  const { mesh } = useMesh('sphere', {
+    radius: 0.1,
+    color: 0xff0000,
+    materialType: 'basic',
+  });
+}
+```
+
+```ts
+// Applying texture maps with normalScale
+import { useMesh } from '@pulse-ts/three';
+import * as THREE from 'three';
+
+function TexturedWall(diffuse: THREE.Texture, normal: THREE.Texture) {
+  const { mesh } = useMesh('box', {
+    size: [4, 3, 0.2],
+    map: diffuse,
+    normalMap: normal,
+    normalScale: [1, 1],
+    roughness: 0.9,
+  });
+}
+```

--- a/apps/docs/api/three/src/interfaces/MeshMaterialOptions.md
+++ b/apps/docs/api/three/src/interfaces/MeshMaterialOptions.md
@@ -1,0 +1,130 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [three/src](../README.md) / MeshMaterialOptions
+
+# Interface: MeshMaterialOptions
+
+Defined in: packages/three/src/public/useMesh.ts
+
+Material options forwarded to the underlying Three.js material.
+
+All properties are optional and backward-compatible. String enums are used
+for Three.js constants so callers never need to import `THREE.*` values.
+
+## Properties
+
+### color?
+
+> `optional` **color**: `number`
+
+Mesh color (hex). Defaults to `0xcccccc`.
+
+### roughness?
+
+> `optional` **roughness**: `number`
+
+Surface roughness `[0, 1]`. Defaults to `1`.
+
+### metalness?
+
+> `optional` **metalness**: `number`
+
+Metalness `[0, 1]`. Defaults to `0`.
+
+### emissive?
+
+> `optional` **emissive**: `number`
+
+Emissive color (hex).
+
+### emissiveIntensity?
+
+> `optional` **emissiveIntensity**: `number`
+
+Emissive intensity. Defaults to `1`.
+
+### transparent?
+
+> `optional` **transparent**: `boolean`
+
+Whether the material is transparent. Defaults to `false`.
+
+### opacity?
+
+> `optional` **opacity**: `number`
+
+Opacity `[0, 1]`. Only effective when `transparent` is true. Defaults to `1`.
+
+### map?
+
+> `optional` **map**: `Texture`
+
+Color (diffuse) texture map.
+
+### normalMap?
+
+> `optional` **normalMap**: `Texture`
+
+Normal map texture.
+
+### normalScale?
+
+> `optional` **normalScale**: `[number, number]`
+
+Normal map scale as `[x, y]` tuple. Converted to `THREE.Vector2` internally. Defaults to `[1, 1]`.
+
+### emissiveMap?
+
+> `optional` **emissiveMap**: `Texture`
+
+Emissive map texture.
+
+### roughnessMap?
+
+> `optional` **roughnessMap**: `Texture`
+
+Roughness map texture.
+
+### metalnessMap?
+
+> `optional` **metalnessMap**: `Texture`
+
+Metalness map texture.
+
+### alphaMap?
+
+> `optional` **alphaMap**: `Texture`
+
+Alpha map texture. Controls per-pixel opacity.
+
+### envMap?
+
+> `optional` **envMap**: `Texture`
+
+Environment map texture.
+
+### side?
+
+> `optional` **side**: `'front'` | `'back'` | `'double'`
+
+Which faces to render. Defaults to `'front'`.
+
+### depthWrite?
+
+> `optional` **depthWrite**: `boolean`
+
+Whether to write to the depth buffer. Defaults to `true`.
+
+### blending?
+
+> `optional` **blending**: `'normal'` | `'additive'` | `'multiply'`
+
+Blending mode. Defaults to `'normal'`.
+
+### materialType?
+
+> `optional` **materialType**: `MaterialType`
+
+Which Three.js material class to use. Defaults to `'standard'`.

--- a/apps/docs/api/three/src/interfaces/UseMeshResult.md
+++ b/apps/docs/api/three/src/interfaces/UseMeshResult.md
@@ -1,0 +1,37 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [three/src](../README.md) / UseMeshResult
+
+# Interface: UseMeshResult
+
+Defined in: packages/three/src/public/useMesh.ts
+
+Object returned by `useMesh`.
+
+## Properties
+
+### root
+
+> **root**: `Object3D`
+
+The Object3D root managed by `useThreeRoot`.
+
+### mesh
+
+> **mesh**: `Mesh`
+
+The created `THREE.Mesh`.
+
+### material
+
+> **material**: `Material`
+
+The material instance (type depends on `materialType`).
+
+### geometry
+
+> **geometry**: `BufferGeometry`
+
+The `BufferGeometry` instance.

--- a/apps/docs/api/three/src/type-aliases/GeometryType.md
+++ b/apps/docs/api/three/src/type-aliases/GeometryType.md
@@ -1,0 +1,13 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [three/src](../README.md) / GeometryType
+
+# Type Alias: GeometryType
+
+> **GeometryType** = `'box'` | `'sphere'` | `'capsule'` | `'cylinder'` | `'cone'` | `'icosahedron'` | `'octahedron'` | `'plane'` | `'torus'`
+
+Defined in: packages/three/src/public/useMesh.ts
+
+Valid geometry type strings accepted by `useMesh`.

--- a/apps/docs/api/three/src/type-aliases/MaterialType.md
+++ b/apps/docs/api/three/src/type-aliases/MaterialType.md
@@ -1,0 +1,17 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [three/src](../README.md) / MaterialType
+
+# Type Alias: MaterialType
+
+> **MaterialType** = `'standard'` | `'basic'` | `'phong'`
+
+Defined in: packages/three/src/public/useMesh.ts
+
+Supported material types for `useMesh`.
+
+- `'standard'` — `MeshStandardMaterial` (PBR, default)
+- `'basic'` — `MeshBasicMaterial` (unlit, no lighting)
+- `'phong'` — `MeshPhongMaterial` (Blinn-Phong shading)

--- a/packages/three/src/public/index.ts
+++ b/packages/three/src/public/index.ts
@@ -18,6 +18,7 @@ export {
     type OctahedronGeometryOptions,
     type PlaneGeometryOptions,
     type TorusGeometryOptions,
+    type MaterialType,
     type MeshMaterialOptions,
     type MeshShadowOptions,
     type UseMeshOptions,

--- a/packages/three/src/public/useMesh.test.ts
+++ b/packages/three/src/public/useMesh.test.ts
@@ -465,31 +465,31 @@ describe('useMesh', () => {
 
     // ----- Render state options -----
 
-    test('maps side "front" to FrontSide constant', () => {
-        const THREE = require('three');
+    test('maps side "front" to FrontSide constant (0)', () => {
         const { result } = mountUseMesh(world, 'box', {
             size: [1, 1, 1],
             side: 'front',
         });
-        expect((result.material as any)._opts.side).toBe(THREE.FrontSide);
+        // FrontSide = 0 in our mock (matches Three.js)
+        expect((result.material as any)._opts.side).toBe(0);
     });
 
-    test('maps side "back" to BackSide constant', () => {
-        const THREE = require('three');
+    test('maps side "back" to BackSide constant (1)', () => {
         const { result } = mountUseMesh(world, 'box', {
             size: [1, 1, 1],
             side: 'back',
         });
-        expect((result.material as any)._opts.side).toBe(THREE.BackSide);
+        // BackSide = 1
+        expect((result.material as any)._opts.side).toBe(1);
     });
 
-    test('maps side "double" to DoubleSide constant', () => {
-        const THREE = require('three');
+    test('maps side "double" to DoubleSide constant (2)', () => {
         const { result } = mountUseMesh(world, 'box', {
             size: [1, 1, 1],
             side: 'double',
         });
-        expect((result.material as any)._opts.side).toBe(THREE.DoubleSide);
+        // DoubleSide = 2
+        expect((result.material as any)._opts.side).toBe(2);
     });
 
     test('forwards depthWrite option', () => {
@@ -500,37 +500,31 @@ describe('useMesh', () => {
         expect((result.material as any)._opts.depthWrite).toBe(false);
     });
 
-    test('maps blending "normal" to NormalBlending constant', () => {
-        const THREE = require('three');
+    test('maps blending "normal" to NormalBlending constant (1)', () => {
         const { result } = mountUseMesh(world, 'box', {
             size: [1, 1, 1],
             blending: 'normal',
         });
-        expect((result.material as any)._opts.blending).toBe(
-            THREE.NormalBlending,
-        );
+        // NormalBlending = 1
+        expect((result.material as any)._opts.blending).toBe(1);
     });
 
-    test('maps blending "additive" to AdditiveBlending constant', () => {
-        const THREE = require('three');
+    test('maps blending "additive" to AdditiveBlending constant (2)', () => {
         const { result } = mountUseMesh(world, 'box', {
             size: [1, 1, 1],
             blending: 'additive',
         });
-        expect((result.material as any)._opts.blending).toBe(
-            THREE.AdditiveBlending,
-        );
+        // AdditiveBlending = 2
+        expect((result.material as any)._opts.blending).toBe(2);
     });
 
-    test('maps blending "multiply" to MultiplyBlending constant', () => {
-        const THREE = require('three');
+    test('maps blending "multiply" to MultiplyBlending constant (4)', () => {
         const { result } = mountUseMesh(world, 'box', {
             size: [1, 1, 1],
             blending: 'multiply',
         });
-        expect((result.material as any)._opts.blending).toBe(
-            THREE.MultiplyBlending,
-        );
+        // MultiplyBlending = 4
+        expect((result.material as any)._opts.blending).toBe(4);
     });
 
     // ----- Material type options -----

--- a/packages/three/src/public/useMesh.test.ts
+++ b/packages/three/src/public/useMesh.test.ts
@@ -8,6 +8,14 @@ import type { UseMeshResult } from './useMesh';
 // Lightweight Three.js mock — extends the standard mock with geometry classes
 // ---------------------------------------------------------------------------
 jest.mock('three', () => {
+    class Vector2 {
+        x: number;
+        y: number;
+        constructor(x = 0, y = 0) {
+            this.x = x;
+            this.y = y;
+        }
+    }
     class Vector3 {
         x = 0;
         y = 0;
@@ -131,6 +139,23 @@ jest.mock('three', () => {
     }
 
     class MeshStandardMaterial {
+        _type = 'MeshStandardMaterial';
+        _opts: Record<string, unknown>;
+        constructor(opts: Record<string, unknown> = {}) {
+            this._opts = opts;
+        }
+    }
+
+    class MeshBasicMaterial {
+        _type = 'MeshBasicMaterial';
+        _opts: Record<string, unknown>;
+        constructor(opts: Record<string, unknown> = {}) {
+            this._opts = opts;
+        }
+    }
+
+    class MeshPhongMaterial {
+        _type = 'MeshPhongMaterial';
         _opts: Record<string, unknown>;
         constructor(opts: Record<string, unknown> = {}) {
             this._opts = opts;
@@ -139,15 +164,30 @@ jest.mock('three', () => {
 
     class Mesh extends Object3D {
         geometry: BufferGeometry;
-        material: MeshStandardMaterial;
-        constructor(geometry: BufferGeometry, material: MeshStandardMaterial) {
+        material: MeshStandardMaterial | MeshBasicMaterial | MeshPhongMaterial;
+        constructor(
+            geometry: BufferGeometry,
+            material:
+                | MeshStandardMaterial
+                | MeshBasicMaterial
+                | MeshPhongMaterial,
+        ) {
             super();
             this.geometry = geometry;
             this.material = material;
         }
     }
 
+    // Three.js constants
+    const FrontSide = 0;
+    const BackSide = 1;
+    const DoubleSide = 2;
+    const NormalBlending = 1;
+    const AdditiveBlending = 2;
+    const MultiplyBlending = 4;
+
     return {
+        Vector2,
         Vector3,
         Quaternion,
         Object3D,
@@ -168,7 +208,15 @@ jest.mock('three', () => {
         PlaneGeometry,
         TorusGeometry,
         MeshStandardMaterial,
+        MeshBasicMaterial,
+        MeshPhongMaterial,
         Mesh,
+        FrontSide,
+        BackSide,
+        DoubleSide,
+        NormalBlending,
+        AdditiveBlending,
+        MultiplyBlending,
     };
 });
 
@@ -379,5 +427,158 @@ describe('useMesh', () => {
         node.destroy();
 
         expect(svc.scene.children).not.toContain(result.root);
+    });
+
+    // ----- Texture map options -----
+
+    test('forwards texture map options to material', () => {
+        const fakeTexture = {} as any;
+        const { result } = mountUseMesh(world, 'box', {
+            size: [1, 1, 1],
+            map: fakeTexture,
+            normalMap: fakeTexture,
+            emissiveMap: fakeTexture,
+            roughnessMap: fakeTexture,
+            metalnessMap: fakeTexture,
+            alphaMap: fakeTexture,
+            envMap: fakeTexture,
+        });
+        const opts = (result.material as any)._opts;
+        expect(opts.map).toBe(fakeTexture);
+        expect(opts.normalMap).toBe(fakeTexture);
+        expect(opts.emissiveMap).toBe(fakeTexture);
+        expect(opts.roughnessMap).toBe(fakeTexture);
+        expect(opts.metalnessMap).toBe(fakeTexture);
+        expect(opts.alphaMap).toBe(fakeTexture);
+        expect(opts.envMap).toBe(fakeTexture);
+    });
+
+    test('converts normalScale tuple to Vector2', () => {
+        const { result } = mountUseMesh(world, 'box', {
+            size: [1, 1, 1],
+            normalScale: [0.5, 0.8],
+        });
+        const ns = (result.material as any)._opts.normalScale;
+        expect(ns.x).toBe(0.5);
+        expect(ns.y).toBe(0.8);
+    });
+
+    // ----- Render state options -----
+
+    test('maps side "front" to FrontSide constant', () => {
+        const THREE = require('three');
+        const { result } = mountUseMesh(world, 'box', {
+            size: [1, 1, 1],
+            side: 'front',
+        });
+        expect((result.material as any)._opts.side).toBe(THREE.FrontSide);
+    });
+
+    test('maps side "back" to BackSide constant', () => {
+        const THREE = require('three');
+        const { result } = mountUseMesh(world, 'box', {
+            size: [1, 1, 1],
+            side: 'back',
+        });
+        expect((result.material as any)._opts.side).toBe(THREE.BackSide);
+    });
+
+    test('maps side "double" to DoubleSide constant', () => {
+        const THREE = require('three');
+        const { result } = mountUseMesh(world, 'box', {
+            size: [1, 1, 1],
+            side: 'double',
+        });
+        expect((result.material as any)._opts.side).toBe(THREE.DoubleSide);
+    });
+
+    test('forwards depthWrite option', () => {
+        const { result } = mountUseMesh(world, 'box', {
+            size: [1, 1, 1],
+            depthWrite: false,
+        });
+        expect((result.material as any)._opts.depthWrite).toBe(false);
+    });
+
+    test('maps blending "normal" to NormalBlending constant', () => {
+        const THREE = require('three');
+        const { result } = mountUseMesh(world, 'box', {
+            size: [1, 1, 1],
+            blending: 'normal',
+        });
+        expect((result.material as any)._opts.blending).toBe(
+            THREE.NormalBlending,
+        );
+    });
+
+    test('maps blending "additive" to AdditiveBlending constant', () => {
+        const THREE = require('three');
+        const { result } = mountUseMesh(world, 'box', {
+            size: [1, 1, 1],
+            blending: 'additive',
+        });
+        expect((result.material as any)._opts.blending).toBe(
+            THREE.AdditiveBlending,
+        );
+    });
+
+    test('maps blending "multiply" to MultiplyBlending constant', () => {
+        const THREE = require('three');
+        const { result } = mountUseMesh(world, 'box', {
+            size: [1, 1, 1],
+            blending: 'multiply',
+        });
+        expect((result.material as any)._opts.blending).toBe(
+            THREE.MultiplyBlending,
+        );
+    });
+
+    // ----- Material type options -----
+
+    test('defaults to MeshStandardMaterial when materialType is omitted', () => {
+        const { result } = mountUseMesh(world, 'box', {
+            size: [1, 1, 1],
+        });
+        expect((result.material as any)._type).toBe('MeshStandardMaterial');
+    });
+
+    test('creates MeshStandardMaterial when materialType is "standard"', () => {
+        const { result } = mountUseMesh(world, 'box', {
+            size: [1, 1, 1],
+            materialType: 'standard',
+        });
+        expect((result.material as any)._type).toBe('MeshStandardMaterial');
+    });
+
+    test('creates MeshBasicMaterial when materialType is "basic"', () => {
+        const { result } = mountUseMesh(world, 'box', {
+            size: [1, 1, 1],
+            materialType: 'basic',
+            color: 0x00ff00,
+        });
+        expect((result.material as any)._type).toBe('MeshBasicMaterial');
+        expect((result.material as any)._opts.color).toBe(0x00ff00);
+    });
+
+    test('creates MeshPhongMaterial when materialType is "phong"', () => {
+        const { result } = mountUseMesh(world, 'box', {
+            size: [1, 1, 1],
+            materialType: 'phong',
+            color: 0x0000ff,
+        });
+        expect((result.material as any)._type).toBe('MeshPhongMaterial');
+        expect((result.material as any)._opts.color).toBe(0x0000ff);
+    });
+
+    // ----- Backward compatibility -----
+
+    test('all new options are optional — existing calls work unchanged', () => {
+        const { result } = mountUseMesh(world, 'box', {
+            size: [1, 1, 1],
+            color: 0xcccccc,
+            roughness: 0.5,
+        });
+        expect((result.material as any)._type).toBe('MeshStandardMaterial');
+        expect((result.geometry as any)._type).toBe('BoxGeometry');
     });
 });

--- a/packages/three/src/public/useMesh.ts
+++ b/packages/three/src/public/useMesh.ts
@@ -110,10 +110,29 @@ export interface GeometryTypeMap {
 export type GeometryType = keyof GeometryTypeMap;
 
 // ---------------------------------------------------------------------------
+// Material type
+// ---------------------------------------------------------------------------
+
+/**
+ * Supported material types.
+ *
+ * - `'standard'` — `MeshStandardMaterial` (default, PBR).
+ * - `'basic'` — `MeshBasicMaterial` (unlit, no lighting calculations).
+ * - `'phong'` — `MeshPhongMaterial` (Blinn-Phong shading).
+ */
+export type MaterialType = 'standard' | 'basic' | 'phong';
+
+// ---------------------------------------------------------------------------
 // Shared option types
 // ---------------------------------------------------------------------------
 
-/** Material options forwarded to `THREE.MeshStandardMaterial`. */
+/**
+ * Material options forwarded to the underlying Three.js material.
+ *
+ * All properties are optional and backward-compatible with the original
+ * `MeshStandardMaterial`-only API. String enums are used for Three.js
+ * constants so callers never need to import `THREE.*` values directly.
+ */
 export interface MeshMaterialOptions {
     /** Mesh color (hex). @default 0xcccccc */
     color?: number;
@@ -129,6 +148,61 @@ export interface MeshMaterialOptions {
     transparent?: boolean;
     /** Opacity `[0, 1]`. Only effective when `transparent` is true. @default 1 */
     opacity?: number;
+
+    // -- Texture maps --
+
+    /** Color (diffuse) texture map. */
+    map?: THREE.Texture;
+    /** Normal map texture. */
+    normalMap?: THREE.Texture;
+    /**
+     * Normal map scale as `[x, y]` tuple.
+     * Converted to `THREE.Vector2` internally.
+     * @default [1, 1]
+     */
+    normalScale?: [number, number];
+    /** Emissive map texture. */
+    emissiveMap?: THREE.Texture;
+    /** Roughness map texture. */
+    roughnessMap?: THREE.Texture;
+    /** Metalness map texture. */
+    metalnessMap?: THREE.Texture;
+    /** Alpha map texture. Controls per-pixel opacity. */
+    alphaMap?: THREE.Texture;
+    /** Environment map texture. */
+    envMap?: THREE.Texture;
+
+    // -- Render state --
+
+    /**
+     * Which faces to render.
+     * - `'front'` — front faces only (`THREE.FrontSide`).
+     * - `'back'` — back faces only (`THREE.BackSide`).
+     * - `'double'` — both sides (`THREE.DoubleSide`).
+     * @default 'front'
+     */
+    side?: 'front' | 'back' | 'double';
+    /** Whether to write to the depth buffer. @default true */
+    depthWrite?: boolean;
+    /**
+     * Blending mode.
+     * - `'normal'` — `THREE.NormalBlending`.
+     * - `'additive'` — `THREE.AdditiveBlending`.
+     * - `'multiply'` — `THREE.MultiplyBlending`.
+     * @default 'normal'
+     */
+    blending?: 'normal' | 'additive' | 'multiply';
+
+    // -- Material type --
+
+    /**
+     * Which Three.js material class to use.
+     * - `'standard'` — `MeshStandardMaterial` (PBR, default).
+     * - `'basic'` — `MeshBasicMaterial` (unlit).
+     * - `'phong'` — `MeshPhongMaterial` (Blinn-Phong).
+     * @default 'standard'
+     */
+    materialType?: MaterialType;
 }
 
 /** Shadow options applied to the mesh. */
@@ -154,11 +228,30 @@ export interface UseMeshResult {
     root: THREE.Object3D;
     /** The created `THREE.Mesh`. */
     mesh: THREE.Mesh;
-    /** The `MeshStandardMaterial` instance. */
-    material: THREE.MeshStandardMaterial;
+    /** The material instance (type depends on `materialType`). */
+    material: THREE.Material;
     /** The `BufferGeometry` instance. */
     geometry: THREE.BufferGeometry;
 }
+
+// ---------------------------------------------------------------------------
+// String enum → Three.js constant maps
+// ---------------------------------------------------------------------------
+
+const SIDE_MAP: Record<NonNullable<MeshMaterialOptions['side']>, THREE.Side> = {
+    front: THREE.FrontSide,
+    back: THREE.BackSide,
+    double: THREE.DoubleSide,
+};
+
+const BLENDING_MAP: Record<
+    NonNullable<MeshMaterialOptions['blending']>,
+    THREE.Blending
+> = {
+    normal: THREE.NormalBlending,
+    additive: THREE.AdditiveBlending,
+    multiply: THREE.MultiplyBlending,
+};
 
 // ---------------------------------------------------------------------------
 // Geometry factory
@@ -227,6 +320,83 @@ function createGeometry<T extends GeometryType>(
 }
 
 // ---------------------------------------------------------------------------
+// Material factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the shared material parameter object from user-facing options,
+ * mapping string enums to Three.js constants.
+ */
+function buildMaterialParams(
+    opts: MeshMaterialOptions,
+): Record<string, unknown> {
+    const params: Record<string, unknown> = {
+        color: opts.color,
+        roughness: opts.roughness,
+        metalness: opts.metalness,
+        emissive: opts.emissive,
+        emissiveIntensity: opts.emissiveIntensity,
+        transparent: opts.transparent,
+        opacity: opts.opacity,
+        map: opts.map,
+        normalMap: opts.normalMap,
+        emissiveMap: opts.emissiveMap,
+        roughnessMap: opts.roughnessMap,
+        metalnessMap: opts.metalnessMap,
+        alphaMap: opts.alphaMap,
+        envMap: opts.envMap,
+    };
+
+    if (opts.normalScale !== undefined) {
+        params.normalScale = new THREE.Vector2(
+            opts.normalScale[0],
+            opts.normalScale[1],
+        );
+    }
+
+    if (opts.side !== undefined) {
+        params.side = SIDE_MAP[opts.side];
+    }
+
+    if (opts.depthWrite !== undefined) {
+        params.depthWrite = opts.depthWrite;
+    }
+
+    if (opts.blending !== undefined) {
+        params.blending = BLENDING_MAP[opts.blending];
+    }
+
+    return params;
+}
+
+/**
+ * Creates a Three.js material based on the `materialType` option.
+ *
+ * @param opts - Material options including the `materialType` discriminator.
+ * @returns A Three.js material instance.
+ */
+function createMaterial(opts: MeshMaterialOptions): THREE.Material {
+    const params = buildMaterialParams(opts);
+    const type = opts.materialType ?? 'standard';
+
+    switch (type) {
+        case 'basic':
+            return new THREE.MeshBasicMaterial(
+                params as THREE.MeshBasicMaterialParameters,
+            );
+        case 'phong':
+            return new THREE.MeshPhongMaterial(
+                params as THREE.MeshPhongMaterialParameters,
+            );
+        case 'standard':
+        default:
+            return new THREE.MeshStandardMaterial(
+                params as THREE.MeshStandardMaterialParameters,
+            );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
 
@@ -234,10 +404,21 @@ function createGeometry<T extends GeometryType>(
  * Creates a `THREE.Mesh` with the specified geometry, material, and shadow
  * settings, and attaches it to the current node's Three.js root.
  *
- * Combines `useThreeRoot()`, geometry creation, `MeshStandardMaterial` setup,
+ * Combines `useThreeRoot()`, geometry creation, material setup,
  * shadow configuration, and `useObject3D()` into a single declarative call.
  * Returns all internals so callers can still modify them after creation
  * (e.g. animating emissive intensity or reading `mesh.rotation`).
+ *
+ * Supports multiple material types via `materialType`:
+ * - `'standard'` (default) — PBR material (`MeshStandardMaterial`)
+ * - `'basic'` — unlit material (`MeshBasicMaterial`)
+ * - `'phong'` — Blinn-Phong shading (`MeshPhongMaterial`)
+ *
+ * String enums are used for Three.js constants so callers never need to
+ * import `THREE.*` values directly:
+ * - `side`: `'front'` | `'back'` | `'double'`
+ * - `blending`: `'normal'` | `'additive'` | `'multiply'`
+ * - `normalScale`: `[number, number]` tuple instead of `THREE.Vector2`
  *
  * @param type - The geometry type to create (e.g. `'box'`, `'sphere'`, `'capsule'`).
  * @param options - Geometry dimensions, material properties, and shadow flags.
@@ -260,21 +441,50 @@ function createGeometry<T extends GeometryType>(
  *
  * @example
  * ```ts
+ * // Using texture maps and render state
  * import { useMesh } from '@pulse-ts/three';
- * import { useFrameUpdate } from '@pulse-ts/core';
  *
- * function CollectibleNode() {
- *   const { mesh, material } = useMesh('icosahedron', {
- *     radius: 0.25,
- *     color: 0xf4d03f,
- *     emissive: 0xf4d03f,
- *     emissiveIntensity: 0.3,
- *     castShadow: true,
+ * function GlassPanel() {
+ *   const { mesh } = useMesh('plane', {
+ *     width: 2,
+ *     height: 3,
+ *     color: 0xffffff,
+ *     transparent: true,
+ *     opacity: 0.3,
+ *     side: 'double',
+ *     depthWrite: false,
+ *     blending: 'normal',
  *   });
+ * }
+ * ```
  *
- *   // Callers can still manipulate the returned objects.
- *   useFrameUpdate((dt) => {
- *     mesh.rotation.y += 2 * dt;
+ * @example
+ * ```ts
+ * // Using an alternative material type
+ * import { useMesh } from '@pulse-ts/three';
+ *
+ * function UnlitMarker() {
+ *   const { mesh } = useMesh('sphere', {
+ *     radius: 0.1,
+ *     color: 0xff0000,
+ *     materialType: 'basic',
+ *   });
+ * }
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Applying texture maps with normalScale
+ * import { useMesh } from '@pulse-ts/three';
+ * import * as THREE from 'three';
+ *
+ * function TexturedWall(diffuse: THREE.Texture, normal: THREE.Texture) {
+ *   const { mesh } = useMesh('box', {
+ *     size: [4, 3, 0.2],
+ *     map: diffuse,
+ *     normalMap: normal,
+ *     normalScale: [1, 1],
+ *     roughness: 0.9,
  *   });
  * }
  * ```
@@ -286,16 +496,7 @@ export function useMesh<T extends GeometryType>(
     const root = useThreeRoot();
 
     const geometry = createGeometry(type, options as GeometryTypeMap[T]);
-
-    const material = new THREE.MeshStandardMaterial({
-        color: options.color,
-        roughness: options.roughness,
-        metalness: options.metalness,
-        emissive: options.emissive,
-        emissiveIntensity: options.emissiveIntensity,
-        transparent: options.transparent,
-        opacity: options.opacity,
-    });
+    const material = createMaterial(options);
 
     const mesh = new THREE.Mesh(geometry, material);
     mesh.castShadow = options.castShadow ?? false;


### PR DESCRIPTION
## Description

Extend useMesh hook to support texture maps, render state options, and alternative material types.

### Changes

- **Texture maps**: `map`, `normalMap`, `normalScale`, `emissiveMap`, `roughnessMap`, `metalnessMap`, `alphaMap`, `envMap`
- **Render state**: `side` ('front'/'back'/'double'), `depthWrite`, `blending` ('normal'/'additive'/'multiply')
- **Material types**: `materialType` ('standard'/'basic'/'phong') — selects between `MeshStandardMaterial`, `MeshBasicMaterial`, `MeshPhongMaterial`
- String enums for Three.js constants (no raw `THREE.*` values needed)
- `normalScale` as `[number, number]` tuple (converted to `THREE.Vector2` internally)
- All new options are optional — fully backward compatible

## Acceptance Criteria

- [x] Texture map options
- [x] Render state options
- [x] Material type option
- [x] String enums for Three.js constants
- [x] normalScale as tuple
- [x] Backward compatible
- [x] JSDoc with examples
- [x] Unit tests (30 passing)
- [x] Documentation updated

Part of EPIC-019: Three.js Rendering DX Pass