### PR TITLE
TICKET-123: useEffectPool Hook

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-021-effects-package-dx-pass/done/TICKET-123-use-effect-pool.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-021-effects-package-dx-pass/done/TICKET-123-use-effect-pool.md
@@ -2,7 +2,7 @@
 id: TICKET-123
 epic: EPIC-021
 title: useEffectPool Hook
-status: in-progress
+status: done
 priority: medium
 created: 2026-03-13
 updated: 2026-03-14
@@ -21,14 +21,14 @@ Design doc: `design-docs/approved/016-use-effect-pool.md`
 
 ## Acceptance Criteria
 
-- [ ] `useEffectPool(size, duration)` creates a fixed-size pool
-- [ ] `pool.trigger(data)` activates the oldest inactive slot (or recycles oldest active)
-- [ ] Each slot has `active`, `progress` (0→1), and user data
-- [ ] Slots auto-deactivate when progress reaches 1
-- [ ] `pool.active()` iterates currently active slots
-- [ ] JSDoc with examples
-- [ ] Unit tests for triggering, recycling, progress, auto-deactivation
-- [ ] Documentation updated
+- [x] `useEffectPool(size, duration)` creates a fixed-size pool
+- [x] `pool.trigger(data)` activates the oldest inactive slot (or recycles oldest active)
+- [x] Each slot has `active`, `progress` (0→1), and user data
+- [x] Slots auto-deactivate when progress reaches 1
+- [x] `pool.active()` iterates currently active slots
+- [x] JSDoc with examples
+- [x] Unit tests for triggering, recycling, progress, auto-deactivation
+- [x] Documentation updated
 
 ## Notes
 

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-021-effects-package-dx-pass/in-progress/TICKET-123-use-effect-pool.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-021-effects-package-dx-pass/in-progress/TICKET-123-use-effect-pool.md
@@ -2,10 +2,10 @@
 id: TICKET-123
 epic: EPIC-021
 title: useEffectPool Hook
-status: todo
+status: in-progress
 priority: medium
 created: 2026-03-13
-updated: 2026-03-13
+updated: 2026-03-14
 labels:
   - effects
   - dx

--- a/apps/docs/guides/effect-pool.md
+++ b/apps/docs/guides/effect-pool.md
@@ -1,0 +1,114 @@
+# Effect Pool
+
+`useEffectPool` provides a fixed-size pool of timed effects with automatic aging, oldest-slot recycling, and auto-deactivation. It is ideal for visual effects that spawn repeatedly and expire after a set duration: shockwaves, hit impacts, floating damage numbers, explosions, etc.
+
+## Quick start
+
+```ts
+import { useEffectPool } from '@pulse-ts/effects';
+import { useFrameUpdate } from '@pulse-ts/core';
+
+function HitEffects() {
+    const impacts = useEffectPool({
+        size: 4,
+        duration: 1.2,
+        create: () => ({ worldX: 0, worldZ: 0 }),
+    });
+
+    // Trigger on collision
+    useOnCollisionStart(({ point }) => {
+        impacts.trigger({ worldX: point[0], worldZ: point[2] });
+    });
+
+    // Render active impacts
+    useFrameUpdate(() => {
+        for (const slot of impacts.active()) {
+            const fade = 1 - slot.progress;
+            // draw impact at slot.data.worldX, slot.data.worldZ with fade...
+        }
+    });
+}
+```
+
+## How it works
+
+1. **Fixed allocation** -- `size` slots are pre-allocated at creation. No dynamic growth.
+2. **Triggering** -- `pool.trigger(data)` activates the first inactive slot, shallow-merging the provided data onto the slot's existing data object. Zero per-trigger allocation.
+3. **Recycling** -- When all slots are active, `trigger()` recycles the oldest active slot (highest `age`), ensuring new effects are always visible.
+4. **Aging** -- Each fixed tick advances `age` (seconds since activation) on active slots.
+5. **Auto-deactivation** -- When `age >= duration`, the slot is automatically deactivated.
+6. **Progress** -- `slot.progress` is `age / duration` clamped to `[0, 1]`, useful for fade curves, size interpolation, and shader uniforms.
+
+## API
+
+### `useEffectPool(options)`
+
+| Option | Type | Description |
+|---|---|---|
+| `size` | `number` | Maximum concurrent effects |
+| `duration` | `number` | Seconds before auto-deactivation |
+| `create` | `() => T` | Factory for slot data, called once per slot |
+
+Returns an `EffectPoolHandle<T>` with:
+
+| Member | Type | Description |
+|---|---|---|
+| `trigger(data)` | `(data: Partial<T>) => void` | Activate a slot with merged data |
+| `active()` | `Iterable<EffectSlot<T>>` | Iterate currently active slots |
+| `hasActive` | `boolean` | Whether any slot is active |
+| `reset()` | `() => void` | Deactivate all slots |
+
+Each `EffectSlot<T>` exposes:
+
+| Field | Type | Description |
+|---|---|---|
+| `data` | `T` | The slot's user data |
+| `age` | `number` | Seconds since activation |
+| `progress` | `number` | `0` to `1` normalized progress |
+| `active` | `boolean` | Always `true` when iterating `active()` |
+
+## Examples
+
+### Shockwave pool
+
+```ts
+const shockwaves = useEffectPool({
+    size: 4,
+    duration: 0.6,
+    create: () => ({ u: 0, v: 0 }),
+});
+
+shockwaves.trigger({ u: screenU, v: screenV });
+
+useFrameUpdate(() => {
+    let i = 0;
+    for (const slot of shockwaves.active()) {
+        uniforms.uRippleRadii.value.setComponent(i, slot.progress * MAX_RADIUS);
+        i++;
+    }
+});
+```
+
+### Floating damage numbers
+
+```ts
+const damageNumbers = useEffectPool({
+    size: 8,
+    duration: 1.5,
+    create: () => ({ x: 0, y: 0, amount: 0 }),
+});
+
+damageNumbers.trigger({ x: enemyPos.x, y: enemyPos.y, amount: 42 });
+
+for (const slot of damageNumbers.active()) {
+    const floatY = slot.data.y + slot.progress * 2;
+    const fade = 1 - slot.progress;
+    // render slot.data.amount at (slot.data.x, floatY) with fade...
+}
+```
+
+## Limitations
+
+- Pool size is fixed at creation and cannot be changed.
+- `trigger()` performs a shallow merge -- nested objects are replaced, not deep-merged.
+- Ages advance on the fixed-update tick, so timing precision is bound by `fixedStepMs`.

--- a/packages/effects/src/index.ts
+++ b/packages/effects/src/index.ts
@@ -1,8 +1,9 @@
 /**
  * @packageDocumentation
- * Visual effects for Pulse TS — particle systems and animated values.
+ * Visual effects for Pulse TS — particle systems, animated values, and effect pools.
  *
  * Features:
+ * - **`useEffectPool`** — fixed-size pool of timed effects with auto-recycling
  * - **`installParticles`** — world-level service for shared particle pools
  * - **`useParticleBurst`** — declarative one-shot burst from any node
  * - **`useParticleEmitter`** — declarative continuous emitter tied to node position

--- a/packages/effects/src/public/index.ts
+++ b/packages/effects/src/public/index.ts
@@ -24,6 +24,14 @@ export type {
     ParticleStyleOptions,
 } from '../domain/ParticlesService';
 
+// Effect pool
+export { useEffectPool } from './useEffectPool';
+export type {
+    EffectPoolOptions,
+    EffectSlot,
+    EffectPoolHandle,
+} from './useEffectPool';
+
 // Animated values
 export { useAnimate } from './useAnimate';
 export type {

--- a/packages/effects/src/public/useEffectPool.test.ts
+++ b/packages/effects/src/public/useEffectPool.test.ts
@@ -1,0 +1,265 @@
+import { World } from '@pulse-ts/core';
+import { useEffectPool } from './useEffectPool';
+import type { EffectPoolHandle } from './useEffectPool';
+
+const TICK_MS = 10;
+
+interface HitData {
+    x: number;
+    y: number;
+}
+
+function setup(size: number, durationSec: number) {
+    const world = new World({ fixedStepMs: TICK_MS });
+    let pool!: EffectPoolHandle<HitData>;
+
+    function TestNode() {
+        pool = useEffectPool({
+            size,
+            duration: durationSec,
+            create: () => ({ x: 0, y: 0 }),
+        });
+    }
+
+    world.mount(TestNode);
+
+    const step = (steps = 1) => {
+        for (let i = 0; i < steps; i++) world.tick(TICK_MS);
+    };
+
+    return { pool, step };
+}
+
+// ---------------------------------------------------------------------------
+// Triggering
+// ---------------------------------------------------------------------------
+
+describe('useEffectPool — triggering', () => {
+    test('initially has no active slots', () => {
+        const { pool } = setup(4, 1);
+        expect(pool.hasActive).toBe(false);
+        expect([...pool.active()]).toHaveLength(0);
+    });
+
+    test('trigger activates a slot with merged data', () => {
+        const { pool, step } = setup(4, 1);
+
+        pool.trigger({ x: 10, y: 20 });
+        step();
+
+        const slots = [...pool.active()];
+        expect(slots).toHaveLength(1);
+        expect(slots[0].data.x).toBe(10);
+        expect(slots[0].data.y).toBe(20);
+        expect(slots[0].active).toBe(true);
+    });
+
+    test('trigger with partial data only overwrites specified fields', () => {
+        const { pool, step } = setup(4, 1);
+
+        pool.trigger({ x: 5, y: 7 });
+        step();
+
+        // Trigger again on a new slot with only x
+        pool.trigger({ x: 99 });
+        step();
+
+        const slots = [...pool.active()];
+        expect(slots).toHaveLength(2);
+        // Second slot: x overwritten, y stays at default (0)
+        const second = slots[1];
+        expect(second.data.x).toBe(99);
+        expect(second.data.y).toBe(0);
+    });
+
+    test('multiple triggers fill multiple slots', () => {
+        const { pool, step } = setup(4, 1);
+
+        pool.trigger({ x: 1 });
+        pool.trigger({ x: 2 });
+        pool.trigger({ x: 3 });
+        step();
+
+        expect([...pool.active()]).toHaveLength(3);
+        expect(pool.hasActive).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Recycling
+// ---------------------------------------------------------------------------
+
+describe('useEffectPool — recycling', () => {
+    test('recycles oldest active slot when pool is full', () => {
+        const { pool, step } = setup(2, 1);
+
+        pool.trigger({ x: 1, y: 0 });
+        step(10); // first slot ages 0.1s
+
+        pool.trigger({ x: 2, y: 0 });
+        step(5); // second slot ages 0.05s, first ages 0.15s
+
+        // Pool is now full (2 slots). Trigger a third.
+        pool.trigger({ x: 3, y: 0 });
+        step();
+
+        const slots = [...pool.active()];
+        expect(slots).toHaveLength(2);
+
+        // The oldest (x=1) should have been recycled with x=3
+        const dataValues = slots.map((s) => s.data.x);
+        expect(dataValues).toContain(2);
+        expect(dataValues).toContain(3);
+        expect(dataValues).not.toContain(1);
+    });
+
+    test('recycled slot resets age to 0', () => {
+        const { pool, step } = setup(1, 1);
+
+        pool.trigger({ x: 1 });
+        step(50); // age = 0.5s
+
+        pool.trigger({ x: 2 }); // recycle
+        step();
+
+        const slots = [...pool.active()];
+        expect(slots).toHaveLength(1);
+        expect(slots[0].data.x).toBe(2);
+        expect(slots[0].age).toBeCloseTo(0.01, 2); // one tick after trigger
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Progress and aging
+// ---------------------------------------------------------------------------
+
+describe('useEffectPool — progress and aging', () => {
+    test('progress advances from 0 toward 1 over duration', () => {
+        const { pool, step } = setup(4, 1);
+
+        pool.trigger({ x: 0 });
+
+        // At t=0 (before any tick)
+        step();
+        const slotsEarly = [...pool.active()];
+        expect(slotsEarly[0].progress).toBeCloseTo(0.01, 2);
+
+        // At t=0.5s
+        step(49); // 50 ticks total = 0.5s
+        const slotsMid = [...pool.active()];
+        expect(slotsMid[0].progress).toBeCloseTo(0.5, 1);
+    });
+
+    test('age tracks elapsed seconds since activation', () => {
+        const { pool, step } = setup(4, 2);
+
+        pool.trigger({ x: 0 });
+        step(100); // 1 second
+
+        const slots = [...pool.active()];
+        expect(slots[0].age).toBeCloseTo(1.0, 1);
+    });
+
+    test('progress is clamped to 1', () => {
+        const { pool, step } = setup(4, 0.5);
+
+        pool.trigger({ x: 0 });
+        // Run slightly past duration but slot should auto-deactivate,
+        // so read at exactly the boundary
+        step(49); // 0.49s
+        const slots = [...pool.active()];
+        expect(slots[0].progress).toBeLessThanOrEqual(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Auto-deactivation
+// ---------------------------------------------------------------------------
+
+describe('useEffectPool — auto-deactivation', () => {
+    test('slot deactivates when age reaches duration', () => {
+        const { pool, step } = setup(4, 0.5);
+
+        pool.trigger({ x: 0 });
+        expect(pool.hasActive).toBe(true);
+
+        step(50); // 0.5s = duration
+        expect(pool.hasActive).toBe(false);
+        expect([...pool.active()]).toHaveLength(0);
+    });
+
+    test('slot deactivates when age exceeds duration', () => {
+        const { pool, step } = setup(4, 0.1);
+
+        pool.trigger({ x: 0 });
+        step(20); // 0.2s > 0.1s duration
+
+        expect(pool.hasActive).toBe(false);
+    });
+
+    test('deactivated slot can be reused by trigger', () => {
+        const { pool, step } = setup(1, 0.1);
+
+        pool.trigger({ x: 1 });
+        step(20); // expires
+        expect(pool.hasActive).toBe(false);
+
+        pool.trigger({ x: 2 });
+        step();
+        expect(pool.hasActive).toBe(true);
+
+        const slots = [...pool.active()];
+        expect(slots[0].data.x).toBe(2);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Reset
+// ---------------------------------------------------------------------------
+
+describe('useEffectPool — reset', () => {
+    test('reset deactivates all slots', () => {
+        const { pool, step } = setup(4, 1);
+
+        pool.trigger({ x: 1 });
+        pool.trigger({ x: 2 });
+        pool.trigger({ x: 3 });
+        step();
+        expect([...pool.active()]).toHaveLength(3);
+
+        pool.reset();
+        expect(pool.hasActive).toBe(false);
+        expect([...pool.active()]).toHaveLength(0);
+    });
+
+    test('slots can be triggered again after reset', () => {
+        const { pool, step } = setup(2, 1);
+
+        pool.trigger({ x: 1 });
+        pool.trigger({ x: 2 });
+        step();
+        pool.reset();
+
+        pool.trigger({ x: 3 });
+        step();
+
+        const slots = [...pool.active()];
+        expect(slots).toHaveLength(1);
+        expect(slots[0].data.x).toBe(3);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Handle interface
+// ---------------------------------------------------------------------------
+
+describe('useEffectPool — handle interface', () => {
+    test('exposes expected interface', () => {
+        const { pool } = setup(2, 1);
+
+        expect(typeof pool.trigger).toBe('function');
+        expect(typeof pool.active).toBe('function');
+        expect(typeof pool.hasActive).toBe('boolean');
+        expect(typeof pool.reset).toBe('function');
+    });
+});

--- a/packages/effects/src/public/useEffectPool.ts
+++ b/packages/effects/src/public/useEffectPool.ts
@@ -1,0 +1,182 @@
+import { useFixedUpdate } from '@pulse-ts/core';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration for {@link useEffectPool}.
+ *
+ * @typeParam T - Shape of user data stored in each slot.
+ */
+export interface EffectPoolOptions<T> {
+    /** Maximum concurrent effects. */
+    size: number;
+    /** Duration in seconds before auto-deactivation. */
+    duration: number;
+    /** Factory for slot data. Called once per slot at pool creation. */
+    create: () => T;
+}
+
+/**
+ * A single slot in an effect pool.
+ *
+ * @typeParam T - Shape of user data stored in the slot.
+ */
+export interface EffectSlot<T> {
+    /** The slot's data (mutated via trigger). */
+    readonly data: T;
+    /** Seconds since activation. */
+    readonly age: number;
+    /** 0 to 1 normalized progress through duration. */
+    readonly progress: number;
+    /** Whether this slot is currently active. */
+    readonly active: boolean;
+}
+
+/**
+ * Handle for interacting with an effect pool.
+ *
+ * @typeParam T - Shape of user data stored in each slot.
+ */
+export interface EffectPoolHandle<T> {
+    /** Activate a slot with the given data. Recycles oldest if full. */
+    trigger(data: Partial<T>): void;
+    /** Iterate active slots. */
+    active(): Iterable<EffectSlot<T>>;
+    /** Whether any slot is active. */
+    readonly hasActive: boolean;
+    /** Reset all slots to inactive. */
+    reset(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Internal slot representation
+// ---------------------------------------------------------------------------
+
+interface InternalSlot<T> {
+    data: T;
+    age: number;
+    active: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// useEffectPool
+// ---------------------------------------------------------------------------
+
+/**
+ * Fixed-size pool of timed effects with automatic recycling.
+ *
+ * Ages advance each fixed tick; expired slots auto-deactivate.
+ * When all slots are active and a new effect is triggered, the oldest
+ * active slot is recycled to make room.
+ *
+ * @typeParam T - Shape of user data stored in each slot.
+ * @param options - Pool configuration.
+ * @returns A handle for triggering and querying effects.
+ *
+ * @example
+ * ```ts
+ * import { useEffectPool } from '@pulse-ts/effects';
+ *
+ * const impacts = useEffectPool({
+ *     size: 4,
+ *     duration: 1.2,
+ *     create: () => ({ worldX: 0, worldZ: 0 }),
+ * });
+ *
+ * // Trigger from collision handler
+ * impacts.trigger({ worldX: surfX, worldZ: surfZ });
+ *
+ * // Read in frame update
+ * for (const slot of impacts.active()) {
+ *     const fade = 1 - slot.progress;
+ *     // draw impact at slot.data.worldX, slot.data.worldZ with fade...
+ * }
+ * ```
+ */
+export function useEffectPool<T>(
+    options: Readonly<EffectPoolOptions<T>>,
+): EffectPoolHandle<T> {
+    const { size, duration, create } = options;
+
+    // Pre-allocate all slots
+    const slots: InternalSlot<T>[] = [];
+    for (let i = 0; i < size; i++) {
+        slots.push({ data: create(), age: 0, active: false });
+    }
+
+    // Advance ages each fixed tick and auto-deactivate expired slots
+    useFixedUpdate((dt) => {
+        for (let i = 0; i < size; i++) {
+            const slot = slots[i];
+            if (!slot.active) continue;
+            slot.age += dt;
+            if (slot.age >= duration) {
+                slot.active = false;
+            }
+        }
+    });
+
+    return {
+        trigger(data: Partial<T>): void {
+            // Find first inactive slot
+            let target: InternalSlot<T> | undefined;
+            for (let i = 0; i < size; i++) {
+                if (!slots[i].active) {
+                    target = slots[i];
+                    break;
+                }
+            }
+
+            // If no inactive slot, recycle the oldest active one
+            if (!target) {
+                let oldestAge = -1;
+                for (let i = 0; i < size; i++) {
+                    if (slots[i].age > oldestAge) {
+                        oldestAge = slots[i].age;
+                        target = slots[i];
+                    }
+                }
+            }
+
+            // Should always have a target since size > 0
+            if (target) {
+                // Shallow merge user data
+                Object.assign(target.data as Record<string, unknown>, data);
+                target.age = 0;
+                target.active = true;
+            }
+        },
+
+        active(): Iterable<EffectSlot<T>> {
+            const activeSlots: EffectSlot<T>[] = [];
+            for (let i = 0; i < size; i++) {
+                const slot = slots[i];
+                if (slot.active) {
+                    activeSlots.push({
+                        data: slot.data,
+                        age: slot.age,
+                        progress: Math.min(slot.age / duration, 1),
+                        active: true,
+                    });
+                }
+            }
+            return activeSlots;
+        },
+
+        get hasActive(): boolean {
+            for (let i = 0; i < size; i++) {
+                if (slots[i].active) return true;
+            }
+            return false;
+        },
+
+        reset(): void {
+            for (let i = 0; i < size; i++) {
+                slots[i].age = 0;
+                slots[i].active = false;
+            }
+        },
+    };
+}


### PR DESCRIPTION
## Summary

- Implements `useEffectPool` hook in `@pulse-ts/effects` -- a fixed-size slot pool for timed game effects (shockwaves, hit impacts, explosions, etc.)
- Each slot tracks `age`, `progress` (0 to 1), and user data with automatic deactivation when duration expires
- Oldest-slot recycling when pool is full ensures new effects are always visible

## Changes

- `packages/effects/src/public/useEffectPool.ts` -- hook implementation with full JSDoc
- `packages/effects/src/public/useEffectPool.test.ts` -- 15 unit tests covering triggering, recycling, progress/aging, auto-deactivation, reset, and handle interface
- `packages/effects/src/public/index.ts` -- exports for `useEffectPool`, `EffectPoolOptions`, `EffectSlot`, `EffectPoolHandle`
- `packages/effects/src/index.ts` -- updated package-level JSDoc
- `apps/docs/guides/effect-pool.md` -- guide documentation with examples and API reference

## Test plan

- [x] All 15 new unit tests pass
- [x] Existing effects tests unaffected (pre-existing `@pulse-ts/three` resolution failures in worktree are unrelated)
- [x] Lint passes with no errors

Generated with [Claude Code](https://claude.com/claude-code)