### PR TITLE
TICKET-121: useSequence Hook

### DIFF
--- a/apps/docs/guides/sequencing.md
+++ b/apps/docs/guides/sequencing.md
@@ -1,0 +1,110 @@
+# Sequencing Actions
+
+`useSequence` provides declarative, time-based sequencing of actions in `@pulse-ts/effects`. Use it for intros, cutscenes, transitions, and multi-step effects.
+
+## Overview
+
+A sequence is an ordered list of steps. Each step executes as:
+
+1. **`pre`** — Wait this many seconds before the action (default 0).
+2. **`action`** — Call this function (optional; omit for a bare delay).
+3. **`post`** — Wait this many seconds after the action (default 0).
+
+Call `play()` to start. The sequence advances automatically via `useFrameUpdate`.
+
+## Quick Start
+
+```ts
+import { useSequence } from '@pulse-ts/effects';
+
+function IntroNode() {
+    const intro = useSequence([
+        { action: () => showTitle(), post: 2.0 },
+        { action: () => fadeOut(), post: 0.5 },
+        { action: () => startGame() },
+    ]);
+
+    intro.play();
+}
+```
+
+## Delays
+
+Use `pre` and `post` to add delays around actions:
+
+```ts
+const seq = useSequence([
+    // Wait 1 second, then show text, then wait 2 seconds
+    { pre: 1.0, action: () => showText(), post: 2.0 },
+    // Bare delay — just wait 0.5 seconds
+    { post: 0.5 },
+    // Immediate action
+    { action: () => done() },
+]);
+```
+
+## Parallel Steps
+
+Run multiple sub-sequences concurrently with `parallel`. The parallel group advances when the longest sub-sequence finishes:
+
+```ts
+const knockoutFx = useSequence([
+    {
+        parallel: [
+            { action: () => flash(), post: 0.3 },
+            { action: () => shake(), post: 0.5 },
+            { action: () => slowMotion(), post: 0.5 },
+        ],
+    },
+    { action: () => showKOText() },
+]);
+```
+
+## Playback Control
+
+```ts
+const seq = useSequence(steps);
+
+seq.play();      // Start or restart from beginning
+seq.reset();     // Stop and reset to initial state
+seq.finished;    // true when all steps have completed
+seq.elapsed;     // Seconds since play() was called
+```
+
+- `play()` always restarts from the beginning, even if the sequence is mid-playback.
+- `reset()` stops playback without restarting.
+
+## Composing with State Machines
+
+Sequences and state machines are complementary. Use sequences for linear timed flows and state machines for branching logic:
+
+```ts
+import { useStateMachine } from '@pulse-ts/core';
+import { useSequence } from '@pulse-ts/effects';
+
+function GameNode() {
+    const intro = useSequence([
+        { action: () => showTitle(), post: 2.0 },
+        { action: () => fadeOut(), post: 0.5 },
+    ]);
+
+    const sm = useStateMachine({
+        initial: 'intro',
+        states: {
+            intro: {
+                onEnter: () => intro.play(),
+            },
+            playing: { /* ... */ },
+        },
+        transitions: [
+            { from: 'intro', to: 'playing', when: () => intro.finished },
+        ],
+    });
+}
+```
+
+## Limitations
+
+- Sequences are presentation-layer constructs and advance via frame timing, not fixed-step timing.
+- There is no built-in pause/resume — use `reset()` and `play()` to restart.
+- Nested `parallel` groups are supported but deeply nested structures may be hard to read; consider splitting into multiple sequences.

--- a/packages/effects/src/index.ts
+++ b/packages/effects/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * @packageDocumentation
- * Visual effects for Pulse TS — particle systems, animated values, and effect pools.
+ * Visual effects for Pulse TS — particle systems, animated values, effect pools, and sequencing.
  *
  * Features:
  * - **`useEffectPool`** — fixed-size pool of timed effects with auto-recycling
@@ -10,6 +10,7 @@
  * - **`useParticles`** — low-level callback-driven emitter (escape hatch)
  * - Per-particle position, velocity, color, opacity, size, and userData
  * - Three.js Points rendering with custom shader
+ * - **`useSequence`** — declarative time-based action sequences with delays and parallel sub-sequences
  *
  * Quick start (convenience hooks)
  * ```ts

--- a/packages/effects/src/public/index.ts
+++ b/packages/effects/src/public/index.ts
@@ -46,6 +46,10 @@ export type {
     AnimatedValue,
 } from './useAnimate';
 
+// Sequencing
+export { useSequence } from './useSequence';
+export type { SequenceStep, SequenceHandle } from './useSequence';
+
 // Re-export domain types consumers need for init/update callbacks
 export type {
     Particle,

--- a/packages/effects/src/public/useSequence.test.ts
+++ b/packages/effects/src/public/useSequence.test.ts
@@ -1,0 +1,315 @@
+import { World } from '@pulse-ts/core';
+import { useSequence } from './useSequence';
+import type { SequenceHandle, SequenceStep } from './useSequence';
+
+const TICK_MS = 10;
+
+/** Mounts an FC that calls useSequence and returns the handle + step helper. */
+function setup(steps: SequenceStep[]) {
+    const world = new World({ fixedStepMs: TICK_MS });
+    let handle!: SequenceHandle;
+
+    function TestNode() {
+        handle = useSequence(steps);
+    }
+
+    world.mount(TestNode);
+
+    const step = (count = 1) => {
+        for (let i = 0; i < count; i++) world.tick(TICK_MS);
+    };
+
+    return { handle, step };
+}
+
+// ---------------------------------------------------------------------------
+// Sequential steps
+// ---------------------------------------------------------------------------
+
+describe('useSequence — sequential steps', () => {
+    test('does not advance until play() is called', () => {
+        const action = jest.fn();
+        const { handle, step } = setup([{ action }]);
+
+        step(10);
+        expect(action).not.toHaveBeenCalled();
+        expect(handle.finished).toBe(false);
+    });
+
+    test('executes a single action step immediately on play', () => {
+        const action = jest.fn();
+        const { handle, step } = setup([{ action }]);
+
+        handle.play();
+        step(1);
+        expect(action).toHaveBeenCalledTimes(1);
+        expect(handle.finished).toBe(true);
+    });
+
+    test('executes multiple steps in order', () => {
+        const order: number[] = [];
+        const { handle, step } = setup([
+            { action: () => order.push(1) },
+            { action: () => order.push(2) },
+            { action: () => order.push(3) },
+        ]);
+
+        handle.play();
+        step(1);
+        expect(order).toEqual([1, 2, 3]);
+        expect(handle.finished).toBe(true);
+    });
+
+    test('empty sequence is immediately finished on play', () => {
+        const { handle, step } = setup([]);
+
+        handle.play();
+        step(1);
+        expect(handle.finished).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Delays (pre/post)
+// ---------------------------------------------------------------------------
+
+describe('useSequence — delays', () => {
+    test('pre delay waits before calling action', () => {
+        const action = jest.fn();
+        // pre = 0.05s = 50ms = 5 ticks
+        const { handle, step } = setup([{ pre: 0.05, action }]);
+
+        handle.play();
+        step(4); // 40ms — not enough
+        expect(action).not.toHaveBeenCalled();
+
+        step(1); // 50ms — should fire
+        expect(action).toHaveBeenCalledTimes(1);
+    });
+
+    test('post delay waits after action before advancing', () => {
+        const first = jest.fn();
+        const second = jest.fn();
+        // post = 0.05s = 50ms = 5 ticks
+        // The tick that fires the action also counts toward post,
+        // so total ticks = 5 (not 6).
+        const { handle, step } = setup([
+            { action: first, post: 0.05 },
+            { action: second },
+        ]);
+
+        handle.play();
+        step(1); // first fires immediately, 10ms counts toward post
+        expect(first).toHaveBeenCalledTimes(1);
+        expect(second).not.toHaveBeenCalled();
+
+        step(3); // 40ms total — not enough post time yet
+        expect(second).not.toHaveBeenCalled();
+
+        step(1); // 50ms total — post done, second fires
+        expect(second).toHaveBeenCalledTimes(1);
+    });
+
+    test('pre + post delays combine correctly', () => {
+        const action = jest.fn();
+        const after = jest.fn();
+        const { handle, step } = setup([
+            { pre: 0.03, action, post: 0.02 },
+            { action: after },
+        ]);
+
+        handle.play();
+        step(2); // 20ms — still in pre (need 30ms)
+        expect(action).not.toHaveBeenCalled();
+
+        step(1); // 30ms — action fires, starts post
+        expect(action).toHaveBeenCalledTimes(1);
+        expect(after).not.toHaveBeenCalled();
+
+        step(2); // 50ms — post done, after fires
+        expect(after).toHaveBeenCalledTimes(1);
+    });
+
+    test('bare delay step (no action) just waits', () => {
+        const after = jest.fn();
+        const { handle, step } = setup([{ pre: 0.03 }, { action: after }]);
+
+        handle.play();
+        step(2);
+        expect(after).not.toHaveBeenCalled();
+
+        step(1);
+        expect(after).toHaveBeenCalledTimes(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Parallel sub-sequences
+// ---------------------------------------------------------------------------
+
+describe('useSequence — parallel', () => {
+    test('parallel runs sub-steps concurrently', () => {
+        const a = jest.fn();
+        const b = jest.fn();
+        const { handle, step } = setup([
+            {
+                parallel: [{ action: a }, { action: b }],
+            },
+        ]);
+
+        handle.play();
+        step(1);
+        expect(a).toHaveBeenCalledTimes(1);
+        expect(b).toHaveBeenCalledTimes(1);
+        expect(handle.finished).toBe(true);
+    });
+
+    test('parallel waits for longest sub-sequence', () => {
+        const after = jest.fn();
+        const { handle, step } = setup([
+            {
+                parallel: [
+                    { action: () => {}, post: 0.02 }, // 20ms
+                    { action: () => {}, post: 0.05 }, // 50ms (longest)
+                ],
+            },
+            { action: after },
+        ]);
+
+        handle.play();
+        step(1); // both actions fire
+        step(3); // 40ms total — shorter is done, longer is not
+        expect(after).not.toHaveBeenCalled();
+
+        step(2); // 60ms total — both done now
+        expect(after).toHaveBeenCalledTimes(1);
+    });
+
+    test('parallel with pre delays in sub-steps', () => {
+        const a = jest.fn();
+        const b = jest.fn();
+        const { handle, step } = setup([
+            {
+                parallel: [
+                    { pre: 0.02, action: a },
+                    { pre: 0.04, action: b },
+                ],
+            },
+        ]);
+
+        handle.play();
+        step(2); // 20ms — a fires
+        expect(a).toHaveBeenCalledTimes(1);
+        expect(b).not.toHaveBeenCalled();
+
+        step(2); // 40ms — b fires
+        expect(b).toHaveBeenCalledTimes(1);
+        expect(handle.finished).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// play / reset / finished / elapsed
+// ---------------------------------------------------------------------------
+
+describe('useSequence — playback control', () => {
+    test('play() restarts a finished sequence', () => {
+        const action = jest.fn();
+        const { handle, step } = setup([{ action }]);
+
+        handle.play();
+        step(1);
+        expect(action).toHaveBeenCalledTimes(1);
+        expect(handle.finished).toBe(true);
+
+        handle.play();
+        step(1);
+        expect(action).toHaveBeenCalledTimes(2);
+        expect(handle.finished).toBe(true);
+    });
+
+    test('play() restarts a playing sequence from the beginning', () => {
+        const first = jest.fn();
+        const second = jest.fn();
+        const { handle, step } = setup([
+            { action: first, post: 0.1 },
+            { action: second },
+        ]);
+
+        handle.play();
+        step(1); // first fires
+        expect(first).toHaveBeenCalledTimes(1);
+
+        // Restart before post finishes
+        handle.play();
+        step(1); // first fires again from restart
+        expect(first).toHaveBeenCalledTimes(2);
+        expect(second).not.toHaveBeenCalled();
+    });
+
+    test('reset() stops playback and resets state', () => {
+        const action = jest.fn();
+        const { handle, step } = setup([{ pre: 0.1, action }]);
+
+        handle.play();
+        step(5); // 50ms into pre delay
+
+        handle.reset();
+        step(10); // should not advance
+        expect(action).not.toHaveBeenCalled();
+        expect(handle.finished).toBe(false);
+        expect(handle.elapsed).toBe(0);
+    });
+
+    test('elapsed tracks time since play()', () => {
+        const { handle, step } = setup([{ post: 1.0 }]);
+
+        expect(handle.elapsed).toBe(0);
+
+        handle.play();
+        step(10); // 100ms = 0.1s
+        expect(handle.elapsed).toBeCloseTo(0.1, 2);
+
+        step(40); // 500ms total = 0.5s
+        expect(handle.elapsed).toBeCloseTo(0.5, 2);
+    });
+
+    test('elapsed stops incrementing when sequence finishes', () => {
+        const { handle, step } = setup([{ post: 0.05 }]);
+
+        handle.play();
+        step(10); // 100ms, well past 50ms post
+        const e = handle.elapsed;
+
+        step(10); // more time passes
+        expect(handle.elapsed).toBe(e);
+    });
+
+    test('finished is true only after all steps complete', () => {
+        const { handle, step } = setup([{ post: 0.03 }, { post: 0.03 }]);
+
+        handle.play();
+        expect(handle.finished).toBe(false);
+
+        step(3); // 30ms — first step done
+        expect(handle.finished).toBe(false);
+
+        step(3); // 60ms — second step done
+        expect(handle.finished).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Interface contract
+// ---------------------------------------------------------------------------
+
+describe('useSequence — interface', () => {
+    test('handle exposes expected interface', () => {
+        const { handle } = setup([]);
+
+        expect(typeof handle.play).toBe('function');
+        expect(typeof handle.reset).toBe('function');
+        expect(typeof handle.finished).toBe('boolean');
+        expect(typeof handle.elapsed).toBe('number');
+    });
+});

--- a/packages/effects/src/public/useSequence.ts
+++ b/packages/effects/src/public/useSequence.ts
@@ -1,0 +1,290 @@
+import { useFrameUpdate } from '@pulse-ts/core';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single step in a sequence.
+ *
+ * Execution order: wait `pre` seconds → call `action` → wait `post` seconds.
+ * All fields are optional — a step with only `pre` or `post` acts as a bare delay.
+ *
+ * Alternatively, a step can contain `parallel` to run multiple sub-sequences
+ * concurrently; the parallel group advances when the longest sub-sequence finishes.
+ */
+export type SequenceStep =
+    | { pre?: number; action?: () => void; post?: number }
+    | { parallel: SequenceStep[] };
+
+/**
+ * Handle returned by {@link useSequence} for controlling playback.
+ */
+export interface SequenceHandle {
+    /** Start or restart the sequence from the beginning. */
+    play(): void;
+    /** Stop and reset to initial state. */
+    reset(): void;
+    /** Whether all steps have completed. */
+    readonly finished: boolean;
+    /** Total elapsed time since `play()` was called. */
+    readonly elapsed: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Phases within a single action step. */
+type StepPhase = 'pre' | 'action' | 'post' | 'done';
+
+interface ActionStep {
+    pre: number;
+    action: (() => void) | undefined;
+    post: number;
+}
+
+function isParallel(step: SequenceStep): step is { parallel: SequenceStep[] } {
+    return 'parallel' in step;
+}
+
+/**
+ * Small tolerance to avoid floating-point comparison failures
+ * when accumulating frame deltas (e.g. 5 × 0.01 vs 0.05).
+ */
+const EPS = 1e-9;
+
+/** Mutable runner state for a flat (non-parallel) step. */
+interface ActionRunner {
+    kind: 'action';
+    step: ActionStep;
+    phase: StepPhase;
+    phaseElapsed: number;
+    done: boolean;
+}
+
+/** Mutable runner state for a parallel group. */
+interface ParallelRunner {
+    kind: 'parallel';
+    children: SequenceRunner[];
+}
+
+type StepRunner = ActionRunner | ParallelRunner;
+
+/** Top-level runner that walks through an array of steps. */
+interface SequenceRunner {
+    runners: StepRunner[];
+    index: number;
+    done: boolean;
+}
+
+function buildRunner(steps: SequenceStep[]): SequenceRunner {
+    const runners: StepRunner[] = steps.map((step) => {
+        if (isParallel(step)) {
+            return {
+                kind: 'parallel',
+                children: step.parallel.map((sub) => buildRunner([sub])),
+            } satisfies ParallelRunner;
+        }
+        return {
+            kind: 'action',
+            step: {
+                pre: step.pre ?? 0,
+                action: step.action,
+                post: step.post ?? 0,
+            },
+            phase: 'pre' as StepPhase,
+            phaseElapsed: 0,
+            done: false,
+        } satisfies ActionRunner;
+    });
+
+    return { runners, index: 0, done: steps.length === 0 };
+}
+
+function resetRunner(runner: SequenceRunner): void {
+    runner.index = 0;
+    runner.done = runner.runners.length === 0;
+    for (const r of runner.runners) {
+        if (r.kind === 'action') {
+            r.phase = 'pre';
+            r.phaseElapsed = 0;
+            r.done = false;
+        } else {
+            for (const child of r.children) {
+                resetRunner(child);
+            }
+        }
+    }
+}
+
+/**
+ * Advances a sequence runner by `dt` seconds.
+ */
+function advanceRunner(runner: SequenceRunner, dt: number): void {
+    if (runner.done) return;
+
+    let remaining = dt;
+    let advanced = true;
+
+    while (advanced && !runner.done) {
+        advanced = false;
+        const current = runner.runners[runner.index];
+        if (!current) {
+            runner.done = true;
+            break;
+        }
+
+        if (current.kind === 'parallel') {
+            for (const child of current.children) {
+                advanceRunner(child, remaining);
+            }
+            const allDone = current.children.every((c) => c.done);
+            if (allDone) {
+                runner.index++;
+                if (runner.index >= runner.runners.length) {
+                    runner.done = true;
+                }
+                advanced = true;
+            }
+            remaining = 0;
+        } else {
+            const prevDone = current.done;
+            remaining = advanceActionRunner(current, remaining);
+            if (current.done) {
+                if (!prevDone) {
+                    runner.index++;
+                    if (runner.index >= runner.runners.length) {
+                        runner.done = true;
+                    }
+                    advanced = true;
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Advances a single action runner through its phases.
+ * Returns unconsumed time.
+ */
+function advanceActionRunner(runner: ActionRunner, dt: number): number {
+    let remaining = dt;
+
+    // Pre phase
+    if (runner.phase === 'pre') {
+        const needed = runner.step.pre - runner.phaseElapsed;
+        if (remaining >= needed - EPS) {
+            remaining = Math.max(0, remaining - needed);
+            runner.phase = 'action';
+            runner.phaseElapsed = 0;
+        } else {
+            runner.phaseElapsed += remaining;
+            return 0;
+        }
+    }
+
+    // Action phase (instantaneous)
+    if (runner.phase === 'action') {
+        if (runner.step.action) {
+            runner.step.action();
+        }
+        runner.phase = 'post';
+        runner.phaseElapsed = 0;
+    }
+
+    // Post phase
+    if (runner.phase === 'post') {
+        const needed = runner.step.post - runner.phaseElapsed;
+        if (remaining >= needed - EPS) {
+            remaining = Math.max(0, remaining - needed);
+            runner.phase = 'done';
+            runner.done = true;
+            runner.phaseElapsed = 0;
+        } else {
+            runner.phaseElapsed += remaining;
+            return 0;
+        }
+    }
+
+    return remaining;
+}
+
+// ---------------------------------------------------------------------------
+// useSequence
+// ---------------------------------------------------------------------------
+
+/**
+ * Declarative time-based sequence of actions and delays.
+ *
+ * Each step executes as: wait `pre` → call `action` → wait `post`.
+ * All three fields are optional. A `parallel` step runs sub-sequences
+ * concurrently and advances when the longest finishes.
+ *
+ * Advances automatically via `useFrameUpdate` (presentation-layer timing).
+ * Call `play()` to start or restart from the beginning.
+ *
+ * @param steps - Array of sequence steps to execute in order.
+ * @returns A {@link SequenceHandle} for controlling playback.
+ *
+ * @example
+ * ```ts
+ * import { useSequence } from '@pulse-ts/effects';
+ *
+ * function IntroNode() {
+ *     const intro = useSequence([
+ *         { action: () => showTitle(), post: 2.0 },
+ *         { action: () => fadeOut(), post: 0.5 },
+ *         { action: () => startGame() },
+ *     ]);
+ *
+ *     // Start the sequence
+ *     intro.play();
+ * }
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Parallel sub-sequences
+ * const fx = useSequence([
+ *     { parallel: [
+ *         { action: () => flash(), post: 0.3 },
+ *         { action: () => shake(), post: 0.5 },
+ *     ]},
+ *     { action: () => showText() },
+ * ]);
+ * ```
+ */
+export function useSequence(steps: SequenceStep[]): SequenceHandle {
+    let runner = buildRunner(steps);
+    let playing = false;
+    let elapsed = 0;
+
+    useFrameUpdate((dt) => {
+        if (!playing || runner.done) return;
+        elapsed += dt;
+        advanceRunner(runner, dt);
+        if (runner.done) {
+            playing = false;
+        }
+    });
+
+    return {
+        play() {
+            runner = buildRunner(steps);
+            elapsed = 0;
+            playing = true;
+        },
+        reset() {
+            resetRunner(runner);
+            elapsed = 0;
+            playing = false;
+        },
+        get finished() {
+            return runner.done;
+        },
+        get elapsed() {
+            return elapsed;
+        },
+    };
+}


### PR DESCRIPTION
## Summary
- Implement `useSequence` hook in `@pulse-ts/effects` for declarative time-based action sequences
- Steps support `pre` delay, `action` callback, and `post` delay with floating-point-safe timing
- Parallel sub-sequences via `{ parallel: SequenceStep[] }` that advance when the longest finishes
- Full playback control: `play()`, `reset()`, `finished`, `elapsed`

## Test plan
- [x] 18 unit tests covering sequential steps, delays, parallel execution, playback control, and interface contract
- [x] Lint passes
- [x] Documentation guide added at `apps/docs/guides/sequencing.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)