### PR TITLE
TICKET-125: useVirtualJoystick Hook

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-022-input-and-platform-dx-pass/done/TICKET-125-use-virtual-joystick.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-022-input-and-platform-dx-pass/done/TICKET-125-use-virtual-joystick.md
@@ -2,7 +2,7 @@
 id: TICKET-125
 epic: EPIC-022
 title: useVirtualJoystick Hook
-status: in-progress
+status: done
 priority: medium
 created: 2026-03-13
 updated: 2026-03-14
@@ -23,17 +23,18 @@ Design doc: `design-docs/approved/015-use-virtual-joystick.md`
 
 ## Acceptance Criteria
 
-- [ ] `useVirtualJoystick(options)` creates a touch joystick
-- [ ] Injects into input system as an Axis2D binding
-- [ ] Dead zone and normalization handled by the hook
-- [ ] `render` callback receives reactive state (position, angle, magnitude, active)
-- [ ] Default visual rendering if no `render` callback provided
-- [ ] Works on touch devices
-- [ ] JSDoc with examples
-- [ ] Unit tests for touch math, dead zone, input injection
-- [ ] Documentation updated
+- [x] `useVirtualJoystick(options)` creates a touch joystick
+- [x] Injects into input system as an Axis2D binding
+- [x] Dead zone and normalization handled by the hook
+- [x] `render` callback receives reactive state (position, angle, magnitude, active)
+- [x] Default visual rendering if no `render` callback provided
+- [x] Works on touch devices
+- [x] JSDoc with examples
+- [x] Unit tests for touch math, dead zone, input injection
+- [x] Documentation updated
 
 ## Notes
 
 - **2026-03-13**: Ticket created from approved design doc #15.
 - **2026-03-14**: Moved to in-progress.
+- **2026-03-14**: Implementation complete. All 79 tests passing, lint clean.

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-022-input-and-platform-dx-pass/in-progress/TICKET-125-use-virtual-joystick.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-022-input-and-platform-dx-pass/in-progress/TICKET-125-use-virtual-joystick.md
@@ -2,10 +2,10 @@
 id: TICKET-125
 epic: EPIC-022
 title: useVirtualJoystick Hook
-status: todo
+status: in-progress
 priority: medium
 created: 2026-03-13
-updated: 2026-03-13
+updated: 2026-03-14
 labels:
   - input
   - dx
@@ -36,3 +36,4 @@ Design doc: `design-docs/approved/015-use-virtual-joystick.md`
 ## Notes
 
 - **2026-03-13**: Ticket created from approved design doc #15.
+- **2026-03-14**: Moved to in-progress.

--- a/apps/docs/api/input/src/README.md
+++ b/apps/docs/api/input/src/README.md
@@ -15,6 +15,9 @@
 ## Interfaces
 
 - [InputProvider](interfaces/InputProvider.md)
+- [JoystickRenderState](interfaces/JoystickRenderState.md)
+- [VirtualJoystickHandle](interfaces/VirtualJoystickHandle.md)
+- [VirtualJoystickOptions](interfaces/VirtualJoystickOptions.md)
 
 ## Type Aliases
 
@@ -52,3 +55,4 @@
 - [useAxis2D](functions/useAxis2D.md)
 - [useInput](functions/useInput.md)
 - [usePointer](functions/usePointer.md)
+- [useVirtualJoystick](functions/useVirtualJoystick.md)

--- a/apps/docs/api/input/src/functions/useVirtualJoystick.md
+++ b/apps/docs/api/input/src/functions/useVirtualJoystick.md
@@ -1,0 +1,67 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [input/src](../README.md) / useVirtualJoystick
+
+# Function: useVirtualJoystick()
+
+> **useVirtualJoystick**(`axisAction`, `options?`): [`VirtualJoystickHandle`](../interfaces/VirtualJoystickHandle.md)
+
+Defined in: packages/input/src/public/useVirtualJoystick.ts
+
+Creates a virtual joystick that injects into the input system's named axis action.
+Handles touch ID tracking, displacement math, deadzone application,
+input system injection, and cleanup.
+
+The hook owns all touch math. Visual rendering is pluggable via the `render`
+option; when omitted, a default circle + knob design is used.
+
+## Parameters
+
+### axisAction
+
+`string`
+
+The input action name to inject axis values into (via `holdAxis2D`).
+
+### options?
+
+[`VirtualJoystickOptions`](../interfaces/VirtualJoystickOptions.md)
+
+Configuration and optional custom render callback.
+
+## Returns
+
+[`VirtualJoystickHandle`](../interfaces/VirtualJoystickHandle.md)
+
+A handle for controlling visibility, reading axis values, and cleanup.
+
+## Examples
+
+```ts
+import { useVirtualJoystick } from '@pulse-ts/input';
+
+// Default visuals — zero config
+const joystick = useVirtualJoystick('move', {
+    position: 'bottom-left',
+    size: 120,
+    deadzone: 0.15,
+});
+```
+
+```ts
+import { useVirtualJoystick } from '@pulse-ts/input';
+
+// Custom visuals via render callback
+const joystick = useVirtualJoystick('move', {
+    position: 'bottom-right',
+    render: (state) => {
+        const el = document.createElement('div');
+        el.style.width = `${state.size}px`;
+        el.style.height = `${state.size}px`;
+        // Use state.knobX(), state.knobY(), state.active() for updates
+        return el;
+    },
+});
+```

--- a/apps/docs/api/input/src/interfaces/JoystickRenderState.md
+++ b/apps/docs/api/input/src/interfaces/JoystickRenderState.md
@@ -1,0 +1,51 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [input/src](../README.md) / JoystickRenderState
+
+# Interface: JoystickRenderState
+
+Defined in: packages/input/src/public/useVirtualJoystick.ts
+
+Reactive state passed to a custom joystick render callback.
+All value accessors are functions (reactive getters) so they integrate
+with reactive DOM binding systems.
+
+## Properties
+
+### knobX
+
+> **knobX**: () => `number`
+
+Knob offset in pixels from center (-maxOffset to +maxOffset). Reactive getter.
+
+### knobY
+
+> **knobY**: () => `number`
+
+Knob offset in pixels from center (-maxOffset to +maxOffset). Reactive getter.
+
+### axisX
+
+> **axisX**: () => `number`
+
+Normalized axis after deadzone (-1 to 1). Reactive getter.
+
+### axisY
+
+> **axisY**: () => `number`
+
+Normalized axis after deadzone (-1 to 1). Reactive getter.
+
+### active
+
+> **active**: () => `boolean`
+
+Whether a touch is currently active. Reactive getter.
+
+### size
+
+> **size**: `number`
+
+Base size in pixels.

--- a/apps/docs/api/input/src/interfaces/VirtualJoystickHandle.md
+++ b/apps/docs/api/input/src/interfaces/VirtualJoystickHandle.md
@@ -1,0 +1,45 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [input/src](../README.md) / VirtualJoystickHandle
+
+# Interface: VirtualJoystickHandle
+
+Defined in: packages/input/src/public/useVirtualJoystick.ts
+
+Handle returned by `useVirtualJoystick` for controlling the joystick.
+
+## Properties
+
+### element
+
+> `readonly` **element**: `HTMLElement`
+
+The root DOM element containing the joystick.
+
+### axes
+
+> `readonly` **axes**: \{ `x`: `number`; `y`: `number` \}
+
+Current axis values after deadzone (-1 to 1 each).
+
+## Methods
+
+### setVisible()
+
+> **setVisible**(`visible`): `void`
+
+Show or hide the joystick.
+
+#### Parameters
+
+##### visible
+
+`boolean`
+
+### destroy()
+
+> **destroy**(): `void`
+
+Remove the joystick from the DOM and detach all listeners.

--- a/apps/docs/api/input/src/interfaces/VirtualJoystickOptions.md
+++ b/apps/docs/api/input/src/interfaces/VirtualJoystickOptions.md
@@ -1,0 +1,43 @@
+[**pulse-ts**](../../../README.md)
+
+***
+
+[pulse-ts](../../../README.md) / [input/src](../README.md) / VirtualJoystickOptions
+
+# Interface: VirtualJoystickOptions
+
+Defined in: packages/input/src/public/useVirtualJoystick.ts
+
+Configuration options for `useVirtualJoystick`.
+
+## Properties
+
+### position?
+
+> `optional` **position**: `'bottom-left'` \| `'bottom-right'` \| \{ `x`: `string`; `y`: `string` \}
+
+Screen position preset or custom CSS coordinates. Default: `'bottom-left'`.
+
+### size?
+
+> `optional` **size**: `number`
+
+Outer diameter in pixels. Default: `120`.
+
+### deadzone?
+
+> `optional` **deadzone**: `number`
+
+Deadzone radius as a fraction (0-1). Below this threshold, output is zero. Default: `0.15`.
+
+### parent?
+
+> `optional` **parent**: `HTMLElement`
+
+Parent element to append the joystick to. Default: `document.body`.
+
+### render?
+
+> `optional` **render**: (`state`: [`JoystickRenderState`](JoystickRenderState.md)) => `HTMLElement`
+
+Custom render callback. Receives reactive state. Omit for default circle + knob visuals.

--- a/apps/docs/guides/input-bindings.md
+++ b/apps/docs/guides/input-bindings.md
@@ -85,6 +85,46 @@ const off = input.actionEvent.on(({ name, state }) => {
 off();
 ```
 
+## Virtual joystick (touch/mobile)
+
+Use `useVirtualJoystick` to create a touch-based virtual joystick that injects into the input system as a held Axis2D value. The hook handles all touch math (touch ID tracking, deadzone, normalization) and provides pluggable visuals.
+
+```ts
+import { useVirtualJoystick } from '@pulse-ts/input';
+
+// Default visuals (circle + knob)
+const joystick = useVirtualJoystick('move', {
+  position: 'bottom-left',
+  size: 120,
+  deadzone: 0.15,
+});
+
+// Hide/show based on game state
+joystick.setVisible(false);
+
+// Read current axis values
+const { x, y } = joystick.axes;
+
+// Clean up
+joystick.destroy();
+```
+
+Custom visuals via the `render` callback:
+
+```ts
+const joystick = useVirtualJoystick('move', {
+  position: 'bottom-right',
+  render: (state) => {
+    const el = document.createElement('div');
+    // state.knobX(), state.knobY() — pixel offsets (reactive getters)
+    // state.axisX(), state.axisY() — normalized -1..1 (reactive getters)
+    // state.active() — whether touch is active (reactive getter)
+    // state.size — joystick diameter in pixels
+    return el;
+  },
+});
+```
+
 ## Tips
 
 - Set `preventDefault` to avoid scrolling/back/forward during gameplay.

--- a/packages/input/src/domain/services/internal/joystickMath.test.ts
+++ b/packages/input/src/domain/services/internal/joystickMath.test.ts
@@ -1,0 +1,140 @@
+import {
+    computeDisplacement,
+    applyDeadzone,
+    clampToRadius,
+} from './joystickMath';
+
+describe('computeDisplacement', () => {
+    test('returns zero displacement when touch is at center', () => {
+        const d = computeDisplacement(60, 60, 60, 60);
+        expect(d.dx).toBe(0);
+        expect(d.dy).toBe(0);
+        expect(d.distance).toBe(0);
+    });
+
+    test('computes positive X displacement', () => {
+        const d = computeDisplacement(60, 60, 90, 60);
+        expect(d.dx).toBe(30);
+        expect(d.dy).toBe(0);
+        expect(d.distance).toBe(30);
+        expect(d.angle).toBeCloseTo(0);
+    });
+
+    test('computes negative Y displacement (up in screen coords)', () => {
+        const d = computeDisplacement(60, 60, 60, 30);
+        expect(d.dx).toBe(0);
+        expect(d.dy).toBe(-30);
+        expect(d.distance).toBe(30);
+        expect(d.angle).toBeCloseTo(-Math.PI / 2);
+    });
+
+    test('computes diagonal displacement', () => {
+        const d = computeDisplacement(0, 0, 3, 4);
+        expect(d.distance).toBeCloseTo(5);
+        expect(d.angle).toBeCloseTo(Math.atan2(4, 3));
+    });
+});
+
+describe('applyDeadzone', () => {
+    test('returns zero output when within deadzone', () => {
+        const d = computeDisplacement(60, 60, 62, 60); // 2px, well within deadzone
+        const out = applyDeadzone(d, 50, 0.15); // dzRadius = 7.5
+        expect(out.x).toBe(0);
+        expect(out.y).toBe(0);
+        expect(out.magnitude).toBe(0);
+    });
+
+    test('returns zero when exactly at deadzone boundary', () => {
+        const dzRadius = 0.15 * 50; // 7.5
+        const d = computeDisplacement(60, 60, 60 + dzRadius, 60);
+        const out = applyDeadzone(d, 50, 0.15);
+        expect(out.magnitude).toBeCloseTo(0);
+    });
+
+    test('returns full magnitude at max radius', () => {
+        const d = computeDisplacement(60, 60, 110, 60); // 50px = maxRadius
+        const out = applyDeadzone(d, 50, 0.15);
+        expect(out.magnitude).toBeCloseTo(1);
+        expect(out.x).toBeCloseTo(1);
+        expect(out.y).toBeCloseTo(0);
+    });
+
+    test('clamps magnitude to 1 when beyond max radius', () => {
+        const d = computeDisplacement(60, 60, 200, 60); // way beyond
+        const out = applyDeadzone(d, 50, 0.15);
+        expect(out.magnitude).toBeCloseTo(1);
+        expect(out.x).toBeCloseTo(1);
+    });
+
+    test('linearly rescales between deadzone and max', () => {
+        const maxRadius = 100;
+        const deadzone = 0.2;
+        const dzRadius = 20; // 0.2 * 100
+        const midDistance = (dzRadius + maxRadius) / 2; // 60, halfway
+        const d = computeDisplacement(0, 0, midDistance, 0);
+        const out = applyDeadzone(d, maxRadius, deadzone);
+        expect(out.magnitude).toBeCloseTo(0.5);
+    });
+
+    test('handles zero deadzone', () => {
+        const d = computeDisplacement(0, 0, 25, 0);
+        const out = applyDeadzone(d, 50, 0);
+        expect(out.magnitude).toBeCloseTo(0.5);
+        expect(out.x).toBeCloseTo(0.5);
+    });
+
+    test('returns zero for zero maxRadius', () => {
+        const d = computeDisplacement(0, 0, 10, 10);
+        const out = applyDeadzone(d, 0, 0.15);
+        expect(out.x).toBe(0);
+        expect(out.y).toBe(0);
+        expect(out.magnitude).toBe(0);
+    });
+
+    test('handles diagonal displacement correctly', () => {
+        // 45-degree angle, distance = 50 (at max)
+        const dist = 50;
+        const dx = dist * Math.cos(Math.PI / 4);
+        const dy = dist * Math.sin(Math.PI / 4);
+        const d = computeDisplacement(0, 0, dx, dy);
+        const out = applyDeadzone(d, 50, 0.15);
+        expect(out.magnitude).toBeCloseTo(1);
+        // x and y should be equal for 45 degrees
+        expect(Math.abs(out.x - out.y)).toBeLessThan(0.001);
+    });
+});
+
+describe('clampToRadius', () => {
+    test('returns original offsets when within radius', () => {
+        const result = clampToRadius(3, 4, 10);
+        expect(result.x).toBe(3);
+        expect(result.y).toBe(4);
+    });
+
+    test('clamps to radius boundary when exceeding', () => {
+        const result = clampToRadius(100, 0, 50);
+        expect(result.x).toBeCloseTo(50);
+        expect(result.y).toBeCloseTo(0);
+    });
+
+    test('preserves direction when clamping', () => {
+        const result = clampToRadius(-100, 0, 50);
+        expect(result.x).toBeCloseTo(-50);
+        expect(result.y).toBeCloseTo(0);
+    });
+
+    test('clamps diagonal correctly', () => {
+        // 3-4-5 triangle scaled to distance 10, radius 5
+        const result = clampToRadius(6, 8, 5);
+        const dist = Math.sqrt(result.x * result.x + result.y * result.y);
+        expect(dist).toBeCloseTo(5);
+        // Should preserve ratio
+        expect(result.x / result.y).toBeCloseTo(6 / 8);
+    });
+
+    test('returns exact values when at boundary', () => {
+        const result = clampToRadius(3, 4, 5); // distance exactly 5
+        expect(result.x).toBe(3);
+        expect(result.y).toBe(4);
+    });
+});

--- a/packages/input/src/domain/services/internal/joystickMath.ts
+++ b/packages/input/src/domain/services/internal/joystickMath.ts
@@ -1,0 +1,136 @@
+/**
+ * Pure math utilities for virtual joystick touch computation.
+ * Handles displacement, deadzone application, and normalization.
+ *
+ * @module
+ */
+
+/**
+ * Raw displacement from a joystick center to a touch point.
+ */
+export interface JoystickDisplacement {
+    /** Pixel offset from center on the X axis. */
+    dx: number;
+    /** Pixel offset from center on the Y axis. */
+    dy: number;
+    /** Distance from center in pixels. */
+    distance: number;
+    /** Angle in radians from positive X axis. */
+    angle: number;
+}
+
+/**
+ * Normalized joystick output after deadzone and clamping.
+ */
+export interface JoystickOutput {
+    /** Normalized X axis value (-1 to 1). */
+    x: number;
+    /** Normalized Y axis value (-1 to 1). */
+    y: number;
+    /** Magnitude after deadzone (0 to 1). */
+    magnitude: number;
+    /** Angle in radians. */
+    angle: number;
+}
+
+/**
+ * Compute raw displacement between a center point and a touch point.
+ *
+ * @param centerX - Center X coordinate in pixels.
+ * @param centerY - Center Y coordinate in pixels.
+ * @param touchX - Touch X coordinate in pixels.
+ * @param touchY - Touch Y coordinate in pixels.
+ * @returns Raw displacement with distance and angle.
+ *
+ * @example
+ * ```ts
+ * const d = computeDisplacement(60, 60, 90, 60);
+ * // d.dx === 30, d.dy === 0, d.distance === 30, d.angle === 0
+ * ```
+ */
+export function computeDisplacement(
+    centerX: number,
+    centerY: number,
+    touchX: number,
+    touchY: number,
+): JoystickDisplacement {
+    const dx = touchX - centerX;
+    const dy = touchY - centerY;
+    const distance = Math.sqrt(dx * dx + dy * dy);
+    const angle = Math.atan2(dy, dx);
+    return { dx, dy, distance, angle };
+}
+
+/**
+ * Apply deadzone and normalize joystick displacement to -1..1 range.
+ *
+ * When distance is within the deadzone radius, output is zero.
+ * Beyond the deadzone, output is linearly rescaled so the usable range
+ * maps to 0..1 magnitude, clamped at `maxRadius`.
+ *
+ * @param displacement - Raw displacement from {@link computeDisplacement}.
+ * @param maxRadius - Maximum radius in pixels (half the joystick size).
+ * @param deadzone - Deadzone as a fraction of maxRadius (0 to 1). Default 0.15.
+ * @returns Normalized output with deadzone applied.
+ *
+ * @example
+ * ```ts
+ * const d = computeDisplacement(60, 60, 90, 60);
+ * const out = applyDeadzone(d, 50, 0.15);
+ * // out.x ~= 0.588, out.y === 0, out.magnitude ~= 0.588
+ * ```
+ */
+export function applyDeadzone(
+    displacement: JoystickDisplacement,
+    maxRadius: number,
+    deadzone: number = 0.15,
+): JoystickOutput {
+    if (maxRadius <= 0) {
+        return { x: 0, y: 0, magnitude: 0, angle: displacement.angle };
+    }
+
+    const dzRadius = deadzone * maxRadius;
+    const { distance, angle } = displacement;
+
+    if (distance <= dzRadius) {
+        return { x: 0, y: 0, magnitude: 0, angle };
+    }
+
+    // Rescale so that dzRadius..maxRadius maps to 0..1
+    const usableRange = maxRadius - dzRadius;
+    const clampedDistance = Math.min(distance, maxRadius);
+    const magnitude = (clampedDistance - dzRadius) / usableRange;
+
+    const x = Math.cos(angle) * magnitude;
+    const y = Math.sin(angle) * magnitude;
+
+    return { x, y, magnitude, angle };
+}
+
+/**
+ * Clamp pixel displacement to a maximum radius, returning clamped pixel offsets.
+ * Used for visual knob positioning.
+ *
+ * @param dx - X displacement in pixels.
+ * @param dy - Y displacement in pixels.
+ * @param maxRadius - Maximum radius in pixels.
+ * @returns Clamped pixel offsets `{ x, y }`.
+ *
+ * @example
+ * ```ts
+ * const clamped = clampToRadius(100, 0, 50);
+ * // clamped === { x: 50, y: 0 }
+ * ```
+ */
+export function clampToRadius(
+    dx: number,
+    dy: number,
+    maxRadius: number,
+): { x: number; y: number } {
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    if (dist <= maxRadius) {
+        return { x: dx, y: dy };
+    }
+    const scale = maxRadius / dist;
+    return { x: dx * scale, y: dy * scale };
+}

--- a/packages/input/src/public/index.ts
+++ b/packages/input/src/public/index.ts
@@ -7,6 +7,13 @@ export { InputCommitSystem } from '../domain/systems/commit';
 
 // FC hooks
 export { useInput, useAction, useAxis1D, useAxis2D, usePointer } from './hooks';
+export { useVirtualJoystick } from './useVirtualJoystick';
+export type {
+    VirtualJoystickOptions,
+    VirtualJoystickHandle,
+    JoystickRenderState,
+    JoystickPosition,
+} from './useVirtualJoystick';
 
 // Testing/bots helper
 export { VirtualInput } from './virtual';

--- a/packages/input/src/public/useVirtualJoystick.test.ts
+++ b/packages/input/src/public/useVirtualJoystick.test.ts
@@ -1,0 +1,332 @@
+import { World, mount } from '@pulse-ts/core';
+import { installInput } from './install';
+import type { VirtualJoystickHandle } from './useVirtualJoystick';
+import { useVirtualJoystick } from './useVirtualJoystick';
+import { InputService } from '../domain/services/Input';
+
+// Minimal Touch/TouchEvent mocks for jsdom
+function createTouch(
+    target: EventTarget,
+    id: number,
+    clientX: number,
+    clientY: number,
+): Touch {
+    return {
+        identifier: id,
+        target,
+        clientX,
+        clientY,
+        screenX: clientX,
+        screenY: clientY,
+        pageX: clientX,
+        pageY: clientY,
+        radiusX: 0,
+        radiusY: 0,
+        rotationAngle: 0,
+        force: 1,
+    } as Touch;
+}
+
+function createTouchList(...touches: Touch[]): TouchList {
+    const list = touches as unknown as TouchList;
+    (list as any).length = touches.length;
+    (list as any).item = (i: number) => touches[i] ?? null;
+    // Allow indexed access
+    for (let i = 0; i < touches.length; i++) {
+        (list as any)[i] = touches[i];
+    }
+    return list;
+}
+
+function fireTouchEvent(el: HTMLElement, type: string, touches: Touch[]): void {
+    const event = new Event(type, {
+        bubbles: true,
+        cancelable: true,
+    }) as any;
+    event.changedTouches = createTouchList(...touches);
+    event.touches = createTouchList(...touches);
+    event.preventDefault = jest.fn();
+    el.dispatchEvent(event);
+}
+
+// Mock getBoundingClientRect for the container
+function mockContainerRect(
+    el: HTMLElement,
+    x: number,
+    y: number,
+    size: number,
+): void {
+    jest.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+        left: x,
+        top: y,
+        right: x + size,
+        bottom: y + size,
+        width: size,
+        height: size,
+        x,
+        y,
+        toJSON: () => ({}),
+    });
+}
+
+describe('useVirtualJoystick', () => {
+    let world: World;
+    let svc: InputService;
+
+    beforeEach(() => {
+        world = new World();
+        svc = installInput(world, {});
+    });
+
+    afterEach(() => {
+        // Clean up any appended elements
+        document.body.innerHTML = '';
+    });
+
+    function mountJoystick(
+        action: string,
+        options: Parameters<typeof useVirtualJoystick>[1] = {},
+    ): VirtualJoystickHandle {
+        let handle!: VirtualJoystickHandle;
+        mount(
+            world,
+            () => {
+                handle = useVirtualJoystick(action, options);
+            },
+            undefined,
+        );
+        return handle;
+    }
+
+    test('creates a DOM element appended to document.body', () => {
+        const handle = mountJoystick('move');
+        expect(handle.element).toBeInstanceOf(HTMLElement);
+        expect(document.body.contains(handle.element)).toBe(true);
+    });
+
+    test('appends to custom parent when specified', () => {
+        const parent = document.createElement('div');
+        document.body.appendChild(parent);
+        const handle = mountJoystick('move', { parent });
+        expect(parent.contains(handle.element)).toBe(true);
+    });
+
+    test('initial axes are zero', () => {
+        const handle = mountJoystick('move');
+        expect(handle.axes).toEqual({ x: 0, y: 0 });
+    });
+
+    test('setVisible hides and shows the element', () => {
+        const handle = mountJoystick('move');
+        handle.setVisible(false);
+        expect(handle.element.style.display).toBe('none');
+        handle.setVisible(true);
+        expect(handle.element.style.display).toBe('');
+    });
+
+    test('destroy removes the element and releases axis', () => {
+        const handle = mountJoystick('move');
+        const el = handle.element;
+        expect(document.body.contains(el)).toBe(true);
+        handle.destroy();
+        expect(document.body.contains(el)).toBe(false);
+    });
+
+    test('uses default size of 120', () => {
+        const handle = mountJoystick('move');
+        expect(handle.element.style.width).toBe('120px');
+        expect(handle.element.style.height).toBe('120px');
+    });
+
+    test('respects custom size', () => {
+        const handle = mountJoystick('move', { size: 200 });
+        expect(handle.element.style.width).toBe('200px');
+        expect(handle.element.style.height).toBe('200px');
+    });
+
+    test('positions bottom-left by default', () => {
+        const handle = mountJoystick('move');
+        expect(handle.element.style.left).toBe('20px');
+        expect(handle.element.style.bottom).toBe('20px');
+    });
+
+    test('positions bottom-right when specified', () => {
+        const handle = mountJoystick('move', { position: 'bottom-right' });
+        expect(handle.element.style.right).toBe('20px');
+        expect(handle.element.style.bottom).toBe('20px');
+    });
+
+    test('positions with custom coordinates', () => {
+        const handle = mountJoystick('move', {
+            position: { x: '50%', y: '80%' },
+        });
+        expect(handle.element.style.left).toBe('50%');
+        expect(handle.element.style.top).toBe('80%');
+    });
+
+    test('touch interaction injects axis2D hold into InputService', () => {
+        const handle = mountJoystick('move', { size: 120, deadzone: 0 });
+        const el = handle.element;
+        mockContainerRect(el, 0, 0, 120); // center at (60, 60)
+
+        const touch = createTouch(el, 1, 120, 60); // max right
+        fireTouchEvent(el, 'touchstart', [touch]);
+
+        svc.commit();
+        const vec = svc.vec2('move');
+        expect(vec.x).toBeCloseTo(1);
+        expect(vec.y).toBeCloseTo(0);
+    });
+
+    test('touch move updates axis values', () => {
+        const handle = mountJoystick('move', { size: 120, deadzone: 0 });
+        const el = handle.element;
+        mockContainerRect(el, 0, 0, 120);
+
+        const startTouch = createTouch(el, 1, 90, 60); // right of center
+        fireTouchEvent(el, 'touchstart', [startTouch]);
+
+        const moveTouch = createTouch(el, 1, 60, 120); // below center (max down)
+        fireTouchEvent(el, 'touchmove', [moveTouch]);
+
+        svc.commit();
+        const vec = svc.vec2('move');
+        expect(vec.x).toBeCloseTo(0);
+        expect(vec.y).toBeCloseTo(1);
+    });
+
+    test('touch end releases axis hold', () => {
+        const handle = mountJoystick('move', { size: 120, deadzone: 0 });
+        const el = handle.element;
+        mockContainerRect(el, 0, 0, 120);
+
+        const touch = createTouch(el, 1, 120, 60);
+        fireTouchEvent(el, 'touchstart', [touch]);
+
+        svc.commit();
+        expect(svc.vec2('move').x).toBeCloseTo(1);
+
+        fireTouchEvent(el, 'touchend', [touch]);
+        svc.commit();
+        // After release, the hold is cleared so the default zero is returned
+        expect(svc.vec2('move')).toEqual({ x: 0, y: 0 });
+    });
+
+    test('touch cancel releases axis hold', () => {
+        const handle = mountJoystick('move', { size: 120, deadzone: 0 });
+        const el = handle.element;
+        mockContainerRect(el, 0, 0, 120);
+
+        const touch = createTouch(el, 1, 120, 60);
+        fireTouchEvent(el, 'touchstart', [touch]);
+        svc.commit();
+        expect(svc.vec2('move').x).toBeCloseTo(1);
+
+        fireTouchEvent(el, 'touchcancel', [touch]);
+        svc.commit();
+        expect(svc.vec2('move')).toEqual({ x: 0, y: 0 });
+    });
+
+    test('deadzone suppresses small movements', () => {
+        const handle = mountJoystick('move', {
+            size: 120,
+            deadzone: 0.5, // Large deadzone: 50% of radius
+        });
+        const el = handle.element;
+        mockContainerRect(el, 0, 0, 120);
+
+        // Touch 15px right of center — within deadzone (30px)
+        const touch = createTouch(el, 1, 75, 60);
+        fireTouchEvent(el, 'touchstart', [touch]);
+
+        expect(handle.axes.x).toBe(0);
+        expect(handle.axes.y).toBe(0);
+    });
+
+    test('ignores second simultaneous touch', () => {
+        const handle = mountJoystick('move', { size: 120, deadzone: 0 });
+        const el = handle.element;
+        mockContainerRect(el, 0, 0, 120);
+
+        const touch1 = createTouch(el, 1, 120, 60);
+        fireTouchEvent(el, 'touchstart', [touch1]);
+        expect(handle.axes.x).toBeCloseTo(1);
+
+        // Second touch should be ignored
+        const touch2 = createTouch(el, 2, 0, 60);
+        fireTouchEvent(el, 'touchstart', [touch2]);
+        // Axes should still reflect first touch
+        expect(handle.axes.x).toBeCloseTo(1);
+    });
+
+    test('clamps displacement to max radius for visuals but normalizes axis to 1', () => {
+        const handle = mountJoystick('move', { size: 120, deadzone: 0 });
+        const el = handle.element;
+        mockContainerRect(el, 0, 0, 120);
+
+        // Touch way beyond max radius
+        const touch = createTouch(el, 1, 500, 60);
+        fireTouchEvent(el, 'touchstart', [touch]);
+
+        // Axis should be clamped to 1
+        expect(handle.axes.x).toBeCloseTo(1);
+        expect(handle.axes.y).toBeCloseTo(0);
+    });
+
+    test('custom render callback receives render state', () => {
+        const renderFn = jest.fn((state: any) => {
+            const el = document.createElement('div');
+            el.className = 'custom-joystick';
+            // Verify state has reactive getters
+            expect(typeof state.knobX).toBe('function');
+            expect(typeof state.knobY).toBe('function');
+            expect(typeof state.axisX).toBe('function');
+            expect(typeof state.axisY).toBe('function');
+            expect(typeof state.active).toBe('function');
+            expect(state.size).toBe(120);
+            return el;
+        });
+
+        mountJoystick('move', { render: renderFn });
+        expect(renderFn).toHaveBeenCalledTimes(1);
+    });
+
+    test('render state getters update on touch', () => {
+        let capturedState: any;
+        const renderFn = (state: any) => {
+            capturedState = state;
+            return document.createElement('div');
+        };
+
+        const handle = mountJoystick('move', {
+            size: 120,
+            deadzone: 0,
+            render: renderFn,
+        });
+        const el = handle.element;
+        mockContainerRect(el, 0, 0, 120);
+
+        expect(capturedState.active()).toBe(false);
+        expect(capturedState.knobX()).toBe(0);
+
+        const touch = createTouch(el, 1, 120, 60);
+        fireTouchEvent(el, 'touchstart', [touch]);
+
+        expect(capturedState.active()).toBe(true);
+        expect(capturedState.knobX()).toBeGreaterThan(0);
+        expect(capturedState.axisX()).toBeCloseTo(1);
+    });
+
+    test('throws if InputService is not installed', () => {
+        const bareWorld = new World();
+        expect(() => {
+            mount(
+                bareWorld,
+                () => {
+                    useVirtualJoystick('move');
+                },
+                undefined,
+            );
+        }).toThrow('InputService not provided');
+    });
+});

--- a/packages/input/src/public/useVirtualJoystick.ts
+++ b/packages/input/src/public/useVirtualJoystick.ts
@@ -1,0 +1,383 @@
+import { __fcCurrent } from '@pulse-ts/core';
+import { InputService } from '../domain/services/Input';
+import {
+    computeDisplacement,
+    applyDeadzone,
+    clampToRadius,
+} from '../domain/services/internal/joystickMath';
+
+/**
+ * Position preset or custom CSS coordinates for the joystick.
+ */
+export type JoystickPosition =
+    | 'bottom-left'
+    | 'bottom-right'
+    | { x: string; y: string };
+
+/**
+ * Reactive state passed to a custom joystick render callback.
+ * All value accessors are functions (reactive getters) so they integrate
+ * with reactive DOM binding systems.
+ */
+export interface JoystickRenderState {
+    /** Knob offset in pixels from center (-maxOffset to +maxOffset). Reactive getter. */
+    knobX: () => number;
+    /** Knob offset in pixels from center (-maxOffset to +maxOffset). Reactive getter. */
+    knobY: () => number;
+    /** Normalized axis after deadzone (-1 to 1). Reactive getter. */
+    axisX: () => number;
+    /** Normalized axis after deadzone (-1 to 1). Reactive getter. */
+    axisY: () => number;
+    /** Whether a touch is currently active. Reactive getter. */
+    active: () => boolean;
+    /** Base size in pixels. */
+    size: number;
+}
+
+/**
+ * Configuration options for {@link useVirtualJoystick}.
+ */
+export interface VirtualJoystickOptions {
+    /** Screen position preset or custom CSS coordinates. Default: `'bottom-left'`. */
+    position?: JoystickPosition;
+    /** Outer diameter in pixels. Default: `120`. */
+    size?: number;
+    /** Deadzone radius as a fraction (0-1). Below this threshold, output is zero. Default: `0.15`. */
+    deadzone?: number;
+    /** Parent element to append the joystick to. Default: `document.body`. */
+    parent?: HTMLElement;
+    /** Custom render callback. Receives reactive state. Omit for default circle + knob visuals. */
+    render?: (state: JoystickRenderState) => HTMLElement;
+}
+
+/**
+ * Handle returned by {@link useVirtualJoystick} for controlling the joystick.
+ */
+export interface VirtualJoystickHandle {
+    /** The root DOM element containing the joystick. */
+    readonly element: HTMLElement;
+    /** Current axis values after deadzone (-1 to 1 each). */
+    readonly axes: { x: number; y: number };
+    /** Show or hide the joystick. */
+    setVisible(visible: boolean): void;
+    /** Remove the joystick from the DOM and detach all listeners. */
+    destroy(): void;
+}
+
+/** Default joystick size in pixels. */
+const DEFAULT_SIZE = 120;
+/** Default deadzone fraction. */
+const DEFAULT_DEADZONE = 0.15;
+
+/**
+ * Creates a virtual joystick that injects into the input system's named axis action.
+ * Handles touch ID tracking, displacement math, deadzone application,
+ * input system injection, and cleanup.
+ *
+ * The hook owns all touch math. Visual rendering is pluggable via the `render`
+ * option; when omitted, a default circle + knob design is used.
+ *
+ * @param axisAction - The input action name to inject axis values into (via `holdAxis2D`).
+ * @param options - Configuration and optional custom render callback.
+ * @returns A handle for controlling visibility, reading axis values, and cleanup.
+ *
+ * @example
+ * ```ts
+ * import { useVirtualJoystick } from '@pulse-ts/input';
+ *
+ * // Default visuals — zero config
+ * const joystick = useVirtualJoystick('move', {
+ *     position: 'bottom-left',
+ *     size: 120,
+ *     deadzone: 0.15,
+ * });
+ * ```
+ *
+ * @example
+ * ```ts
+ * import { useVirtualJoystick } from '@pulse-ts/input';
+ *
+ * // Custom visuals via render callback
+ * const joystick = useVirtualJoystick('move', {
+ *     position: 'bottom-right',
+ *     render: (state) => {
+ *         const el = document.createElement('div');
+ *         el.style.width = `${state.size}px`;
+ *         el.style.height = `${state.size}px`;
+ *         // Use state.knobX(), state.knobY(), state.active() for updates
+ *         return el;
+ *     },
+ * });
+ * ```
+ */
+export function useVirtualJoystick(
+    axisAction: string,
+    options: VirtualJoystickOptions = {},
+): VirtualJoystickHandle {
+    const world = __fcCurrent().world;
+    const svc = world.getService(InputService);
+    if (!svc) {
+        throw new Error(
+            'InputService not provided. Call installInput(world) first.',
+        );
+    }
+
+    const size = options.size ?? DEFAULT_SIZE;
+    const deadzone = options.deadzone ?? DEFAULT_DEADZONE;
+    const maxRadius = size / 2;
+
+    // Mutable state tracked by touch handlers
+    let activeTouchId: number | null = null;
+    let currentKnobX = 0;
+    let currentKnobY = 0;
+    let currentAxisX = 0;
+    let currentAxisY = 0;
+    let isActive = false;
+
+    // Build reactive state for render callback
+    const renderState: JoystickRenderState = {
+        knobX: () => currentKnobX,
+        knobY: () => currentKnobY,
+        axisX: () => currentAxisX,
+        axisY: () => currentAxisY,
+        active: () => isActive,
+        size,
+    };
+
+    // Create root container
+    const container = document.createElement('div');
+    container.style.position = 'fixed';
+    container.style.zIndex = '9999';
+    container.style.touchAction = 'none';
+    container.style.userSelect = 'none';
+    applyPosition(container, options.position ?? 'bottom-left', size);
+
+    // Build visual content
+    let knobElement: HTMLElement | null = null;
+
+    if (options.render) {
+        const customEl = options.render(renderState);
+        container.appendChild(customEl);
+    } else {
+        const { base, knob } = createDefaultVisuals(size);
+        knobElement = knob;
+        container.appendChild(base);
+    }
+
+    // Touch handlers
+    const onTouchStart = (e: TouchEvent): void => {
+        if (activeTouchId !== null) return; // Already tracking a touch
+        const touch = e.changedTouches[0];
+        if (!touch) return;
+
+        const rect = container.getBoundingClientRect();
+        const centerX = rect.left + rect.width / 2;
+        const centerY = rect.top + rect.height / 2;
+        const dx = touch.clientX - centerX;
+        const dy = touch.clientY - centerY;
+
+        // Only capture if touch is within the joystick bounds (generous)
+        if (Math.abs(dx) > size && Math.abs(dy) > size) return;
+
+        activeTouchId = touch.identifier;
+        e.preventDefault();
+
+        updateFromTouch(touch.clientX, touch.clientY, rect, svc);
+    };
+
+    const onTouchMove = (e: TouchEvent): void => {
+        if (activeTouchId === null) return;
+        const touch = findTouch(e.changedTouches, activeTouchId);
+        if (!touch) return;
+        e.preventDefault();
+
+        const rect = container.getBoundingClientRect();
+        updateFromTouch(touch.clientX, touch.clientY, rect, svc);
+    };
+
+    const onTouchEnd = (e: TouchEvent): void => {
+        if (activeTouchId === null) return;
+        const touch = findTouch(e.changedTouches, activeTouchId);
+        if (!touch) return;
+        e.preventDefault();
+
+        activeTouchId = null;
+        resetState(svc);
+    };
+
+    /**
+     * Update joystick state from a touch position.
+     */
+    function updateFromTouch(
+        touchX: number,
+        touchY: number,
+        rect: DOMRect,
+        inputService: InputService,
+    ): void {
+        const centerX = rect.left + rect.width / 2;
+        const centerY = rect.top + rect.height / 2;
+
+        const displacement = computeDisplacement(
+            centerX,
+            centerY,
+            touchX,
+            touchY,
+        );
+        const output = applyDeadzone(displacement, maxRadius, deadzone);
+        const clamped = clampToRadius(
+            displacement.dx,
+            displacement.dy,
+            maxRadius,
+        );
+
+        currentKnobX = clamped.x;
+        currentKnobY = clamped.y;
+        currentAxisX = output.x;
+        currentAxisY = output.y;
+        isActive = true;
+
+        // Inject into input system as a held axis
+        inputService.holdAxis2D(axisAction, { x: output.x, y: output.y });
+
+        // Update default visuals
+        updateDefaultVisuals();
+    }
+
+    /**
+     * Reset joystick to center/inactive state.
+     * Injects a zero hold before releasing so the last committed vec2 is zero.
+     */
+    function resetState(inputService: InputService): void {
+        currentKnobX = 0;
+        currentKnobY = 0;
+        currentAxisX = 0;
+        currentAxisY = 0;
+        isActive = false;
+
+        inputService.holdAxis2D(axisAction, { x: 0, y: 0 });
+        updateDefaultVisuals();
+    }
+
+    /**
+     * Update default knob element position and style.
+     */
+    function updateDefaultVisuals(): void {
+        if (!knobElement) return;
+        const center = size / 2;
+        knobElement.style.left = `${center + currentKnobX - 20}px`;
+        knobElement.style.top = `${center + currentKnobY - 20}px`;
+        knobElement.style.background = isActive
+            ? 'rgba(255, 255, 255, 0.6)'
+            : 'rgba(255, 255, 255, 0.3)';
+    }
+
+    // Attach listeners to container
+    container.addEventListener('touchstart', onTouchStart, { passive: false });
+    container.addEventListener('touchmove', onTouchMove, { passive: false });
+    container.addEventListener('touchend', onTouchEnd, { passive: false });
+    container.addEventListener('touchcancel', onTouchEnd, { passive: false });
+
+    // Append to parent
+    const parent = options.parent ?? document.body;
+    parent.appendChild(container);
+
+    // Build handle
+    const handle: VirtualJoystickHandle = {
+        get element() {
+            return container;
+        },
+        get axes() {
+            return { x: currentAxisX, y: currentAxisY };
+        },
+        setVisible(visible: boolean): void {
+            container.style.display = visible ? '' : 'none';
+        },
+        destroy(): void {
+            container.removeEventListener('touchstart', onTouchStart);
+            container.removeEventListener('touchmove', onTouchMove);
+            container.removeEventListener('touchend', onTouchEnd);
+            container.removeEventListener('touchcancel', onTouchEnd);
+            svc.releaseAxis2D(axisAction);
+            container.remove();
+        },
+    };
+
+    return handle;
+}
+
+/**
+ * Apply a position preset or custom coordinates to a container element.
+ *
+ * @param el - The element to position.
+ * @param position - Position preset or custom `{ x, y }` CSS values.
+ * @param size - Joystick size in pixels (used for margin calculations).
+ */
+function applyPosition(
+    el: HTMLElement,
+    position: JoystickPosition,
+    size: number,
+): void {
+    const margin = '20px';
+    if (typeof position === 'string') {
+        el.style.bottom = margin;
+        if (position === 'bottom-left') {
+            el.style.left = margin;
+        } else {
+            el.style.right = margin;
+        }
+    } else {
+        el.style.left = position.x;
+        el.style.top = position.y;
+    }
+    el.style.width = `${size}px`;
+    el.style.height = `${size}px`;
+}
+
+/**
+ * Create default circle + knob visual elements.
+ *
+ * @param size - Diameter of the outer circle in pixels.
+ * @returns Object with `base` (outer circle) and `knob` (inner draggable) elements.
+ */
+function createDefaultVisuals(size: number): {
+    base: HTMLElement;
+    knob: HTMLElement;
+} {
+    const base = document.createElement('div');
+    base.style.position = 'relative';
+    base.style.width = `${size}px`;
+    base.style.height = `${size}px`;
+    base.style.borderRadius = '50%';
+    base.style.border = '2px solid rgba(255, 255, 255, 0.2)';
+    base.style.background = 'rgba(0, 0, 0, 0.15)';
+    base.style.boxSizing = 'border-box';
+
+    const knobSize = 40;
+    const knob = document.createElement('div');
+    knob.style.position = 'absolute';
+    knob.style.width = `${knobSize}px`;
+    knob.style.height = `${knobSize}px`;
+    knob.style.borderRadius = '50%';
+    knob.style.background = 'rgba(255, 255, 255, 0.3)';
+    knob.style.left = `${size / 2 - knobSize / 2}px`;
+    knob.style.top = `${size / 2 - knobSize / 2}px`;
+    knob.style.transition = 'background 0.1s';
+    knob.style.pointerEvents = 'none';
+
+    base.appendChild(knob);
+    return { base, knob };
+}
+
+/**
+ * Find a specific touch by identifier in a TouchList.
+ *
+ * @param touches - The TouchList to search.
+ * @param id - The touch identifier to find.
+ * @returns The matching Touch, or undefined.
+ */
+function findTouch(touches: TouchList, id: number): Touch | undefined {
+    for (let i = 0; i < touches.length; i++) {
+        if (touches[i].identifier === id) return touches[i];
+    }
+    return undefined;
+}


### PR DESCRIPTION
## Summary

- Implement `useVirtualJoystick` hook in `@pulse-ts/input` with touch math (deadzone, normalization, touch ID tracking) and input injection via `holdAxis2D`
- Pluggable visual layer via `render` callback with reactive getters (`JoystickRenderState`); default circle + knob visuals when omitted
- Pure math utilities (`computeDisplacement`, `applyDeadzone`, `clampToRadius`) in `joystickMath.ts`

## Test plan

- [x] Unit tests for `computeDisplacement` (zero, positive, negative, diagonal)
- [x] Unit tests for `applyDeadzone` (within deadzone, boundary, max, beyond, linear rescale, zero deadzone, diagonal)
- [x] Unit tests for `clampToRadius` (within, beyond, boundary, diagonal direction preservation)
- [x] Hook tests: DOM creation, custom parent, initial state, visibility toggle, destroy
- [x] Hook tests: position presets (bottom-left, bottom-right, custom)
- [x] Hook tests: touch interaction injects axis2D, touch move updates, touch end/cancel releases
- [x] Hook tests: deadzone suppresses small movements, ignores second touch, clamps beyond max
- [x] Hook tests: custom render callback receives reactive state with getters
- [x] Hook tests: throws if InputService not installed
- [x] All 79 tests passing, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)