### PR TITLE
TICKET-124: Input Binding Shorthand (Axis2D.keys / wasd / arrows)

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-022-input-and-platform-dx-pass/done/TICKET-124-input-binding-shorthand.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-022-input-and-platform-dx-pass/done/TICKET-124-input-binding-shorthand.md
@@ -2,7 +2,7 @@
 id: TICKET-124
 epic: EPIC-022
 title: Input Binding Shorthand (Axis2D.keys / wasd / arrows)
-status: in-progress
+status: done
 priority: low
 created: 2026-03-13
 updated: 2026-03-13
@@ -21,14 +21,14 @@ Design doc: `design-docs/approved/037-input-binding-shorthand.md`
 
 ## Acceptance Criteria
 
-- [ ] `Axis2D.keys(left, right, down, up)` creates a 2D axis from four key codes
-- [ ] `Axis2D.wasd()` preset for WASD keys
-- [ ] `Axis2D.arrows()` preset for arrow keys
-- [ ] Parameter order: left, right, down, up (X-axis first, then Y-axis)
-- [ ] Full form `Axis2D({ x: Axis1D(...), y: Axis1D(...) })` still available
-- [ ] JSDoc with examples
-- [ ] Unit tests for all shorthands
-- [ ] Documentation updated
+- [x] `Axis2D.keys(left, right, down, up)` creates a 2D axis from four key codes
+- [x] `Axis2D.wasd()` preset for WASD keys
+- [x] `Axis2D.arrows()` preset for arrow keys
+- [x] Parameter order: left, right, down, up (X-axis first, then Y-axis)
+- [x] Full form `Axis2D({ x: Axis1D(...), y: Axis1D(...) })` still available
+- [x] JSDoc with examples
+- [x] Unit tests for all shorthands
+- [x] Documentation updated
 
 ## Notes
 

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-022-input-and-platform-dx-pass/in-progress/TICKET-124-input-binding-shorthand.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-022-input-and-platform-dx-pass/in-progress/TICKET-124-input-binding-shorthand.md
@@ -2,7 +2,7 @@
 id: TICKET-124
 epic: EPIC-022
 title: Input Binding Shorthand (Axis2D.keys / wasd / arrows)
-status: todo
+status: in-progress
 priority: low
 created: 2026-03-13
 updated: 2026-03-13

--- a/apps/docs/api/input/src/functions/Axis2D.md
+++ b/apps/docs/api/input/src/functions/Axis2D.md
@@ -32,3 +32,35 @@ The Axis2D binding expression.
 import { Axis2D, Key } from '@pulse-ts/input';
 const move = Axis2D({ x: { pos: Key('D'), neg: Key('A') }, y: { pos: Key('W'), neg: Key('S') } });
 ```
+
+## Static Methods
+
+### Axis2D.keys()
+
+> **Axis2D.keys**(`left`, `right`, `down`, `up`): [`Axis2DBinding`](../type-aliases/Axis2DBinding.md)
+
+Create a 2D axis from four key codes: left, right, down, up. Parameter order is X-axis first (left, right), then Y-axis (down, up).
+
+```ts
+const ijklMove = Axis2D.keys('KeyJ', 'KeyL', 'KeyK', 'KeyI');
+```
+
+### Axis2D.wasd()
+
+> **Axis2D.wasd**(): [`Axis2DBinding`](../type-aliases/Axis2DBinding.md)
+
+Create a 2D axis bound to WASD keys. Shorthand for `Axis2D.keys('KeyA', 'KeyD', 'KeyS', 'KeyW')`.
+
+```ts
+const move = Axis2D.wasd();
+```
+
+### Axis2D.arrows()
+
+> **Axis2D.arrows**(): [`Axis2DBinding`](../type-aliases/Axis2DBinding.md)
+
+Create a 2D axis bound to arrow keys. Shorthand for `Axis2D.keys('ArrowLeft', 'ArrowRight', 'ArrowDown', 'ArrowUp')`.
+
+```ts
+const move = Axis2D.arrows();
+```

--- a/apps/docs/guides/input-bindings.md
+++ b/apps/docs/guides/input-bindings.md
@@ -15,10 +15,14 @@ installInput(world, {
     jump: Chord([Key('Space')]),
     dash: Sequence([Key('KeyD'), Key('KeyS')], { maxGapFrames: 10 }),
 
-    // Axes
+    // Axes (shorthand)
+    move: Axis2D.wasd(),
+    p2Move: Axis2D.arrows(),
+
+    // Axes (full form — use when you need custom keys or scale)
     moveX: Axis1D({ pos: Key('D'), neg: Key('A') }),
     moveY: Axis1D({ pos: Key('W'), neg: Key('S') }),
-    move: Axis2D({ x: { pos: Key('D'), neg: Key('A') }, y: { pos: Key('W'), neg: Key('S') } }),
+    customMove: Axis2D({ x: { pos: Key('D'), neg: Key('A') }, y: { pos: Key('W'), neg: Key('S') } }),
 
     // Pointer
     look: PointerMovement({ scaleX: 0.1, scaleY: 0.1 }),
@@ -129,7 +133,7 @@ const joystick = useVirtualJoystick('move', {
 
 - Set `preventDefault` to avoid scrolling/back/forward during gameplay.
 - Enable `pointerLock` to capture mouse for FPS-style look.
-- Use `Axis2D` for combined WASD vectors and `Axis1D` for single axes.
+- Use `Axis2D.wasd()` or `Axis2D.arrows()` for common movement bindings, or `Axis2D.keys(left, right, down, up)` for custom four-key layouts.
 - Use `Chord` for simultaneous keys and `Sequence` for combos.
 
 Note: `preventDefault` and `pointerLock` default to `false` unless specified in `installInput` options.

--- a/packages/input/src/domain/bindings/expr.test.ts
+++ b/packages/input/src/domain/bindings/expr.test.ts
@@ -23,4 +23,57 @@ describe('expr helpers', () => {
         expect((a2 as any).invertX).toBeUndefined();
         expect((a2 as any).invertY).toBeUndefined();
     });
+
+    test('Axis2D.keys creates a 2D axis from four key codes', () => {
+        const a = Axis2D.keys('KeyJ', 'KeyL', 'KeyK', 'KeyI');
+        expect(a.type).toBe('axis2d');
+        expect(a.axes['x'].neg[0].code).toBe('KeyJ');
+        expect(a.axes['x'].pos[0].code).toBe('KeyL');
+        expect(a.axes['y'].neg[0].code).toBe('KeyK');
+        expect(a.axes['y'].pos[0].code).toBe('KeyI');
+    });
+
+    test('Axis2D.keys normalizes shorthand key codes', () => {
+        const a = Axis2D.keys('a', 'd', 's', 'w');
+        expect(a.axes['x'].neg[0].code).toBe('KeyA');
+        expect(a.axes['x'].pos[0].code).toBe('KeyD');
+        expect(a.axes['y'].neg[0].code).toBe('KeyS');
+        expect(a.axes['y'].pos[0].code).toBe('KeyW');
+    });
+
+    test('Axis2D.wasd creates WASD bindings', () => {
+        const a = Axis2D.wasd();
+        expect(a.type).toBe('axis2d');
+        expect(a.axes['x'].neg[0].code).toBe('KeyA');
+        expect(a.axes['x'].pos[0].code).toBe('KeyD');
+        expect(a.axes['y'].neg[0].code).toBe('KeyS');
+        expect(a.axes['y'].pos[0].code).toBe('KeyW');
+    });
+
+    test('Axis2D.arrows creates arrow key bindings', () => {
+        const a = Axis2D.arrows();
+        expect(a.type).toBe('axis2d');
+        expect(a.axes['x'].neg[0].code).toBe('ArrowLeft');
+        expect(a.axes['x'].pos[0].code).toBe('ArrowRight');
+        expect(a.axes['y'].neg[0].code).toBe('ArrowDown');
+        expect(a.axes['y'].pos[0].code).toBe('ArrowUp');
+    });
+
+    test('Axis2D.wasd produces same result as manual construction', () => {
+        const shorthand = Axis2D.wasd();
+        const manual = Axis2D({
+            x: { neg: Key('KeyA'), pos: Key('KeyD') },
+            y: { neg: Key('KeyS'), pos: Key('KeyW') },
+        });
+        expect(shorthand).toEqual(manual);
+    });
+
+    test('Axis2D full form still works alongside shorthands', () => {
+        const full = Axis2D({
+            x: { pos: Key('D'), neg: Key('A'), scale: 2 },
+            y: { pos: Key('W'), neg: Key('S') },
+        });
+        expect(full.type).toBe('axis2d');
+        expect(full.axes['x'].scale).toBe(2);
+    });
 });

--- a/packages/input/src/domain/bindings/expr.ts
+++ b/packages/input/src/domain/bindings/expr.ts
@@ -105,6 +105,69 @@ export function Axis2D(
 }
 
 /**
+ * Create a 2D axis from four key codes: left, right, down, up.
+ *
+ * Equivalent to `Axis2D({ x: Axis1D({ neg: Key(left), pos: Key(right) }), y: Axis1D({ neg: Key(down), pos: Key(up) }) })`.
+ *
+ * @param left  Key code for negative X (move left).
+ * @param right Key code for positive X (move right).
+ * @param down  Key code for negative Y (move down).
+ * @param up    Key code for positive Y (move up).
+ * @returns The Axis2D binding expression.
+ *
+ * @example
+ * ```ts
+ * import { Axis2D } from '@pulse-ts/input';
+ * const ijklMove = Axis2D.keys('KeyJ', 'KeyL', 'KeyK', 'KeyI');
+ * ```
+ */
+Axis2D.keys = function keys(
+    left: string,
+    right: string,
+    down: string,
+    up: string,
+): Axis2DBinding {
+    return Axis2D({
+        x: { neg: Key(left), pos: Key(right) },
+        y: { neg: Key(down), pos: Key(up) },
+    });
+};
+
+/**
+ * Create a 2D axis bound to WASD keys.
+ *
+ * Shorthand for `Axis2D.keys('KeyA', 'KeyD', 'KeyS', 'KeyW')`.
+ *
+ * @returns The Axis2D binding expression for WASD.
+ *
+ * @example
+ * ```ts
+ * import { Axis2D } from '@pulse-ts/input';
+ * const move = Axis2D.wasd();
+ * ```
+ */
+Axis2D.wasd = function wasd(): Axis2DBinding {
+    return Axis2D.keys('KeyA', 'KeyD', 'KeyS', 'KeyW');
+};
+
+/**
+ * Create a 2D axis bound to arrow keys.
+ *
+ * Shorthand for `Axis2D.keys('ArrowLeft', 'ArrowRight', 'ArrowDown', 'ArrowUp')`.
+ *
+ * @returns The Axis2D binding expression for arrow keys.
+ *
+ * @example
+ * ```ts
+ * import { Axis2D } from '@pulse-ts/input';
+ * const move = Axis2D.arrows();
+ * ```
+ */
+Axis2D.arrows = function arrows(): Axis2DBinding {
+    return Axis2D.keys('ArrowLeft', 'ArrowRight', 'ArrowDown', 'ArrowUp');
+};
+
+/**
  * Create a pointer movement binding (maps mouse/touch delta to a 2D axis).
  * @param opts Pointer options (invert/scale per-axis).
  * @returns The pointer movement binding expression.


### PR DESCRIPTION
## Summary
- Add `Axis2D.keys(left, right, down, up)` static method for custom four-key 2D axis bindings
- Add `Axis2D.wasd()` and `Axis2D.arrows()` presets for the two most common movement bindings
- Full form `Axis2D({ x: Axis1D(...), y: Axis1D(...) })` remains available for custom configurations

## Test plan
- [x] Unit tests for `Axis2D.keys()` with explicit key codes
- [x] Unit tests for `Axis2D.keys()` with shorthand normalization
- [x] Unit tests for `Axis2D.wasd()` preset
- [x] Unit tests for `Axis2D.arrows()` preset
- [x] Equivalence test: `Axis2D.wasd()` produces same result as manual construction
- [x] Full form still works alongside shorthands
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)