### PR TITLE
TICKET-126: Platform Package (@pulse-ts/platform)

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-022-input-and-platform-dx-pass/done/TICKET-126-platform-package.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-022-input-and-platform-dx-pass/done/TICKET-126-platform-package.md
@@ -2,7 +2,7 @@
 id: TICKET-126
 epic: EPIC-022
 title: Platform Package (@pulse-ts/platform)
-status: in-progress
+status: done
 priority: low
 created: 2026-03-13
 updated: 2026-03-14
@@ -22,13 +22,13 @@ Design doc: `design-docs/approved/014-platform-package.md`
 
 ## Acceptance Criteria
 
-- [ ] New `@pulse-ts/platform` package created
-- [ ] `isMobile()` returns boolean based on user agent / touch support
-- [ ] `installMobileSupport(options)` handles fullscreen, orientation lock, install prompt
-- [ ] Options are all optional with sensible defaults
-- [ ] JSDoc with examples
-- [ ] Unit tests (mocked environment)
-- [ ] Documentation: overview, quickstart
+- [x] New `@pulse-ts/platform` package created
+- [x] `isMobile()` returns boolean based on user agent / touch support
+- [x] `installMobileSupport(options)` handles fullscreen, orientation lock, install prompt
+- [x] Options are all optional with sensible defaults
+- [x] JSDoc with examples
+- [x] Unit tests (mocked environment)
+- [x] Documentation: overview, quickstart
 
 ## Notes
 

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-022-input-and-platform-dx-pass/in-progress/TICKET-126-platform-package.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-022-input-and-platform-dx-pass/in-progress/TICKET-126-platform-package.md
@@ -2,10 +2,10 @@
 id: TICKET-126
 epic: EPIC-022
 title: Platform Package (@pulse-ts/platform)
-status: todo
+status: in-progress
 priority: low
 created: 2026-03-13
-updated: 2026-03-13
+updated: 2026-03-14
 labels:
   - platform
   - new-package

--- a/apps/docs/guides/platform-mobile-support.md
+++ b/apps/docs/guides/platform-mobile-support.md
@@ -1,0 +1,93 @@
+# Guide: Mobile Support with @pulse-ts/platform
+
+Detect mobile devices and set up fullscreen, orientation locking, and PWA install prompts with a single call.
+
+## Install
+
+```bash
+npm install @pulse-ts/platform
+```
+
+## Quick start
+
+```ts
+import { isMobile, installMobileSupport } from '@pulse-ts/platform';
+
+// Set up mobile support before world creation
+const cleanup = installMobileSupport({
+    fullscreen: true,
+    orientation: 'landscape',
+    installPrompt: true,
+});
+
+// Query device type anywhere in your app
+if (isMobile()) {
+    three.renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
+}
+```
+
+## API
+
+### `isMobile()`
+
+Returns `true` if the device is likely a mobile or tablet, using a combination of user-agent detection and touch capability checks.
+
+```ts
+if (isMobile()) {
+    // Reduce quality for mobile
+    three.renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
+}
+```
+
+### `installMobileSupport(options?)`
+
+One-call setup for common mobile game requirements. Returns a cleanup function.
+
+```ts
+const cleanup = installMobileSupport({
+    fullscreen: true,          // Request fullscreen on first touch (default: true)
+    orientation: 'landscape',  // Lock orientation: 'landscape' | 'portrait' | 'any' (default: 'any')
+    installPrompt: true,       // Show PWA install banner (default: false)
+    installPromptDismissKey: 'my-app-install-dismissed', // localStorage key for dismissal
+});
+
+// Tear down when leaving the game
+cleanup();
+```
+
+#### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `fullscreen` | `boolean` | `true` | Request fullscreen on first touch. |
+| `orientation` | `'landscape' \| 'portrait' \| 'any'` | `'any'` | Lock screen orientation and show a rotate overlay when wrong. |
+| `installPrompt` | `boolean` | `false` | Capture the `beforeinstallprompt` event and show an install banner. |
+| `installPromptDismissKey` | `string` | `'pulse-install-prompt-dismissed'` | `localStorage` key to persist user dismissal. |
+
+## Features
+
+### Fullscreen on first touch
+
+When `fullscreen: true`, the first `touchstart` event triggers `requestFullscreen()` on the document element. The listener is automatically removed after the first touch.
+
+### Orientation lock
+
+When `orientation` is `'landscape'` or `'portrait'`:
+
+1. Attempts to lock orientation via the Screen Orientation API.
+2. Displays a full-screen rotate overlay when the device is in the wrong orientation.
+3. The overlay automatically hides when the orientation is correct.
+
+### PWA install prompt
+
+When `installPrompt: true`:
+
+1. Captures the browser's `beforeinstallprompt` event.
+2. Displays a bottom banner with "Install" and "Not now" buttons.
+3. Dismissal is persisted to `localStorage` using the configured key.
+
+## Limitations
+
+- `isMobile()` uses user-agent sniffing combined with touch detection. It may not cover all edge cases (e.g., desktop browsers with touch screens return `false`).
+- Orientation lock via the Screen Orientation API requires fullscreen mode in most browsers.
+- The PWA install prompt (`beforeinstallprompt`) is only available in Chromium-based browsers.

--- a/packages/platform/jest.config.mjs
+++ b/packages/platform/jest.config.mjs
@@ -1,0 +1,10 @@
+export default {
+    testEnvironment: 'jsdom',
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+    transform: {
+        '^.+\\.(ts|tsx|js|jsx)$': ['babel-jest'],
+    },
+    testMatch: ['**/*.test.ts', '**/*.test.tsx'],
+    testPathIgnorePatterns: ['<rootDir>/*/node_modules/', '<rootDir>/*/dist/'],
+    watchman: false,
+};

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,0 +1,43 @@
+{
+    "name": "@pulse-ts/platform",
+    "version": "0.0.1",
+    "type": "module",
+    "publishConfig": {
+        "access": "public"
+    },
+    "main": "dist/index.cjs",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "files": [
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js",
+            "require": "./dist/index.cjs"
+        }
+    },
+    "scripts": {
+        "build": "tsup src/index.ts --dts --format esm,cjs --out-dir dist --clean",
+        "test": "jest",
+        "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
+        "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
+        "release": "npm run build && npm publish"
+    },
+    "babel": {
+        "presets": [
+            [
+                "@babel/preset-env",
+                {
+                    "targets": {
+                        "node": "current"
+                    },
+                    "modules": "auto"
+                }
+            ],
+            "@babel/preset-typescript"
+        ]
+    }
+}

--- a/packages/platform/src/domain/installMobileSupport.test.ts
+++ b/packages/platform/src/domain/installMobileSupport.test.ts
@@ -1,0 +1,240 @@
+import { installMobileSupport } from './installMobileSupport';
+
+describe('installMobileSupport', () => {
+    let addEventSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        addEventSpy = jest.spyOn(document, 'addEventListener');
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        document
+            .querySelectorAll('[data-pulse-rotate-overlay]')
+            .forEach((el) => el.remove());
+        document
+            .querySelectorAll('[data-pulse-install-banner]')
+            .forEach((el) => el.remove());
+        localStorage.clear();
+    });
+
+    it('returns a cleanup function', () => {
+        const cleanup = installMobileSupport();
+        expect(typeof cleanup).toBe('function');
+        cleanup();
+    });
+
+    // -- Fullscreen ---------------------------------------------------------
+
+    describe('fullscreen', () => {
+        it('adds a touchstart listener by default', () => {
+            const cleanup = installMobileSupport();
+            expect(addEventSpy).toHaveBeenCalledWith(
+                'touchstart',
+                expect.any(Function),
+                { once: true },
+            );
+            cleanup();
+        });
+
+        it('does not add touchstart when fullscreen is false', () => {
+            const cleanup = installMobileSupport({ fullscreen: false });
+            expect(addEventSpy).not.toHaveBeenCalledWith(
+                'touchstart',
+                expect.any(Function),
+                expect.anything(),
+            );
+            cleanup();
+        });
+
+        it('calls requestFullscreen on touchstart', () => {
+            const mockRequestFullscreen = jest
+                .fn()
+                .mockResolvedValue(undefined);
+            Object.defineProperty(
+                document.documentElement,
+                'requestFullscreen',
+                {
+                    value: mockRequestFullscreen,
+                    configurable: true,
+                    writable: true,
+                },
+            );
+
+            const cleanup = installMobileSupport({ fullscreen: true });
+
+            // Simulate touchstart
+            const event = new Event('touchstart');
+            document.dispatchEvent(event);
+
+            expect(mockRequestFullscreen).toHaveBeenCalled();
+            cleanup();
+        });
+    });
+
+    // -- Orientation --------------------------------------------------------
+
+    describe('orientation', () => {
+        it('does not create overlay when orientation is "any" (default)', () => {
+            const cleanup = installMobileSupport();
+            expect(
+                document.querySelector('[data-pulse-rotate-overlay]'),
+            ).toBeNull();
+            cleanup();
+        });
+
+        it('creates a rotate overlay when orientation is "landscape"', () => {
+            const cleanup = installMobileSupport({ orientation: 'landscape' });
+            const overlay = document.querySelector(
+                '[data-pulse-rotate-overlay]',
+            );
+            expect(overlay).not.toBeNull();
+            expect(overlay!.textContent).toContain('landscape');
+            cleanup();
+        });
+
+        it('creates a rotate overlay when orientation is "portrait"', () => {
+            const cleanup = installMobileSupport({ orientation: 'portrait' });
+            const overlay = document.querySelector(
+                '[data-pulse-rotate-overlay]',
+            );
+            expect(overlay).not.toBeNull();
+            expect(overlay!.textContent).toContain('portrait');
+            cleanup();
+        });
+
+        it('removes overlay on cleanup', () => {
+            const cleanup = installMobileSupport({ orientation: 'landscape' });
+            expect(
+                document.querySelector('[data-pulse-rotate-overlay]'),
+            ).not.toBeNull();
+            cleanup();
+            expect(
+                document.querySelector('[data-pulse-rotate-overlay]'),
+            ).toBeNull();
+        });
+
+        it('shows overlay when orientation is wrong', () => {
+            // jsdom defaults to 1024x768 (landscape)
+            const cleanup = installMobileSupport({ orientation: 'portrait' });
+            const overlay = document.querySelector(
+                '[data-pulse-rotate-overlay]',
+            ) as HTMLElement;
+            // Width > height means landscape, so portrait overlay should show
+            expect(overlay.style.display).toBe('flex');
+            cleanup();
+        });
+    });
+
+    // -- Install prompt -----------------------------------------------------
+
+    describe('installPrompt', () => {
+        it('does not set up install prompt by default', () => {
+            const windowAddEvent = jest.spyOn(globalThis, 'addEventListener');
+            const cleanup = installMobileSupport();
+            expect(windowAddEvent).not.toHaveBeenCalledWith(
+                'beforeinstallprompt',
+                expect.any(Function),
+            );
+            cleanup();
+            windowAddEvent.mockRestore();
+        });
+
+        it('listens for beforeinstallprompt when enabled', () => {
+            const windowAddEvent = jest.spyOn(globalThis, 'addEventListener');
+            const cleanup = installMobileSupport({ installPrompt: true });
+            expect(windowAddEvent).toHaveBeenCalledWith(
+                'beforeinstallprompt',
+                expect.any(Function),
+            );
+            cleanup();
+            windowAddEvent.mockRestore();
+        });
+
+        it('does not show banner if dismiss key is set in localStorage', () => {
+            localStorage.setItem('pulse-install-prompt-dismissed', '1');
+            const windowAddEvent = jest.spyOn(globalThis, 'addEventListener');
+            const cleanup = installMobileSupport({ installPrompt: true });
+            // Should not have registered the beforeinstallprompt listener
+            expect(windowAddEvent).not.toHaveBeenCalledWith(
+                'beforeinstallprompt',
+                expect.any(Function),
+            );
+            cleanup();
+            windowAddEvent.mockRestore();
+        });
+
+        it('uses a custom dismiss key', () => {
+            localStorage.setItem('my-key', '1');
+            const windowAddEvent = jest.spyOn(globalThis, 'addEventListener');
+            const cleanup = installMobileSupport({
+                installPrompt: true,
+                installPromptDismissKey: 'my-key',
+            });
+            expect(windowAddEvent).not.toHaveBeenCalledWith(
+                'beforeinstallprompt',
+                expect.any(Function),
+            );
+            cleanup();
+            windowAddEvent.mockRestore();
+        });
+
+        it('shows install banner on beforeinstallprompt event', () => {
+            const cleanup = installMobileSupport({ installPrompt: true });
+
+            const event = new Event('beforeinstallprompt', {
+                cancelable: true,
+            });
+            (event as Event & { prompt: () => Promise<void> }).prompt = jest
+                .fn()
+                .mockResolvedValue(undefined);
+            globalThis.dispatchEvent(event);
+
+            const banner = document.querySelector(
+                '[data-pulse-install-banner]',
+            );
+            expect(banner).not.toBeNull();
+            expect(banner!.textContent).toContain('Install');
+
+            cleanup();
+        });
+
+        it('removes banner on cleanup', () => {
+            const cleanup = installMobileSupport({ installPrompt: true });
+
+            const event = new Event('beforeinstallprompt', {
+                cancelable: true,
+            });
+            (event as Event & { prompt: () => Promise<void> }).prompt = jest
+                .fn()
+                .mockResolvedValue(undefined);
+            globalThis.dispatchEvent(event);
+
+            expect(
+                document.querySelector('[data-pulse-install-banner]'),
+            ).not.toBeNull();
+            cleanup();
+            expect(
+                document.querySelector('[data-pulse-install-banner]'),
+            ).toBeNull();
+        });
+    });
+
+    // -- Combined -----------------------------------------------------------
+
+    it('supports all options together', () => {
+        const cleanup = installMobileSupport({
+            fullscreen: true,
+            orientation: 'landscape',
+            installPrompt: true,
+        });
+        expect(typeof cleanup).toBe('function');
+        cleanup();
+    });
+
+    it('works with no options (defaults)', () => {
+        const cleanup = installMobileSupport();
+        expect(typeof cleanup).toBe('function');
+        cleanup();
+    });
+});

--- a/packages/platform/src/domain/installMobileSupport.ts
+++ b/packages/platform/src/domain/installMobileSupport.ts
@@ -1,0 +1,265 @@
+/**
+ * Configuration for {@link installMobileSupport}.
+ */
+export interface MobileSupportOptions {
+    /** Request fullscreen on first touch. Default: `true`. */
+    fullscreen?: boolean;
+    /** Lock orientation. `'landscape'` | `'portrait'` | `'any'`. Default: `'any'`. */
+    orientation?: 'landscape' | 'portrait' | 'any';
+    /** Show a PWA install prompt banner. Default: `false`. */
+    installPrompt?: boolean;
+    /** `localStorage` key used to persist install-prompt dismissal. */
+    installPromptDismissKey?: string;
+}
+
+const DEFAULT_OPTIONS: Required<MobileSupportOptions> = {
+    fullscreen: true,
+    orientation: 'any',
+    installPrompt: false,
+    installPromptDismissKey: 'pulse-install-prompt-dismissed',
+};
+
+/**
+ * Initialize mobile support utilities. Sets up fullscreen on first touch,
+ * orientation locking with a rotate overlay, and PWA install prompt.
+ * Returns a cleanup function that tears down all listeners and overlays.
+ *
+ * This function operates at the browser level and is not tied to any
+ * World lifecycle. Call it before world creation.
+ *
+ * @param options - Configuration for mobile support features.
+ * @returns A cleanup function that removes all listeners and DOM elements.
+ *
+ * @example
+ * ```ts
+ * import { installMobileSupport } from '@pulse-ts/platform';
+ *
+ * const cleanup = installMobileSupport({
+ *     fullscreen: true,
+ *     orientation: 'landscape',
+ *     installPrompt: true,
+ * });
+ *
+ * // Later, when tearing down:
+ * cleanup();
+ * ```
+ */
+export function installMobileSupport(
+    options?: MobileSupportOptions,
+): () => void {
+    const opts = { ...DEFAULT_OPTIONS, ...options };
+    const cleanups: Array<() => void> = [];
+
+    if (opts.fullscreen) {
+        cleanups.push(setupFullscreen());
+    }
+
+    if (opts.orientation !== 'any') {
+        cleanups.push(setupOrientationLock(opts.orientation));
+    }
+
+    if (opts.installPrompt) {
+        cleanups.push(setupInstallPrompt(opts.installPromptDismissKey));
+    }
+
+    return () => {
+        for (const fn of cleanups) fn();
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Fullscreen on first touch
+// ---------------------------------------------------------------------------
+
+function setupFullscreen(): () => void {
+    let removed = false;
+
+    const handler = () => {
+        const el = document.documentElement as HTMLElement & {
+            webkitRequestFullscreen?: () => Promise<void>;
+        };
+        const request =
+            el.requestFullscreen?.bind(el) ??
+            el.webkitRequestFullscreen?.bind(el);
+        request?.();
+        document.removeEventListener('touchstart', handler);
+        removed = true;
+    };
+
+    document.addEventListener('touchstart', handler, { once: true });
+
+    return () => {
+        if (!removed) {
+            document.removeEventListener('touchstart', handler);
+        }
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Orientation lock + rotate overlay
+// ---------------------------------------------------------------------------
+
+function setupOrientationLock(target: 'landscape' | 'portrait'): () => void {
+    // Try the Screen Orientation API
+    const lockOrientation = () => {
+        screen.orientation?.lock?.(target).catch(() => {
+            /* ignore — lock may not be available outside fullscreen */
+        });
+    };
+    lockOrientation();
+
+    // Create a rotate overlay for when the orientation is wrong
+    const overlay = document.createElement('div');
+    overlay.setAttribute('data-pulse-rotate-overlay', '');
+    Object.assign(overlay.style, {
+        position: 'fixed',
+        inset: '0',
+        zIndex: '999999',
+        background: 'rgba(0,0,0,0.92)',
+        color: '#fff',
+        display: 'none',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: '1.4rem',
+        fontFamily: 'system-ui, sans-serif',
+        textAlign: 'center',
+        padding: '2rem',
+    } as CSSStyleDeclaration);
+    overlay.textContent =
+        target === 'landscape'
+            ? 'Please rotate your device to landscape'
+            : 'Please rotate your device to portrait';
+    document.body.appendChild(overlay);
+
+    const update = () => {
+        const isLandscape = globalThis.innerWidth > globalThis.innerHeight;
+        const isCorrect = target === 'landscape' ? isLandscape : !isLandscape;
+        overlay.style.display = isCorrect ? 'none' : 'flex';
+    };
+
+    globalThis.addEventListener('resize', update);
+    update();
+
+    return () => {
+        globalThis.removeEventListener('resize', update);
+        screen.orientation?.unlock?.();
+        overlay.remove();
+    };
+}
+
+// ---------------------------------------------------------------------------
+// PWA install prompt
+// ---------------------------------------------------------------------------
+
+function setupInstallPrompt(dismissKey: string): () => void {
+    // Check if already dismissed
+    try {
+        if (localStorage.getItem(dismissKey)) return () => {};
+    } catch {
+        /* localStorage may be unavailable */
+    }
+
+    let deferredEvent: (BeforeInstallPromptEvent & Event) | null = null;
+    let banner: HTMLElement | null = null;
+
+    const onBeforeInstall = (e: Event) => {
+        e.preventDefault();
+        deferredEvent = e as BeforeInstallPromptEvent & Event;
+        showBanner();
+    };
+
+    globalThis.addEventListener(
+        'beforeinstallprompt',
+        onBeforeInstall as EventListener,
+    );
+
+    function showBanner() {
+        banner = document.createElement('div');
+        banner.setAttribute('data-pulse-install-banner', '');
+        Object.assign(banner.style, {
+            position: 'fixed',
+            bottom: '0',
+            left: '0',
+            right: '0',
+            zIndex: '999998',
+            background: '#222',
+            color: '#fff',
+            padding: '1rem',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            fontFamily: 'system-ui, sans-serif',
+            fontSize: '0.95rem',
+        } as CSSStyleDeclaration);
+
+        const text = document.createElement('span');
+        text.textContent = 'Install this app for the best experience';
+
+        const actions = document.createElement('span');
+
+        const installBtn = document.createElement('button');
+        installBtn.textContent = 'Install';
+        Object.assign(installBtn.style, {
+            background: '#4a9eff',
+            color: '#fff',
+            border: 'none',
+            borderRadius: '4px',
+            padding: '0.4rem 1rem',
+            cursor: 'pointer',
+            marginRight: '0.5rem',
+            fontSize: '0.9rem',
+        } as CSSStyleDeclaration);
+        installBtn.addEventListener('click', () => {
+            deferredEvent?.prompt?.();
+            removeBanner();
+        });
+
+        const dismissBtn = document.createElement('button');
+        dismissBtn.textContent = 'Not now';
+        Object.assign(dismissBtn.style, {
+            background: 'transparent',
+            color: '#aaa',
+            border: '1px solid #555',
+            borderRadius: '4px',
+            padding: '0.4rem 1rem',
+            cursor: 'pointer',
+            fontSize: '0.9rem',
+        } as CSSStyleDeclaration);
+        dismissBtn.addEventListener('click', () => {
+            try {
+                localStorage.setItem(dismissKey, '1');
+            } catch {
+                /* ignore */
+            }
+            removeBanner();
+        });
+
+        actions.appendChild(installBtn);
+        actions.appendChild(dismissBtn);
+        banner.appendChild(text);
+        banner.appendChild(actions);
+        document.body.appendChild(banner);
+    }
+
+    function removeBanner() {
+        banner?.remove();
+        banner = null;
+    }
+
+    return () => {
+        globalThis.removeEventListener(
+            'beforeinstallprompt',
+            onBeforeInstall as EventListener,
+        );
+        removeBanner();
+    };
+}
+
+/**
+ * Non-standard `BeforeInstallPromptEvent` interface available in
+ * Chromium-based browsers.
+ */
+interface BeforeInstallPromptEvent {
+    prompt(): Promise<void>;
+    userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}

--- a/packages/platform/src/domain/isMobile.test.ts
+++ b/packages/platform/src/domain/isMobile.test.ts
@@ -1,0 +1,94 @@
+import { isMobile } from './isMobile';
+
+describe('isMobile', () => {
+    const originalNavigator = globalThis.navigator;
+
+    function mockNavigator(
+        userAgent: string,
+        maxTouchPoints: number,
+        hasOntouchstart = false,
+    ) {
+        Object.defineProperty(globalThis, 'navigator', {
+            value: { userAgent, maxTouchPoints },
+            writable: true,
+            configurable: true,
+        });
+        if (hasOntouchstart) {
+            (globalThis as Record<string, unknown>).ontouchstart = null;
+        } else {
+            delete (globalThis as Record<string, unknown>).ontouchstart;
+        }
+    }
+
+    afterEach(() => {
+        Object.defineProperty(globalThis, 'navigator', {
+            value: originalNavigator,
+            writable: true,
+            configurable: true,
+        });
+        delete (globalThis as Record<string, unknown>).ontouchstart;
+    });
+
+    it('returns true for an Android phone with touch support', () => {
+        mockNavigator(
+            'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 Chrome/114 Mobile',
+            5,
+            true,
+        );
+        expect(isMobile()).toBe(true);
+    });
+
+    it('returns true for an iPhone', () => {
+        mockNavigator(
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0) AppleWebKit/605.1.15',
+            5,
+            true,
+        );
+        expect(isMobile()).toBe(true);
+    });
+
+    it('returns true for an iPad', () => {
+        mockNavigator(
+            'Mozilla/5.0 (iPad; CPU OS 16_0 like Mac OS X) AppleWebKit/605.1.15',
+            5,
+            true,
+        );
+        expect(isMobile()).toBe(true);
+    });
+
+    it('returns false for a desktop browser', () => {
+        mockNavigator(
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/114',
+            0,
+            false,
+        );
+        expect(isMobile()).toBe(false);
+    });
+
+    it('returns false when navigator is undefined', () => {
+        Object.defineProperty(globalThis, 'navigator', {
+            value: undefined,
+            writable: true,
+            configurable: true,
+        });
+        expect(isMobile()).toBe(false);
+    });
+
+    it('returns false for a mobile user agent without touch support', () => {
+        mockNavigator(
+            'Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 Chrome/114 Mobile',
+            0,
+            false,
+        );
+        expect(isMobile()).toBe(false);
+    });
+
+    it('returns false for a desktop with touch support but no mobile UA', () => {
+        mockNavigator(
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/114',
+            10,
+            true,
+        );
+        expect(isMobile()).toBe(false);
+    });
+});

--- a/packages/platform/src/domain/isMobile.ts
+++ b/packages/platform/src/domain/isMobile.ts
@@ -1,0 +1,29 @@
+/**
+ * Detect if the current device is touch-primary (mobile/tablet).
+ *
+ * Uses a combination of user-agent sniffing and touch capability detection
+ * to determine whether the device is likely a mobile or tablet.
+ *
+ * @returns `true` if the device is likely a mobile or tablet.
+ *
+ * @example
+ * ```ts
+ * import { isMobile } from '@pulse-ts/platform';
+ *
+ * if (isMobile()) {
+ *     three.renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
+ * }
+ * ```
+ */
+export function isMobile(): boolean {
+    if (typeof navigator === 'undefined') return false;
+
+    const hasTouch =
+        'ontouchstart' in globalThis || navigator.maxTouchPoints > 0;
+
+    const mobileUaPattern =
+        /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i;
+    const isMobileUa = mobileUaPattern.test(navigator.userAgent);
+
+    return hasTouch && isMobileUa;
+}

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -1,0 +1,2 @@
+// Public surface re-exports
+export * from './public/index';

--- a/packages/platform/src/public/index.ts
+++ b/packages/platform/src/public/index.ts
@@ -1,0 +1,5 @@
+export { isMobile } from '../domain/isMobile';
+export {
+    installMobileSupport,
+    type MobileSupportOptions,
+} from '../domain/installMobileSupport';

--- a/packages/platform/tsconfig.json
+++ b/packages/platform/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../configs/tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "rootDir": "src",
+        "baseUrl": "./"
+    },
+    "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- New `@pulse-ts/platform` package with `isMobile()` for mobile/tablet detection and `installMobileSupport()` for one-call fullscreen, orientation lock, and PWA install prompt setup
- All options are independently togglable with sensible defaults; returns a cleanup function
- 24 unit tests passing, full JSDoc coverage, documentation guide added

## Test plan

- [x] `isMobile()` returns true for mobile UAs with touch, false for desktop
- [x] `installMobileSupport()` fullscreen: adds touchstart listener, triggers requestFullscreen
- [x] `installMobileSupport()` orientation: creates/removes rotate overlay, respects landscape/portrait
- [x] `installMobileSupport()` installPrompt: captures beforeinstallprompt, shows banner, respects dismissal
- [x] Cleanup function tears down all listeners and DOM elements
- [x] Lint passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)