### PR TITLE
TICKET-122: useAnimate Play Callback

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-021-effects-package-dx-pass/done/TICKET-122-use-animate-play-callback.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-021-effects-package-dx-pass/done/TICKET-122-use-animate-play-callback.md
@@ -2,7 +2,7 @@
 id: TICKET-122
 epic: EPIC-021
 title: useAnimate Play Callback
-status: in-progress
+status: done
 priority: low
 created: 2026-03-13
 updated: 2026-03-14
@@ -22,13 +22,13 @@ Design doc: `design-docs/approved/013-use-animate-play-callback.md`
 
 ## Acceptance Criteria
 
-- [ ] `play(onUpdate)` accepts optional callback receiving current value each frame
-- [ ] Callback is called each frame while animation is playing
-- [ ] Works with tween, oscillation, and rate modes
-- [ ] Backward compatible — `play()` with no args still works
-- [ ] JSDoc with examples
-- [ ] Unit tests for callback invocation across modes
-- [ ] Documentation updated
+- [x] `play(onUpdate)` accepts optional callback receiving current value each frame
+- [x] Callback is called each frame while animation is playing
+- [x] Works with tween, oscillation, and rate modes
+- [x] Backward compatible — `play()` with no args still works
+- [x] JSDoc with examples
+- [x] Unit tests for callback invocation across modes
+- [x] Documentation updated
 
 ## Notes
 

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-021-effects-package-dx-pass/in-progress/TICKET-122-use-animate-play-callback.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-021-effects-package-dx-pass/in-progress/TICKET-122-use-animate-play-callback.md
@@ -2,10 +2,11 @@
 id: TICKET-122
 epic: EPIC-021
 title: useAnimate Play Callback
-status: todo
+status: in-progress
 priority: low
 created: 2026-03-13
-updated: 2026-03-13
+updated: 2026-03-14
+branch: ticket-122-use-animate-play-callback
 labels:
   - effects
   - dx

--- a/apps/docs/guides/animate.md
+++ b/apps/docs/guides/animate.md
@@ -1,0 +1,99 @@
+# Animated Values
+
+`useAnimate` provides a general-purpose time-varying value source. It supports three modes — oscillation, rate, and tween — selected by the shape of the options object you pass in.
+
+## Quick start
+
+```ts
+import { useAnimate } from '@pulse-ts/effects';
+import { useFrameUpdate } from '@pulse-ts/core';
+
+function BobbingLight() {
+    const bob = useAnimate({ wave: 'sine', amplitude: 0.2, frequency: 2 });
+    const spin = useAnimate({ rate: 1.5 });
+
+    useFrameUpdate(() => {
+        light.position.y = baseY + bob.value;
+        light.rotation.y = spin.value;
+    });
+}
+```
+
+## Modes
+
+### Oscillation
+
+Produces a repeating waveform. Specify a `wave` shape (`'sine'`, `'triangle'`, `'square'`, `'sawtooth'`) plus either an `amplitude` (centered at zero) or a `min`/`max` range.
+
+```ts
+// Centered at 0, oscillates [-0.5, 0.5]
+const bob = useAnimate({ wave: 'sine', amplitude: 0.5, frequency: 2 });
+
+// Oscillates between min and max
+const pulse = useAnimate({ wave: 'sine', min: 0.3, max: 0.9, frequency: 3 });
+```
+
+### Rate
+
+Linearly increasing value: `value = rate * elapsed`.
+
+```ts
+const spin = useAnimate({ rate: 2 }); // 2 units/sec
+```
+
+### Tween
+
+One-shot interpolation from `from` to `to` over `duration` seconds. Must call `play()` to start.
+
+```ts
+const fade = useAnimate({ from: 0, to: 1, duration: 0.5, easing: 'ease-out' });
+fade.play();
+```
+
+Available easing presets: `'linear'`, `'ease-in'`, `'ease-out'`, `'ease-in-out'`. You can also pass a custom `(t: number) => number` function.
+
+## Play callback
+
+All modes support an optional callback on `play()` for fire-and-forget animation consumption. The callback is invoked each frame with the current value, eliminating the need for a separate `useFrameUpdate`.
+
+```ts
+// Tween with callback
+const flash = useAnimate({ from: 2.0, to: 1.0, duration: 0.5, easing: 'ease-out' });
+flash.play((v) => { panel.style.filter = `brightness(${v})`; });
+
+// Oscillation with callback
+const pulse = useAnimate({ wave: 'sine', min: 0.4, max: 1.5, frequency: 1.5 });
+pulse.play((v) => { material.emissiveIntensity = v; });
+
+// Rate with callback
+const spin = useAnimate({ rate: 2 });
+spin.play((v) => { mesh.rotation.y = v; });
+```
+
+Calling `play()` without a callback still works exactly as before. The callback is about how you consume the value, not about the animation configuration. You can also change the callback on replay:
+
+```ts
+const pop = useAnimate({ from: 1.35, to: 1.0, duration: 0.5, easing: 'ease-out' });
+
+function scalePop(el: HTMLElement) {
+    pop.reset();
+    pop.play((v) => { el.style.transform = `scale(${v})`; });
+}
+```
+
+## API reference
+
+### `AnimatedValue`
+
+| Property / Method | Type | Description |
+|---|---|---|
+| `value` | `number` (readonly) | Current animated value, auto-updated each frame. |
+| `play(onUpdate?)` | `(cb?: (value: number) => void) => void` | Start animation (tween) or attach a callback (all modes). |
+| `reset()` | `() => void` | Reset elapsed time to zero / tween to initial state. |
+| `finished` | `boolean` (readonly) | Whether the tween has completed. Always `false` for oscillation/rate. |
+
+### Limitations
+
+- Tween mode does not loop automatically. Call `reset()` then `play()` to replay.
+- Rate mode grows without bound. Use `reset()` if you need to restart.
+- The play callback is replaced (not accumulated) on each `play()` call.

--- a/packages/effects/src/public/useAnimate.test.ts
+++ b/packages/effects/src/public/useAnimate.test.ts
@@ -374,6 +374,158 @@ describe('useAnimate — tween mode', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Play callback
+// ---------------------------------------------------------------------------
+
+describe('useAnimate — play callback', () => {
+    test('tween mode: callback is invoked each frame with current value', () => {
+        const { handle, step } = setup({
+            from: 0,
+            to: 10,
+            duration: 1,
+        });
+
+        const values: number[] = [];
+        handle.play((v) => values.push(v));
+
+        step(50); // 0.5s
+        expect(values.length).toBe(50);
+        expect(values[values.length - 1]).toBeCloseTo(5, 0);
+    });
+
+    test('tween mode: play() without callback still works', () => {
+        const { handle, step } = setup({
+            from: 0,
+            to: 10,
+            duration: 1,
+        });
+
+        handle.play();
+        step(50);
+        expect(handle.value).toBeCloseTo(5, 0);
+    });
+
+    test('tween mode: callback stops after tween finishes', () => {
+        const { handle, step } = setup({
+            from: 0,
+            to: 10,
+            duration: 0.5,
+        });
+
+        const values: number[] = [];
+        handle.play((v) => values.push(v));
+
+        step(60); // 0.6s — tween is 0.5s, so it should finish
+        const countAtFinish = values.length;
+
+        step(20); // more frames after finish
+        // No new calls after the tween completes
+        expect(values.length).toBe(countAtFinish);
+        expect(values[values.length - 1]).toBe(10);
+    });
+
+    test('rate mode: callback is invoked each frame', () => {
+        const { handle, step } = setup({ rate: 2 });
+
+        const values: number[] = [];
+        handle.play((v) => values.push(v));
+
+        step(100); // 1s
+        expect(values.length).toBe(100);
+        expect(values[values.length - 1]).toBeCloseTo(2.0, 1);
+    });
+
+    test('rate mode: play() without callback still works', () => {
+        const { handle, step } = setup({ rate: 2 });
+
+        handle.play();
+        step(100);
+        expect(handle.value).toBeCloseTo(2.0, 1);
+    });
+
+    test('oscillation amplitude mode: callback is invoked each frame', () => {
+        const { handle, step } = setup({
+            wave: 'sine',
+            amplitude: 0.5,
+            frequency: 2,
+        });
+
+        const values: number[] = [];
+        handle.play((v) => values.push(v));
+
+        step(50);
+        expect(values.length).toBe(50);
+        // Values should match handle.value pattern
+        expect(values.every((v) => Math.abs(v) <= 0.5 + 0.001)).toBe(true);
+    });
+
+    test('oscillation range mode: callback is invoked each frame', () => {
+        const { handle, step } = setup({
+            wave: 'sine',
+            min: 0.3,
+            max: 0.9,
+            frequency: 3,
+        });
+
+        const values: number[] = [];
+        handle.play((v) => values.push(v));
+
+        step(50);
+        expect(values.length).toBe(50);
+        expect(values.every((v) => v >= 0.3 - 0.001 && v <= 0.9 + 0.001)).toBe(
+            true,
+        );
+    });
+
+    test('oscillation mode: play() without callback still works', () => {
+        const { handle, step } = setup({
+            wave: 'sine',
+            amplitude: 1,
+            frequency: 2,
+        });
+
+        handle.play();
+        step(50);
+        expect(handle.value).not.toBe(0);
+    });
+
+    test('tween mode: replaying with a new callback replaces the old one', () => {
+        const { handle, step } = setup({
+            from: 0,
+            to: 10,
+            duration: 1,
+        });
+
+        const first: number[] = [];
+        handle.play((v) => first.push(v));
+        step(10);
+
+        handle.reset();
+        const second: number[] = [];
+        handle.play((v) => second.push(v));
+        step(10);
+
+        // First callback should have stopped receiving values after reset+replay
+        expect(first.length).toBe(10);
+        expect(second.length).toBe(10);
+    });
+
+    test('callback receives the final value on the last frame of a tween', () => {
+        const { handle, step } = setup({
+            from: 0,
+            to: 100,
+            duration: 0.5,
+        });
+
+        const values: number[] = [];
+        handle.play((v) => values.push(v));
+
+        step(60); // 0.6s — well past 0.5s duration
+        expect(values[values.length - 1]).toBe(100);
+    });
+});
+
+// ---------------------------------------------------------------------------
 // General
 // ---------------------------------------------------------------------------
 

--- a/packages/effects/src/public/useAnimate.ts
+++ b/packages/effects/src/public/useAnimate.ts
@@ -82,14 +82,36 @@ export type AnimateOptions =
  *
  * Read `.value` each frame to get the current animated number.
  * For tween mode, use `play()`, `reset()`, and `finished`.
- * For oscillation/rate modes, `play()` is a no-op, `reset()` resets
- * elapsed time to zero, and `finished` is always `false`.
+ * For oscillation/rate modes, `play()` registers an optional callback,
+ * `reset()` resets elapsed time to zero, and `finished` is always `false`.
  */
 export interface AnimatedValue {
     /** Current animated value (auto-updated each frame). */
     readonly value: number;
-    /** Start or restart the animation (tween mode only). */
-    play(): void;
+    /**
+     * Start or restart the animation.
+     *
+     * For tween mode this begins playback. For oscillation/rate modes,
+     * the animation runs automatically from mount — `play()` is only
+     * needed if you want to attach a callback.
+     *
+     * @param onUpdate - Optional callback invoked each frame with the
+     *   current animated value. Useful for fire-and-forget consumption
+     *   without a separate `useFrameUpdate`.
+     *
+     * @example
+     * ```ts
+     * const flash = useAnimate({ from: 2.0, to: 1.0, duration: 0.5, easing: 'ease-out' });
+     * flash.play((v) => { panel.style.filter = `brightness(${v})`; });
+     * ```
+     *
+     * @example
+     * ```ts
+     * const pulse = useAnimate({ wave: 'sine', min: 0.4, max: 1.5, frequency: 1.5 });
+     * pulse.play((v) => { material.emissiveIntensity = v; });
+     * ```
+     */
+    play(onUpdate?: (value: number) => void): void;
     /** Reset elapsed time to zero / tween to initial state. */
     reset(): void;
     /** Whether the tween has completed. Always `false` for oscillation/rate. */
@@ -216,18 +238,20 @@ export function useAnimate(options: Readonly<AnimateOptions>): AnimatedValue {
     if (isRate(options)) {
         // Rate mode: value = rate × elapsed
         currentValue = 0;
+        let onUpdate: ((value: number) => void) | undefined;
 
         useFrameUpdate((dt) => {
             elapsed += dt;
             currentValue = options.rate * elapsed;
+            if (onUpdate) onUpdate(currentValue);
         });
 
         return {
             get value() {
                 return currentValue;
             },
-            play() {
-                /* no-op */
+            play(cb?: (value: number) => void) {
+                onUpdate = cb;
             },
             reset() {
                 elapsed = 0;
@@ -244,6 +268,7 @@ export function useAnimate(options: Readonly<AnimateOptions>): AnimatedValue {
         const ease = resolveEasing(options.easing);
         let playing = false;
         let done = false;
+        let onUpdate: ((value: number) => void) | undefined;
         currentValue = options.from;
 
         useFrameUpdate((dt) => {
@@ -252,6 +277,7 @@ export function useAnimate(options: Readonly<AnimateOptions>): AnimatedValue {
             const raw = Math.min(elapsed / options.duration, 1);
             currentValue =
                 options.from + (options.to - options.from) * ease(raw);
+            if (onUpdate) onUpdate(currentValue);
             if (raw >= 1) done = true;
         });
 
@@ -259,7 +285,8 @@ export function useAnimate(options: Readonly<AnimateOptions>): AnimatedValue {
             get value() {
                 return currentValue;
             },
-            play() {
+            play(cb?: (value: number) => void) {
+                onUpdate = cb;
                 playing = true;
                 done = false;
             },
@@ -280,20 +307,22 @@ export function useAnimate(options: Readonly<AnimateOptions>): AnimatedValue {
         const waveFn = WAVE_MAP[options.wave];
         const { min, max, frequency } = options;
         currentValue = min;
+        let onUpdate: ((value: number) => void) | undefined;
 
         useFrameUpdate((dt) => {
             elapsed += dt;
             const raw = waveFn(frequency * elapsed); // [-1, 1]
             const normalized = (raw + 1) / 2; // [0, 1]
             currentValue = min + normalized * (max - min);
+            if (onUpdate) onUpdate(currentValue);
         });
 
         return {
             get value() {
                 return currentValue;
             },
-            play() {
-                /* no-op */
+            play(cb?: (value: number) => void) {
+                onUpdate = cb;
             },
             reset() {
                 elapsed = 0;
@@ -310,18 +339,20 @@ export function useAnimate(options: Readonly<AnimateOptions>): AnimatedValue {
     const waveFn = WAVE_MAP[ampOptions.wave];
     const { amplitude, frequency } = ampOptions;
     currentValue = 0;
+    let onUpdate: ((value: number) => void) | undefined;
 
     useFrameUpdate((dt) => {
         elapsed += dt;
         currentValue = waveFn(frequency * elapsed) * amplitude;
+        if (onUpdate) onUpdate(currentValue);
     });
 
     return {
         get value() {
             return currentValue;
         },
-        play() {
-            /* no-op */
+        play(cb?: (value: number) => void) {
+            onUpdate = cb;
         },
         reset() {
             elapsed = 0;


### PR DESCRIPTION
## Summary
- Enhanced `useAnimate`'s `play()` method to accept an optional `onUpdate` callback: `play(onUpdate?: (value: number) => void)`
- Callback is invoked each frame with the current animated value, enabling fire-and-forget animation consumption without a separate `useFrameUpdate`
- Works across all animation modes (tween, oscillation, rate) and is fully backward compatible

## Test plan
- [x] Tween mode: callback invoked each frame with current value
- [x] Tween mode: callback stops after tween finishes
- [x] Tween mode: replaying with new callback replaces old one
- [x] Rate mode: callback invoked each frame
- [x] Oscillation amplitude mode: callback invoked each frame
- [x] Oscillation range mode: callback invoked each frame
- [x] All modes: play() without callback still works (backward compat)
- [x] Callback receives final value on last frame of tween
- [x] All 32 tests passing
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)