### PR TITLE
TICKET-129: Audio Mixing Groups (useSoundGroup)

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-024-audio-and-physics-dx-pass/done/TICKET-129-audio-mixing-groups.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-024-audio-and-physics-dx-pass/done/TICKET-129-audio-mixing-groups.md
@@ -2,7 +2,7 @@
 id: TICKET-129
 epic: EPIC-024
 title: Audio Mixing Groups (useSoundGroup)
-status: in-progress
+status: done
 priority: medium
 created: 2026-03-13
 updated: 2026-03-14

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-024-audio-and-physics-dx-pass/in-progress/TICKET-129-audio-mixing-groups.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-024-audio-and-physics-dx-pass/in-progress/TICKET-129-audio-mixing-groups.md
@@ -2,10 +2,10 @@
 id: TICKET-129
 epic: EPIC-024
 title: Audio Mixing Groups (useSoundGroup)
-status: todo
+status: in-progress
 priority: medium
 created: 2026-03-13
-updated: 2026-03-13
+updated: 2026-03-14
 labels:
   - audio
   - dx

--- a/apps/docs/guides/audio-mixing-groups.md
+++ b/apps/docs/guides/audio-mixing-groups.md
@@ -1,0 +1,122 @@
+# Audio Mixing Groups
+
+Mixing groups let you control the volume of sound categories independently -- for example, SFX vs music vs UI sounds. Players expect a settings menu where they can adjust each category, and `useSoundGroup` makes that straightforward.
+
+## Quick start
+
+```ts
+import { useSoundGroup, useSound } from '@pulse-ts/audio';
+
+function GameManagerNode() {
+    // Define groups with initial volumes
+    const sfx = useSoundGroup('sfx', { volume: 0.8 });
+    const music = useSoundGroup('music', { volume: 0.5 });
+
+    // Route sounds through groups
+    const beep = useSound('tone', {
+        wave: 'sine',
+        frequency: 880,
+        duration: 0.1,
+        gain: 0.1,
+        group: 'sfx',
+    });
+
+    // Control group volume from a settings menu
+    sfx.setVolume(settingsSliderValue);
+    music.setMuted(true);
+}
+```
+
+## How gain scaling works
+
+A sound's effective gain is:
+
+```
+effective gain = sound.gain * group.volume * masterVolume
+```
+
+- `sound.gain` -- the gain value passed to `useSound` (default `0.1`)
+- `group.volume` -- the group's volume set via `useSoundGroup` (default `1`)
+- `masterVolume` -- the master volume on `AudioService` (default `1`)
+
+If a sound has no `group` option, it scales only by `masterVolume`.
+
+If a group is muted (`group.setMuted(true)`), all sounds in that group play at zero gain.
+
+## Cross-node referencing
+
+Groups are referenced by string name, so different nodes can route sounds through the same group without import dependencies:
+
+```ts
+// In GameManagerNode.ts -- define the group
+const sfx = useSoundGroup('sfx', { volume: 0.8 });
+
+// In PlayerNode.ts -- use the same group by name
+const dashSfx = useSound('noise', {
+    filter: 'bandpass',
+    frequency: [2000, 500],
+    duration: 0.15,
+    gain: 0.12,
+    group: 'sfx',
+});
+
+// In EnemyNode.ts -- same group again
+const impactSfx = useSound('tone', {
+    wave: 'square',
+    frequency: [200, 80],
+    duration: 0.1,
+    gain: 0.15,
+    group: 'sfx',
+});
+```
+
+## Group persistence
+
+Groups are tied to the `AudioService`, not the world. This means volume preferences survive world recreation (e.g., game restarts). If you reuse the same `AudioService` across worlds, the group state carries over.
+
+```ts
+const audio = new AudioService({ masterVolume: 0.8 });
+
+// World 1
+const world1 = new World();
+world1.provideService(audio);
+// ... set sfx volume to 0.4
+
+// World 2 -- same AudioService, group volumes preserved
+const world2 = new World();
+world2.provideService(audio);
+```
+
+## API reference
+
+### `useSoundGroup(name, options?)`
+
+Creates or accesses a named sound group.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `name` | `string` | Unique group name |
+| `options.volume` | `number` | Initial volume `[0, 1]` (default `1`) |
+| `options.muted` | `boolean` | Whether group starts muted (default `false`) |
+
+Returns a `SoundGroupHandle`:
+
+| Property/Method | Description |
+|-----------------|-------------|
+| `name` | The group name (readonly) |
+| `volume` | Current volume (readonly) |
+| `muted` | Current mute state (readonly) |
+| `setVolume(v)` | Set group volume `[0, 1]` |
+| `setMuted(m)` | Set mute state |
+
+### `useSound` `group` option
+
+Pass `group: 'groupName'` in the options to route a sound through a mixing group:
+
+```ts
+const sfx = useSound('tone', {
+    frequency: 440,
+    duration: 0.1,
+    group: 'sfx', // route through the 'sfx' group
+});
+```

--- a/packages/audio/src/domain/services/Audio.ts
+++ b/packages/audio/src/domain/services/Audio.ts
@@ -10,6 +10,14 @@ export interface AudioOptions {
     masterVolume?: number;
 }
 
+/** Internal state for a named sound group. */
+export interface SoundGroup {
+    /** Volume multiplier `[0, 1]`. */
+    volume: number;
+    /** Whether the group is muted. */
+    muted: boolean;
+}
+
 /**
  * Manages the Web Audio `AudioContext` lifecycle and provides a master gain
  * node that all sounds route through.
@@ -35,10 +43,48 @@ export class AudioService extends Service {
     private _ctx: AudioContext | null = null;
     private _masterGain: GainNode | null = null;
     private _masterVolume: number;
+    private readonly _groups = new Map<string, SoundGroup>();
 
     constructor(options: AudioOptions = {}) {
         super();
         this._masterVolume = options.masterVolume ?? 1;
+    }
+
+    /**
+     * Returns an existing sound group or creates one with the given defaults.
+     * Groups persist for the lifetime of the service (across world lifecycles).
+     *
+     * @param name - Unique group name.
+     * @param defaults - Initial volume and muted state (only applied on creation).
+     * @returns The group state object.
+     */
+    getOrCreateGroup(
+        name: string,
+        defaults?: { volume?: number; muted?: boolean },
+    ): SoundGroup {
+        let group = this._groups.get(name);
+        if (!group) {
+            group = {
+                volume: defaults?.volume ?? 1,
+                muted: defaults?.muted ?? false,
+            };
+            this._groups.set(name, group);
+        }
+        return group;
+    }
+
+    /**
+     * Returns the effective volume multiplier for a sound in the given group.
+     * If no group name is provided, returns 1 (no scaling beyond master).
+     *
+     * @param groupName - Optional group name.
+     * @returns The group volume multiplier (0 if muted).
+     */
+    getGroupVolume(groupName?: string): number {
+        if (!groupName) return 1;
+        const group = this._groups.get(groupName);
+        if (!group) return 1;
+        return group.muted ? 0 : group.volume;
     }
 
     /**

--- a/packages/audio/src/public/index.ts
+++ b/packages/audio/src/public/index.ts
@@ -7,8 +7,11 @@ export type {
     ArpeggioOptions,
     SoundTypeMap,
     SoundType,
+    SoundExtraOptions,
     SoundHandle,
 } from './useSound';
+export { useSoundGroup } from './useSoundGroup';
+export type { SoundGroupOptions, SoundGroupHandle } from './useSoundGroup';
 export { useSpatialSound } from './useSpatialSound';
 export type {
     RolloffModel,
@@ -17,4 +20,8 @@ export type {
     SpatialSoundType,
     SpatialSoundHandle,
 } from './useSpatialSound';
-export { AudioService, type AudioOptions } from '../domain/services/Audio';
+export {
+    AudioService,
+    type AudioOptions,
+    type SoundGroup,
+} from '../domain/services/Audio';

--- a/packages/audio/src/public/useSound.ts
+++ b/packages/audio/src/public/useSound.ts
@@ -101,6 +101,20 @@ export interface SoundTypeMap {
 /** The sound types supported by {@link useSound}. */
 export type SoundType = keyof SoundTypeMap;
 
+/**
+ * Additional options accepted by {@link useSound} beyond the sound-type-specific
+ * configuration.
+ */
+export interface SoundExtraOptions {
+    /**
+     * Route this sound through a named mixing group. The sound's gain will be
+     * scaled by the group's volume: `sound.gain * group.volume * masterVolume`.
+     *
+     * Create groups with {@link useSoundGroup}.
+     */
+    group?: string;
+}
+
 /** Handle returned by {@link useSound}. */
 export interface SoundHandle {
     /** Triggers playback. Fire-and-forget — audio nodes self-clean after playback. */
@@ -111,11 +125,15 @@ export interface SoundHandle {
 // Internal play helpers
 // ---------------------------------------------------------------------------
 
-function playTone(audio: AudioService, opts: ToneOptions): void {
+function playTone(
+    audio: AudioService,
+    opts: ToneOptions,
+    groupVolume: number,
+): void {
     const ctx = audio.ensureContext();
     const dest = audio.destination;
     const now = ctx.currentTime;
-    const gain = opts.gain ?? 0.1;
+    const gain = (opts.gain ?? 0.1) * groupVolume;
 
     const osc = ctx.createOscillator();
     osc.type = opts.wave ?? 'sine';
@@ -139,11 +157,15 @@ function playTone(audio: AudioService, opts: ToneOptions): void {
     osc.stop(now + opts.duration);
 }
 
-function playNoise(audio: AudioService, opts: NoiseOptions): void {
+function playNoise(
+    audio: AudioService,
+    opts: NoiseOptions,
+    groupVolume: number,
+): void {
     const ctx = audio.ensureContext();
     const dest = audio.destination;
     const now = ctx.currentTime;
-    const gain = opts.gain ?? 0.1;
+    const gain = (opts.gain ?? 0.1) * groupVolume;
 
     // Generate white noise buffer
     const bufferSize = Math.ceil(ctx.sampleRate * opts.duration);
@@ -178,11 +200,15 @@ function playNoise(audio: AudioService, opts: NoiseOptions): void {
     source.stop(now + opts.duration);
 }
 
-function playArpeggio(audio: AudioService, opts: ArpeggioOptions): void {
+function playArpeggio(
+    audio: AudioService,
+    opts: ArpeggioOptions,
+    groupVolume: number,
+): void {
     const ctx = audio.ensureContext();
     const dest = audio.destination;
     const now = ctx.currentTime;
-    const gain = opts.gain ?? 0.1;
+    const gain = (opts.gain ?? 0.1) * groupVolume;
 
     for (let i = 0; i < opts.notes.length; i++) {
         const offset = i * opts.interval;
@@ -240,6 +266,7 @@ function playArpeggio(audio: AudioService, opts: ArpeggioOptions): void {
  *         frequency: [2000, 500],
  *         duration: 0.15,
  *         gain: 0.12,
+ *         group: 'sfx', // route through the 'sfx' mixing group
  *     });
  *
  *     const collectSfx = useSound('arpeggio', {
@@ -257,21 +284,27 @@ function playArpeggio(audio: AudioService, opts: ArpeggioOptions): void {
  */
 export function useSound<T extends SoundType>(
     type: T,
-    options: SoundTypeMap[T],
+    options: SoundTypeMap[T] & SoundExtraOptions,
 ): SoundHandle {
     const audio = useAudio();
+    const groupName = options.group;
 
     return {
         play() {
+            const groupVolume = audio.getGroupVolume(groupName);
             switch (type) {
                 case 'tone':
-                    playTone(audio, options as ToneOptions);
+                    playTone(audio, options as ToneOptions, groupVolume);
                     break;
                 case 'noise':
-                    playNoise(audio, options as NoiseOptions);
+                    playNoise(audio, options as NoiseOptions, groupVolume);
                     break;
                 case 'arpeggio':
-                    playArpeggio(audio, options as ArpeggioOptions);
+                    playArpeggio(
+                        audio,
+                        options as ArpeggioOptions,
+                        groupVolume,
+                    );
                     break;
             }
         },

--- a/packages/audio/src/public/useSoundGroup.test.ts
+++ b/packages/audio/src/public/useSoundGroup.test.ts
@@ -1,0 +1,323 @@
+/** @jest-environment jsdom */
+import { World } from '@pulse-ts/core';
+import { installAudio } from './install';
+import { useSoundGroup } from './useSoundGroup';
+import { useSound } from './useSound';
+import type { SoundGroupHandle } from './useSoundGroup';
+import type { SoundHandle } from './useSound';
+import { AudioService } from '../domain/services/Audio';
+
+// ---------------------------------------------------------------------------
+// Web Audio API stubs
+// ---------------------------------------------------------------------------
+
+const createdNodes: {
+    oscillators: StubOscillator[];
+    gains: StubGain[];
+} = { oscillators: [], gains: [] };
+
+function resetNodes() {
+    createdNodes.oscillators = [];
+    createdNodes.gains = [];
+}
+
+class StubAudioParam {
+    value = 0;
+    setValueAtTime = jest.fn();
+    linearRampToValueAtTime = jest.fn();
+}
+
+class StubOscillator {
+    type = 'sine';
+    frequency = new StubAudioParam();
+    connect = jest.fn().mockReturnThis();
+    start = jest.fn();
+    stop = jest.fn();
+    constructor() {
+        createdNodes.oscillators.push(this);
+    }
+}
+
+class StubGain {
+    gain = new StubAudioParam();
+    connect = jest.fn().mockReturnThis();
+    constructor() {
+        createdNodes.gains.push(this);
+    }
+}
+
+class StubAudioContext {
+    currentTime = 0;
+    sampleRate = 44100;
+    state = 'running';
+    destination = {};
+    resume = jest.fn();
+    createOscillator() {
+        return new StubOscillator();
+    }
+    createGain() {
+        return new StubGain();
+    }
+    createBufferSource() {
+        return {
+            buffer: null,
+            connect: jest.fn().mockReturnThis(),
+            start: jest.fn(),
+            stop: jest.fn(),
+        };
+    }
+    createBiquadFilter() {
+        return {
+            type: 'lowpass',
+            frequency: new StubAudioParam(),
+            Q: new StubAudioParam(),
+            connect: jest.fn().mockReturnThis(),
+        };
+    }
+    createBuffer(numChannels: number, length: number) {
+        return {
+            getChannelData: () => new Float32Array(length),
+        };
+    }
+}
+
+beforeAll(() => {
+    (global as any).AudioContext = StubAudioContext;
+});
+
+afterAll(() => {
+    delete (global as any).AudioContext;
+});
+
+beforeEach(resetNodes);
+
+// ---------------------------------------------------------------------------
+// Tests — useSoundGroup
+// ---------------------------------------------------------------------------
+
+describe('useSoundGroup', () => {
+    test('creates a group with default volume 1 and muted false', () => {
+        const world = new World();
+        installAudio(world);
+        let handle!: SoundGroupHandle;
+        world.mount(() => {
+            handle = useSoundGroup('sfx');
+        });
+
+        expect(handle.name).toBe('sfx');
+        expect(handle.volume).toBe(1);
+        expect(handle.muted).toBe(false);
+    });
+
+    test('creates a group with custom initial volume and muted state', () => {
+        const world = new World();
+        installAudio(world);
+        let handle!: SoundGroupHandle;
+        world.mount(() => {
+            handle = useSoundGroup('music', { volume: 0.5, muted: true });
+        });
+
+        expect(handle.volume).toBe(0.5);
+        expect(handle.muted).toBe(true);
+    });
+
+    test('setVolume updates the group volume', () => {
+        const world = new World();
+        installAudio(world);
+        let handle!: SoundGroupHandle;
+        world.mount(() => {
+            handle = useSoundGroup('sfx', { volume: 0.8 });
+        });
+
+        handle.setVolume(0.3);
+        expect(handle.volume).toBe(0.3);
+    });
+
+    test('setMuted updates the group muted state', () => {
+        const world = new World();
+        installAudio(world);
+        let handle!: SoundGroupHandle;
+        world.mount(() => {
+            handle = useSoundGroup('sfx');
+        });
+
+        handle.setMuted(true);
+        expect(handle.muted).toBe(true);
+
+        handle.setMuted(false);
+        expect(handle.muted).toBe(false);
+    });
+
+    test('same group name returns the same group across different components', () => {
+        const world = new World();
+        installAudio(world);
+        let handle1!: SoundGroupHandle;
+        let handle2!: SoundGroupHandle;
+        world.mount(() => {
+            handle1 = useSoundGroup('sfx', { volume: 0.7 });
+        });
+        world.mount(() => {
+            handle2 = useSoundGroup('sfx', { volume: 0.3 }); // initial ignored
+        });
+
+        expect(handle1.volume).toBe(0.7);
+        expect(handle2.volume).toBe(0.7); // same underlying group
+
+        handle1.setVolume(0.1);
+        expect(handle2.volume).toBe(0.1);
+    });
+
+    test('groups persist across world lifecycles (tied to AudioService)', () => {
+        const audio = new AudioService();
+
+        // First world
+        const world1 = new World();
+        world1.provideService(audio);
+        let handle1!: SoundGroupHandle;
+        world1.mount(() => {
+            handle1 = useSoundGroup('sfx', { volume: 0.6 });
+        });
+        handle1.setVolume(0.4);
+
+        // Second world, same AudioService
+        const world2 = new World();
+        world2.provideService(audio);
+        let handle2!: SoundGroupHandle;
+        world2.mount(() => {
+            handle2 = useSoundGroup('sfx');
+        });
+
+        expect(handle2.volume).toBe(0.4);
+    });
+
+    test('throws if AudioService not installed', () => {
+        const world = new World();
+        expect(() =>
+            world.mount(() => {
+                useSoundGroup('sfx');
+            }),
+        ).toThrow('AudioService not provided');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — useSound with group integration
+// ---------------------------------------------------------------------------
+
+describe('useSound with group', () => {
+    test('scales gain by group volume', () => {
+        const world = new World();
+        installAudio(world);
+        let sfx!: SoundHandle;
+        world.mount(() => {
+            useSoundGroup('sfx', { volume: 0.5 });
+            sfx = useSound('tone', {
+                frequency: 440,
+                duration: 0.1,
+                gain: 0.2,
+                group: 'sfx',
+            });
+        });
+
+        sfx.play();
+
+        // gains[0] is master gain, gains[1] is tone gain
+        const toneGain = createdNodes.gains[1];
+        // effective gain = 0.2 * 0.5 = 0.1
+        expect(toneGain.gain.setValueAtTime).toHaveBeenCalledWith(0.1, 0);
+    });
+
+    test('muted group results in zero gain', () => {
+        const world = new World();
+        installAudio(world);
+        let sfx!: SoundHandle;
+        let group!: SoundGroupHandle;
+        world.mount(() => {
+            group = useSoundGroup('sfx', { volume: 0.8 });
+            sfx = useSound('tone', {
+                frequency: 440,
+                duration: 0.1,
+                gain: 0.2,
+                group: 'sfx',
+            });
+        });
+
+        group.setMuted(true);
+        sfx.play();
+
+        const toneGain = createdNodes.gains[1];
+        expect(toneGain.gain.setValueAtTime).toHaveBeenCalledWith(0, 0);
+    });
+
+    test('sound without group is unaffected (gain = sound.gain * 1)', () => {
+        const world = new World();
+        installAudio(world);
+        let sfx!: SoundHandle;
+        world.mount(() => {
+            useSoundGroup('sfx', { volume: 0.1 }); // exists but not used
+            sfx = useSound('tone', {
+                frequency: 440,
+                duration: 0.1,
+                gain: 0.2,
+                // no group
+            });
+        });
+
+        sfx.play();
+
+        const toneGain = createdNodes.gains[1];
+        // should be unscaled: 0.2 * 1 = 0.2
+        expect(toneGain.gain.setValueAtTime).toHaveBeenCalledWith(0.2, 0);
+    });
+
+    test('group volume changes apply on next play call', () => {
+        const world = new World();
+        installAudio(world);
+        let sfx!: SoundHandle;
+        let group!: SoundGroupHandle;
+        world.mount(() => {
+            group = useSoundGroup('sfx', { volume: 1 });
+            sfx = useSound('tone', {
+                frequency: 440,
+                duration: 0.1,
+                gain: 0.5,
+                group: 'sfx',
+            });
+        });
+
+        // First play at full volume
+        sfx.play();
+        expect(createdNodes.gains[1].gain.setValueAtTime).toHaveBeenCalledWith(
+            0.5,
+            0,
+        );
+
+        // Change volume, play again
+        group.setVolume(0.4);
+        sfx.play();
+        // gains[0]=master, [1]=first play gain, [2]=second play gain
+        expect(createdNodes.gains[2].gain.setValueAtTime).toHaveBeenCalledWith(
+            0.2, // 0.5 * 0.4
+            0,
+        );
+    });
+
+    test('sound referencing nonexistent group plays at full gain', () => {
+        const world = new World();
+        installAudio(world);
+        let sfx!: SoundHandle;
+        world.mount(() => {
+            sfx = useSound('tone', {
+                frequency: 440,
+                duration: 0.1,
+                gain: 0.3,
+                group: 'nonexistent',
+            });
+        });
+
+        sfx.play();
+
+        const toneGain = createdNodes.gains[1];
+        expect(toneGain.gain.setValueAtTime).toHaveBeenCalledWith(0.3, 0);
+    });
+});

--- a/packages/audio/src/public/useSoundGroup.ts
+++ b/packages/audio/src/public/useSoundGroup.ts
@@ -1,0 +1,122 @@
+import { useAudio } from './hooks';
+import type { SoundGroup } from '../domain/services/Audio';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Options for creating a sound group via {@link useSoundGroup}. */
+export interface SoundGroupOptions {
+    /**
+     * Initial volume `[0, 1]`.
+     *
+     * @default 1
+     */
+    volume?: number;
+
+    /**
+     * Whether the group starts muted.
+     *
+     * @default false
+     */
+    muted?: boolean;
+}
+
+/**
+ * Handle for controlling a named sound group's volume and mute state.
+ *
+ * Sounds routed to this group (via the `group` option on {@link useSound})
+ * have their gain scaled by the group's volume.
+ */
+export interface SoundGroupHandle {
+    /** The group name. */
+    readonly name: string;
+
+    /** Current volume `[0, 1]`. */
+    readonly volume: number;
+
+    /** Whether the group is muted. */
+    readonly muted: boolean;
+
+    /**
+     * Set the group volume.
+     *
+     * @param volume - Volume multiplier `[0, 1]`.
+     */
+    setVolume(volume: number): void;
+
+    /**
+     * Set the group mute state.
+     *
+     * @param muted - Whether the group should be muted.
+     */
+    setMuted(muted: boolean): void;
+}
+
+// ---------------------------------------------------------------------------
+// Public hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates or accesses a named sound group for independent volume control.
+ *
+ * Sound groups allow categorizing sounds (e.g. SFX, music, UI) and
+ * controlling their volume independently. A sound's effective gain is:
+ * `sound.gain * group.volume * masterVolume`.
+ *
+ * Groups persist across world lifecycles because they are tied to the
+ * {@link AudioService}, not the world.
+ *
+ * @param name - Unique group name (e.g. `'sfx'`, `'music'`).
+ * @param options - Initial volume and mute state. Only applied when the
+ *   group is first created; subsequent calls with the same name return the
+ *   existing group.
+ * @returns A {@link SoundGroupHandle} for reading and controlling the group.
+ *
+ * @example
+ * ```ts
+ * import { useSoundGroup, useSound } from '@pulse-ts/audio';
+ *
+ * function GameManagerNode() {
+ *     const sfx = useSoundGroup('sfx', { volume: 0.8 });
+ *     const music = useSoundGroup('music', { volume: 0.5 });
+ *
+ *     // Route sounds through a group:
+ *     const beep = useSound('tone', {
+ *         wave: 'sine',
+ *         frequency: 880,
+ *         duration: 0.1,
+ *         group: 'sfx',
+ *     });
+ *
+ *     // In a settings menu:
+ *     sfx.setVolume(0.3);
+ *     music.setMuted(true);
+ * }
+ * ```
+ */
+export function useSoundGroup(
+    name: string,
+    options?: SoundGroupOptions,
+): SoundGroupHandle {
+    const audio = useAudio();
+    const group: SoundGroup = audio.getOrCreateGroup(name, options);
+
+    return {
+        get name() {
+            return name;
+        },
+        get volume() {
+            return group.volume;
+        },
+        get muted() {
+            return group.muted;
+        },
+        setVolume(volume: number) {
+            group.volume = volume;
+        },
+        setMuted(muted: boolean) {
+            group.muted = muted;
+        },
+    };
+}


### PR DESCRIPTION
## Summary
- Add `useSoundGroup` hook for creating/accessing named sound groups with independent volume and mute controls
- Add `group` option to `useSound` for routing sounds through mixing groups (effective gain = `sound.gain * group.volume * masterVolume`)
- Groups persist across world lifecycles (tied to AudioService, not world)
- Backward compatible -- sounds without a group scale only by master volume

## Changes
- `packages/audio/src/domain/services/Audio.ts` -- Added `SoundGroup` interface and `getOrCreateGroup`/`getGroupVolume` methods to AudioService
- `packages/audio/src/public/useSoundGroup.ts` -- New `useSoundGroup` hook with `SoundGroupHandle` and `SoundGroupOptions` types
- `packages/audio/src/public/useSound.ts` -- Added `SoundExtraOptions` with `group` field; gain scaling by group volume in all play helpers
- `packages/audio/src/public/index.ts` -- Export new hook and types
- `packages/audio/src/public/useSoundGroup.test.ts` -- 12 new tests covering group creation, volume scaling, muting, persistence, cross-node sharing
- `apps/docs/guides/audio-mixing-groups.md` -- Documentation guide

## Test plan
- [x] All 60 audio tests pass (48 existing + 12 new)
- [x] Lint passes clean
- [x] Group volume scaling verified (gain = sound.gain * group.volume)
- [x] Muted group produces zero gain
- [x] Sounds without group unaffected (backward compatible)
- [x] Group persistence across world lifecycles verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)