### PR TITLE
TICKET-132: Arena migration - Three.js rendering

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-025-arena-demo-engine-migration/done/TICKET-132-arena-three-js-migration.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-025-arena-demo-engine-migration/done/TICKET-132-arena-three-js-migration.md
@@ -2,7 +2,7 @@
 id: TICKET-132
 epic: EPIC-025
 title: "Arena migration: Three.js rendering"
-status: in-progress
+status: done
 priority: high
 created: 2026-03-13
 updated: 2026-03-14

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-025-arena-demo-engine-migration/in-progress/TICKET-132-arena-three-js-migration.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-025-arena-demo-engine-migration/in-progress/TICKET-132-arena-three-js-migration.md
@@ -2,10 +2,10 @@
 id: TICKET-132
 epic: EPIC-025
 title: "Arena migration: Three.js rendering"
-status: todo
+status: in-progress
 priority: high
 created: 2026-03-13
-updated: 2026-03-13
+updated: 2026-03-14
 labels:
   - arena
   - migration

--- a/demos/arena/src/nodes/EnergyPillarsNode.ts
+++ b/demos/arena/src/nodes/EnergyPillarsNode.ts
@@ -1,4 +1,4 @@
-import { useObject3D } from '@pulse-ts/three';
+import { useCustomMesh } from '@pulse-ts/three';
 import { useAnimate } from '@pulse-ts/effects';
 import { useFrameUpdate } from '@pulse-ts/core';
 import * as THREE from 'three';
@@ -35,39 +35,66 @@ export const PILLAR_PULSE_FREQ = 1.0;
  * rhythmic energy-fence effect around the arena edge.
  */
 export function EnergyPillarsNode() {
-    const geometry = new THREE.CylinderGeometry(
+    const materials: THREE.MeshStandardMaterial[] = [];
+
+    // Share geometry across all pillars via useCustomMesh for lifecycle management.
+    // The first pillar's useCustomMesh creates and manages the group; remaining
+    // pillars are added as children of the group.
+    const sharedGeometry = new THREE.CylinderGeometry(
         PILLAR_RADIUS,
         PILLAR_RADIUS,
         PILLAR_HEIGHT,
         8,
     );
 
-    const materials: THREE.MeshStandardMaterial[] = [];
-    const group = new THREE.Group();
+    const { object: group } = useCustomMesh({
+        geometry: () => sharedGeometry,
+        material: () => {
+            const mat = new THREE.MeshStandardMaterial({
+                color: 0x000000,
+                emissive: PILLAR_COLOR,
+                emissiveIntensity: 0.6,
+                transparent: true,
+                opacity: 0.8,
+                roughness: 0.3,
+                metalness: 0.6,
+            });
+            materials.push(mat);
+            return mat;
+        },
+    });
 
-    for (let i = 0; i < PILLAR_COUNT; i++) {
+    // Position the first pillar mesh
+    const angle0 = 0;
+    group.position.set(
+        Math.cos(angle0) * PILLAR_ORBIT_RADIUS,
+        PILLAR_HEIGHT / 2,
+        Math.sin(angle0) * PILLAR_ORBIT_RADIUS,
+    );
+
+    // Create remaining pillars as siblings via additional useCustomMesh calls
+    for (let i = 1; i < PILLAR_COUNT; i++) {
         const angle = (i / PILLAR_COUNT) * Math.PI * 2;
-        const material = new THREE.MeshStandardMaterial({
-            color: 0x000000, // no diffuse — all glow from emissive only
-            emissive: PILLAR_COLOR,
-            emissiveIntensity: 0.6,
-            transparent: true,
-            opacity: 0.8,
-            roughness: 0.3,
-            metalness: 0.6,
+        const { object: pillarMesh, material: pillarMat } = useCustomMesh({
+            geometry: () => sharedGeometry,
+            material: () =>
+                new THREE.MeshStandardMaterial({
+                    color: 0x000000,
+                    emissive: PILLAR_COLOR,
+                    emissiveIntensity: 0.6,
+                    transparent: true,
+                    opacity: 0.8,
+                    roughness: 0.3,
+                    metalness: 0.6,
+                }),
         });
-        materials.push(material);
-
-        const mesh = new THREE.Mesh(geometry, material);
-        mesh.position.set(
+        materials.push(pillarMat as THREE.MeshStandardMaterial);
+        pillarMesh.position.set(
             Math.cos(angle) * PILLAR_ORBIT_RADIUS,
             PILLAR_HEIGHT / 2,
             Math.sin(angle) * PILLAR_ORBIT_RADIUS,
         );
-        group.add(mesh);
     }
-
-    useObject3D(group);
 
     const timer = useAnimate({ rate: PILLAR_PULSE_FREQ });
 

--- a/demos/arena/src/nodes/LocalPlayerNode.ts
+++ b/demos/arena/src/nodes/LocalPlayerNode.ts
@@ -3,7 +3,6 @@ import {
     useFixedEarly,
     useFixedUpdate,
     useFrameUpdate,
-    useWorld,
     useContext,
     useStableId,
     useNode,
@@ -19,8 +18,12 @@ import {
     useSphereCollider,
     useOnCollisionStart,
 } from '@pulse-ts/physics';
-import { useMesh, useThreeContext } from '@pulse-ts/three';
-import * as THREE from 'three';
+import {
+    useMesh,
+    useThreeContext,
+    useInterpolatedPosition,
+    useScreenProjection,
+} from '@pulse-ts/three';
 import { useSound } from '@pulse-ts/audio';
 import { useParticleBurst } from '@pulse-ts/effects';
 import { useReplicateTransform, useChannel } from '@pulse-ts/network';
@@ -260,7 +263,6 @@ export function LocalPlayerNode({
         restitution: 0.2,
     });
 
-    const world = useWorld();
     const getMove = useAxis2D(moveAction);
     const getDash = useAction(dashAction);
 
@@ -282,28 +284,19 @@ export function LocalPlayerNode({
     let lastPhase = gameState.phase;
     let lastFramePhase = gameState.phase;
 
-    // Previous physics position for frame interpolation
-    let prevX = spawn[0];
-    let prevY = spawn[1];
-    let prevZ = spawn[2];
-
-    // Snapshot position for frame interpolation, and velocity before
-    // the physics solver runs. In online mode, the solver applies a bounce
-    // against the kinematic remote player that's stronger than the local-play
-    // bounce (100% vs 50/50 split). We capture pre-solver velocity so the
-    // collision handler can undo the physics bounce and apply only our
-    // controlled knockback impulse.
+    // Snapshot velocity before the physics solver runs. In online mode,
+    // the solver applies a bounce against the kinematic remote player
+    // that's stronger than the local-play bounce (100% vs 50/50 split).
+    // We capture pre-solver velocity so the collision handler can undo
+    // the physics bounce and apply only our controlled knockback impulse.
     let prePhysVx = 0;
     let prePhysVz = 0;
-    useFixedEarly(() => {
-        prevX = transform.localPosition.x;
-        prevY = transform.localPosition.y;
-        prevZ = transform.localPosition.z;
-        if (replicate) {
+    if (replicate) {
+        useFixedEarly(() => {
             prePhysVx = body.linearVelocity.x;
             prePhysVz = body.linearVelocity.z;
-        }
-    });
+        });
+    }
 
     // Visual — sphere mesh with subtle emissive glow (blooms under post-processing)
     const meshColor = customColor ?? PLAYER_COLORS[playerId];
@@ -317,11 +310,25 @@ export function LocalPlayerNode({
         castShadow: true,
     });
 
+    // Smooth interpolation from fixed-step transform to render-frame root position.
+    // Snap on round reset to avoid interpolation sweep across the arena.
+    let shouldSnap = false;
+    useInterpolatedPosition(transform, root, {
+        snap: () => {
+            if (shouldSnap) {
+                shouldSnap = false;
+                return true;
+            }
+            return false;
+        },
+    });
+
+    // Screen projection for indicator ring positioning
+    const project = useScreenProjection();
+
     // Online mode indicator ring — screen-space CSS circle, always centered on the ball
     const { renderer: threeRenderer, camera: threeCamera } = useThreeContext();
     let indicatorRing: HTMLDivElement | null = null;
-    const projCenter = new THREE.Vector3();
-    const projEdge = new THREE.Vector3();
 
     if (replicate || showIndicatorRing) {
         const container =
@@ -626,6 +633,7 @@ export function LocalPlayerNode({
             body.setLinearVelocity(0, 0, 0);
             dashTimer.cancel();
             dashCD.reset();
+            shouldSnap = true;
         }
 
         // Trigger dash cooldown when the playing phase starts so the
@@ -730,9 +738,8 @@ export function LocalPlayerNode({
                   ? 1
                   : 1 - dashCD.remaining / DASH_COOLDOWN,
         );
-        // During replay, override mesh position from the replay buffer.
-        // When knocked out (between death and round reset), hide the mesh
-        // so there's no visible snap-to-spawn before the replay finishes.
+        // useInterpolatedPosition handles normal fixed-to-frame interpolation.
+        // Override for replay and knockout visibility.
         const replayPos = getReplayPosition(playerId);
         if (replayPos) {
             root.visible = true;
@@ -741,13 +748,6 @@ export function LocalPlayerNode({
             root.visible = false;
         } else {
             root.visible = true;
-            const alpha = world.getAmbientAlpha();
-            const cur = transform.localPosition;
-            root.position.set(
-                prevX + (cur.x - prevX) * alpha,
-                prevY + (cur.y - prevY) * alpha,
-                prevZ + (cur.z - prevZ) * alpha,
-            );
         }
 
         // Velocity-proportional trail particles during gameplay
@@ -784,26 +784,18 @@ export function LocalPlayerNode({
             } else {
                 indicatorRing.style.display = '';
 
-                const hw = threeRenderer.domElement.clientWidth / 2;
-                const hh = threeRenderer.domElement.clientHeight / 2;
-
                 // Project player center to screen
-                projCenter
-                    .set(root.position.x, root.position.y, root.position.z)
-                    .project(threeCamera);
-                const sx = projCenter.x * hw + hw;
-                const sy = -projCenter.y * hh + hh;
+                const center = project(root.position);
+                const sx = center.x;
+                const sy = center.y;
 
                 // Project edge point to get screen-space radius
-                projEdge
-                    .set(
-                        root.position.x + PLAYER_RADIUS * INDICATOR_RING_SCALE,
-                        root.position.y,
-                        root.position.z,
-                    )
-                    .project(threeCamera);
-                const edgeSx = projEdge.x * hw + hw;
-                const radius = Math.abs(edgeSx - sx);
+                const edge = project({
+                    x: root.position.x + PLAYER_RADIUS * INDICATOR_RING_SCALE,
+                    y: root.position.y,
+                    z: root.position.z,
+                });
+                const radius = Math.abs(edge.x - sx);
                 const size = radius * 2;
 
                 indicatorRing.style.width = `${size}px`;

--- a/demos/arena/src/nodes/NebulaNode.ts
+++ b/demos/arena/src/nodes/NebulaNode.ts
@@ -1,4 +1,4 @@
-import { useObject3D } from '@pulse-ts/three';
+import { useCustomMesh } from '@pulse-ts/three';
 import { useFrameUpdate } from '@pulse-ts/core';
 import * as THREE from 'three';
 import { isMobileDevice } from '../isMobileDevice';
@@ -153,23 +153,21 @@ export function NebulaNode() {
         ? NEBULA_FBM_OCTAVES_MOBILE
         : NEBULA_FBM_OCTAVES_DESKTOP;
     const segments = mobile ? NEBULA_SEGMENTS_MOBILE : NEBULA_SEGMENTS_DESKTOP;
-    const geometry = new THREE.SphereGeometry(
-        NEBULA_RADIUS,
-        segments,
-        segments,
-    );
-    const material = new THREE.ShaderMaterial({
-        vertexShader,
-        fragmentShader: buildNebulaFragmentShader(octaves),
-        uniforms,
-        side: THREE.BackSide,
-        transparent: true,
-        depthWrite: false,
-        fog: false,
-    });
 
-    const mesh = new THREE.Mesh(geometry, material);
-    useObject3D(mesh);
+    useCustomMesh({
+        geometry: () =>
+            new THREE.SphereGeometry(NEBULA_RADIUS, segments, segments),
+        material: () =>
+            new THREE.ShaderMaterial({
+                vertexShader,
+                fragmentShader: buildNebulaFragmentShader(octaves),
+                uniforms,
+                side: THREE.BackSide,
+                transparent: true,
+                depthWrite: false,
+                fog: false,
+            }),
+    });
 
     useFrameUpdate((dt) => {
         uniforms.uTime.value += dt * NEBULA_SPEED;

--- a/demos/arena/src/nodes/PlatformNode.ts
+++ b/demos/arena/src/nodes/PlatformNode.ts
@@ -1,6 +1,12 @@
 import { useComponent, Transform, useFrameUpdate } from '@pulse-ts/core';
 import { useRigidBody, useCylinderCollider } from '@pulse-ts/physics';
-import { useMesh, useObject3D, useThreeContext } from '@pulse-ts/three';
+import {
+    useMesh,
+    useCustomMesh,
+    useThreeContext,
+    createTexture,
+    createTexture1D,
+} from '@pulse-ts/three';
 import { useAnimate } from '@pulse-ts/effects';
 import * as THREE from 'three';
 import { ARENA_RADIUS } from '../config/arena';
@@ -105,32 +111,17 @@ export function createGridNormalMap(
     size: number = GRID_MAP_SIZE,
     spacing: number = GRID_SPACING,
 ): THREE.DataTexture {
-    const data = new Uint8Array(size * size * 4);
-    for (let y = 0; y < size; y++) {
-        for (let x = 0; x < size; x++) {
-            const i = (y * size + x) * 4;
-            // Default flat normal: (0.5, 0.5, 1.0) in [0,1] -> (0, 0, 1) in [-1,1]
+    return createTexture(
+        size,
+        (x, y) => {
             let nx = 128;
             let ny = 128;
-            const nz = 255;
-
-            // Perturb normals at grid-line boundaries
-            if (x % spacing === 0) nx = 96; // tilt left at vertical lines
-            if (y % spacing === 0) ny = 96; // tilt down at horizontal lines
-
-            data[i] = nx;
-            data[i + 1] = ny;
-            data[i + 2] = nz;
-            data[i + 3] = 255;
-        }
-    }
-    const tex = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
-    tex.wrapS = THREE.RepeatWrapping;
-    tex.wrapT = THREE.RepeatWrapping;
-    tex.magFilter = THREE.LinearFilter;
-    tex.minFilter = THREE.LinearFilter;
-    tex.needsUpdate = true;
-    return tex;
+            if (x % spacing === 0) nx = 96;
+            if (y % spacing === 0) ny = 96;
+            return [nx, ny, 255, 255];
+        },
+        { wrap: 'repeat', filter: 'linear' },
+    );
 }
 
 /**
@@ -141,6 +132,7 @@ export function createGridNormalMap(
  * @param size - Texture width and height in pixels.
  * @param spacing - Pixel spacing between grid lines.
  * @param lineWidth - Width of each grid line in pixels.
+ * @param radialFade - When true, lines fade from dark at center to bright at edge.
  * @returns A `THREE.DataTexture` with cyan grid lines on black.
  *
  * @example
@@ -155,44 +147,35 @@ export function createGridEmissiveMap(
     lineWidth: number = GRID_LINE_WIDTH,
     radialFade: boolean = false,
 ): THREE.DataTexture {
-    const data = new Uint8Array(size * size * 4);
     const half = Math.floor(lineWidth / 2);
     const center = size / 2;
 
-    for (let y = 0; y < size; y++) {
-        for (let x = 0; x < size; x++) {
-            const i = (y * size + x) * 4;
+    return createTexture(
+        size,
+        (x, y) => {
             const onVertical =
                 x % spacing <= half || x % spacing >= spacing - half;
             const onHorizontal =
                 y % spacing <= half || y % spacing >= spacing - half;
 
             if (onVertical || onHorizontal) {
-                // Radial fade: 0 at center, 1 at edge
                 let fade = 1;
                 if (radialFade) {
                     const dx = (x - center) / center;
                     const dy = (y - center) / center;
                     fade = Math.min(1, Math.sqrt(dx * dx + dy * dy));
                 }
-                // Cyan grid line scaled by radial fade
-                data[i] = Math.floor(50 * fade);
-                data[i + 1] = Math.floor(180 * fade);
-                data[i + 2] = Math.floor(220 * fade);
+                return [
+                    Math.floor(50 * fade),
+                    Math.floor(180 * fade),
+                    Math.floor(220 * fade),
+                    255,
+                ];
             }
-            // else: black (already 0)
-
-            data[i + 3] = 255;
-        }
-    }
-
-    const tex = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
-    tex.wrapS = THREE.RepeatWrapping;
-    tex.wrapT = THREE.RepeatWrapping;
-    tex.magFilter = THREE.LinearFilter;
-    tex.minFilter = THREE.LinearFilter;
-    tex.needsUpdate = true;
-    return tex;
+            return [0, 0, 0, 255];
+        },
+        { wrap: 'repeat', filter: 'linear' },
+    );
 }
 
 /**
@@ -214,39 +197,31 @@ export function createEnergyLineMap(
     size: number = ENERGY_MAP_SIZE,
     spokeCount: number = ENERGY_SPOKE_COUNT,
 ): THREE.DataTexture {
-    const data = new Uint8Array(size * size * 4);
     const center = size / 2;
 
-    for (let py = 0; py < size; py++) {
-        for (let px = 0; px < size; px++) {
-            const i = (py * size + px) * 4;
+    return createTexture(
+        size,
+        (px, py) => {
             const dx = px - center;
             const dy = py - center;
             const dist = Math.sqrt(dx * dx + dy * dy) / center;
 
-            // Radial spoke pattern with smooth falloff
             const angle = Math.atan2(dy, dx);
             const spokePhase = Math.abs(Math.sin(angle * spokeCount * 0.5));
 
-            // Smooth ramp: fade from 0 at phase 0.9 to full at phase 1.0
             const spokeEdge = Math.max(0, (spokePhase - 0.9) / 0.1);
-            // Dark at center, bright at edge (matching grid radial fade)
             const radialFade = Math.min(1, dist);
             const intensity = spokeEdge * spokeEdge * radialFade * 0.8;
 
-            // Cyan tint (R slightly less than G and B)
-            data[i] = Math.floor(intensity * 128);
-            data[i + 1] = Math.floor(intensity * 220);
-            data[i + 2] = Math.floor(intensity * 255);
-            data[i + 3] = 255;
-        }
-    }
-
-    const tex = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
-    tex.wrapS = THREE.RepeatWrapping;
-    tex.wrapT = THREE.RepeatWrapping;
-    tex.needsUpdate = true;
-    return tex;
+            return [
+                Math.floor(intensity * 128),
+                Math.floor(intensity * 220),
+                Math.floor(intensity * 255),
+                255,
+            ];
+        },
+        { wrap: 'repeat' },
+    );
 }
 
 /**
@@ -266,29 +241,19 @@ export function createEnergyLineMap(
 export function createRingGlowMap(
     size: number = RING_GLOW_MAP_SIZE,
 ): THREE.DataTexture {
-    const data = new Uint8Array(size * 4);
-    for (let x = 0; x < size; x++) {
-        const t = x / size; // 0..1 around the ring
-        // Smooth bright region centered at t=0 spanning ~25% of the ring
-        // Use a cosine falloff for a natural glow shape
-        const dist = Math.min(t, 1 - t) * 2; // 0 at center, 1 at opposite side
-        const glow = Math.pow(Math.max(0, 1 - dist * 3), 2); // smooth falloff
-        const base = 0.08; // dim base so the ring is never fully dark
-        const intensity = base + (1 - base) * glow;
-
-        const i = x * 4;
-        data[i] = Math.floor(intensity * 255);
-        data[i + 1] = Math.floor(intensity * 255);
-        data[i + 2] = Math.floor(intensity * 255);
-        data[i + 3] = 255;
-    }
-    const tex = new THREE.DataTexture(data, size, 1, THREE.RGBAFormat);
-    tex.wrapS = THREE.RepeatWrapping;
-    tex.wrapT = THREE.RepeatWrapping;
-    tex.magFilter = THREE.LinearFilter;
-    tex.minFilter = THREE.LinearFilter;
-    tex.needsUpdate = true;
-    return tex;
+    return createTexture1D(
+        size,
+        (x, width) => {
+            const t = x / width;
+            const dist = Math.min(t, 1 - t) * 2;
+            const glow = Math.pow(Math.max(0, 1 - dist * 3), 2);
+            const base = 0.08;
+            const intensity = base + (1 - base) * glow;
+            const v = Math.floor(intensity * 255);
+            return [v, v, v, 255];
+        },
+        { wrap: 'repeat', filter: 'linear' },
+    );
 }
 
 /**
@@ -306,12 +271,7 @@ export function createRingGlowMap(
  * ```
  */
 export function createWakeMap(size: number = WAKE_MAP_SIZE): THREE.DataTexture {
-    const data = new Uint8Array(size * size * 4);
-    const tex = new THREE.DataTexture(data, size, size, THREE.RGBAFormat);
-    tex.magFilter = THREE.LinearFilter;
-    tex.minFilter = THREE.LinearFilter;
-    tex.needsUpdate = true;
-    return tex;
+    return createTexture(size, () => [0, 0, 0, 0], { filter: 'linear' });
 }
 
 /**
@@ -494,7 +454,17 @@ export function PlatformNode() {
         restitution: 0,
     });
 
+    // Procedural texture maps
+    const normalMap = createGridNormalMap();
+    const gridEmissiveMap = createGridEmissiveMap(
+        GRID_MAP_SIZE,
+        GRID_SPACING / 2,
+        GRID_LINE_WIDTH,
+        true,
+    );
+
     // Visual — cylinder mesh for the platform surface (opaque dark base)
+    // with texture maps passed directly via useMesh extensions
     const { material: platformMat } = useMesh('cylinder', {
         radius: PLATFORM_RADIUS,
         height: PLATFORM_HEIGHT,
@@ -503,100 +473,95 @@ export function PlatformNode() {
         roughness: 0.7,
         metalness: 0.2,
         receiveShadow: true,
+        normalMap,
+        normalScale: [0.3, 0.3],
+        emissive: RING_COLOR,
+        emissiveMap: gridEmissiveMap,
+        emissiveIntensity: 0.15,
     });
 
     // --- Blue tint fill on top of the grid ---
-    const fillGeometry = new THREE.CylinderGeometry(
-        PLATFORM_RADIUS,
-        PLATFORM_RADIUS,
-        0.01,
-        48,
-    );
-    const fillMaterial = new THREE.MeshBasicMaterial({
-        color: 0x2244aa,
-        transparent: true,
-        opacity: 0.035,
-        depthWrite: false,
+    const { object: fillMesh } = useCustomMesh({
+        geometry: () =>
+            new THREE.CylinderGeometry(
+                PLATFORM_RADIUS,
+                PLATFORM_RADIUS,
+                0.01,
+                48,
+            ),
+        material: () =>
+            new THREE.MeshBasicMaterial({
+                color: 0x2244aa,
+                transparent: true,
+                opacity: 0.035,
+                depthWrite: false,
+            }),
     });
-    const fillMesh = new THREE.Mesh(fillGeometry, fillMaterial);
     fillMesh.position.y = PLATFORM_HEIGHT / 2 + 0.01;
-    useObject3D(fillMesh);
-
-    // Procedural grid normal map — subtle surface relief at grid lines
-    const normalMap = createGridNormalMap();
-    platformMat.normalMap = normalMap;
-    platformMat.normalScale = new THREE.Vector2(0.3, 0.3);
-
-    // Grid emissive map — visible glowing grid lines on the surface
-    // Radial fade: lines are dark at center, bright at edge.
-    // No repeat — single pass covers entire surface with baked falloff.
-    const gridEmissiveMap = createGridEmissiveMap(
-        GRID_MAP_SIZE,
-        GRID_SPACING / 2,
-        GRID_LINE_WIDTH,
-        true,
-    );
-    platformMat.emissive = new THREE.Color(RING_COLOR);
-    platformMat.emissiveMap = gridEmissiveMap;
-    platformMat.emissiveIntensity = 0.15;
 
     // --- Energy line overlay ---
     const energyMap = createEnergyLineMap();
-    const energyGeometry = new THREE.CylinderGeometry(
-        PLATFORM_RADIUS - 0.1,
-        PLATFORM_RADIUS - 0.1,
-        0.02,
-        48,
-    );
-    const energyMaterial = new THREE.MeshStandardMaterial({
-        color: 0x000000,
-        emissive: RING_COLOR,
-        emissiveMap: energyMap,
-        emissiveIntensity: 0.12,
-        transparent: true,
-        opacity: 0.15,
-        roughness: 1,
-        metalness: 0,
-        depthWrite: false,
+    const { object: energyMesh } = useCustomMesh({
+        geometry: () =>
+            new THREE.CylinderGeometry(
+                PLATFORM_RADIUS - 0.1,
+                PLATFORM_RADIUS - 0.1,
+                0.02,
+                48,
+            ),
+        material: () =>
+            new THREE.MeshStandardMaterial({
+                color: 0x000000,
+                emissive: RING_COLOR,
+                emissiveMap: energyMap,
+                emissiveIntensity: 0.12,
+                transparent: true,
+                opacity: 0.15,
+                roughness: 1,
+                metalness: 0,
+                depthWrite: false,
+            }),
     });
-    const energyMesh = new THREE.Mesh(energyGeometry, energyMaterial);
     energyMesh.position.y = PLATFORM_HEIGHT / 2 + 0.02;
-    useObject3D(energyMesh);
 
     // --- Enhanced edge ring (primary) with rotating glow ---
     const ringGlowMap = createRingGlowMap();
-    const ringGeometry = new THREE.TorusGeometry(PLATFORM_RADIUS, 0.12, 12, 64);
-    const ringMaterial = new THREE.MeshStandardMaterial({
-        color: 0x000000,
-        emissive: RING_COLOR,
-        emissiveMap: ringGlowMap,
-        emissiveIntensity: 1.5,
-        roughness: 0.3,
-        metalness: 0.5,
+    const { object: ringMesh, material: ringMaterialBase } = useCustomMesh({
+        geometry: () => new THREE.TorusGeometry(PLATFORM_RADIUS, 0.12, 12, 64),
+        material: () =>
+            new THREE.MeshStandardMaterial({
+                color: 0x000000,
+                emissive: RING_COLOR,
+                emissiveMap: ringGlowMap,
+                emissiveIntensity: 1.5,
+                roughness: 0.3,
+                metalness: 0.5,
+            }),
     });
-    const ringMesh = new THREE.Mesh(ringGeometry, ringMaterial);
+    const ringMaterial = ringMaterialBase as THREE.MeshStandardMaterial;
     ringMesh.rotation.x = -Math.PI / 2;
     ringMesh.position.y = PLATFORM_HEIGHT / 2;
-    useObject3D(ringMesh);
 
     // --- Outer glow ring (soft halo) with same rotating glow ---
     const glowGlowMap = createRingGlowMap();
-    const glowGeometry = new THREE.TorusGeometry(PLATFORM_RADIUS, 0.3, 12, 64);
-    const glowMaterial = new THREE.MeshStandardMaterial({
-        color: 0x000000,
-        emissive: RING_COLOR,
-        emissiveMap: glowGlowMap,
-        emissiveIntensity: 0.6,
-        transparent: true,
-        opacity: 0.15,
-        roughness: 0.5,
-        metalness: 0.3,
-        depthWrite: false,
+    const { object: glowMesh, material: glowMaterialBase } = useCustomMesh({
+        geometry: () => new THREE.TorusGeometry(PLATFORM_RADIUS, 0.3, 12, 64),
+        material: () =>
+            new THREE.MeshStandardMaterial({
+                color: 0x000000,
+                emissive: RING_COLOR,
+                emissiveMap: glowGlowMap,
+                emissiveIntensity: 0.6,
+                transparent: true,
+                opacity: 0.15,
+                roughness: 0.5,
+                metalness: 0.3,
+                depthWrite: false,
+            }),
     });
-    const glowMesh = new THREE.Mesh(glowGeometry, glowMaterial);
+    const glowMaterial = glowMaterialBase as THREE.MeshStandardMaterial;
     glowMesh.rotation.x = -Math.PI / 2;
     glowMesh.position.y = PLATFORM_HEIGHT / 2;
-    useObject3D(glowMesh);
 
     // --- Wake map (CPU-rasterized player trail influence) ---
     const mobile = isMobileDevice();

--- a/demos/arena/src/nodes/StarfieldNode.ts
+++ b/demos/arena/src/nodes/StarfieldNode.ts
@@ -1,4 +1,4 @@
-import { useObject3D, useThreeContext } from '@pulse-ts/three';
+import { useCustomMesh, useThreeContext } from '@pulse-ts/three';
 import { useAnimate } from '@pulse-ts/effects';
 import { useFrameUpdate } from '@pulse-ts/core';
 import * as THREE from 'three';
@@ -73,70 +73,78 @@ export function createStarPositions(
  * to give a subtle sense of depth and motion in the background.
  */
 export function StarfieldNode() {
-    const positions = createStarPositions(
-        STAR_COUNT,
-        STAR_RADIUS_MIN,
-        STAR_RADIUS_MAX,
-    );
-
-    const geometry = new THREE.BufferGeometry();
-    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-
-    // Random phase per star for independent twinkle timing
-    const phases = new Float32Array(STAR_COUNT);
-    for (let i = 0; i < STAR_COUNT; i++) {
-        phases[i] = Math.random() * Math.PI * 2;
-    }
-    geometry.setAttribute(
-        'aTwinklePhase',
-        new THREE.BufferAttribute(phases, 1),
-    );
-
     const timeUniform = { value: 0 };
 
-    const material = new THREE.PointsMaterial({
-        color: 0xffffff,
-        size: STAR_SIZE,
-        sizeAttenuation: false,
-        fog: false,
-        transparent: true,
-        opacity: STAR_OPACITY,
-        depthWrite: false,
+    const { object: points, material: pointsMaterial } = useCustomMesh({
+        geometry: () => {
+            const positions = createStarPositions(
+                STAR_COUNT,
+                STAR_RADIUS_MIN,
+                STAR_RADIUS_MAX,
+            );
+            const geo = new THREE.BufferGeometry();
+            geo.setAttribute(
+                'position',
+                new THREE.BufferAttribute(positions, 3),
+            );
+
+            // Random phase per star for independent twinkle timing
+            const phases = new Float32Array(STAR_COUNT);
+            for (let i = 0; i < STAR_COUNT; i++) {
+                phases[i] = Math.random() * Math.PI * 2;
+            }
+            geo.setAttribute(
+                'aTwinklePhase',
+                new THREE.BufferAttribute(phases, 1),
+            );
+            return geo;
+        },
+        material: () => {
+            const mat = new THREE.PointsMaterial({
+                color: 0xffffff,
+                size: STAR_SIZE,
+                sizeAttenuation: false,
+                fog: false,
+                transparent: true,
+                opacity: STAR_OPACITY,
+                depthWrite: false,
+            });
+
+            // Patch shader to oscillate per-star opacity using the phase attribute
+            mat.onBeforeCompile = (shader) => {
+                shader.uniforms.uTime = timeUniform;
+
+                shader.vertexShader = shader.vertexShader.replace(
+                    '#include <common>',
+                    `#include <common>
+                    attribute float aTwinklePhase;
+                    varying float vTwinkle;
+                    uniform float uTime;`,
+                );
+
+                shader.vertexShader = shader.vertexShader.replace(
+                    '#include <begin_vertex>',
+                    `#include <begin_vertex>
+                    vTwinkle = ${STAR_TWINKLE_MIN.toFixed(2)} + ${(1.0 - STAR_TWINKLE_MIN).toFixed(2)} * (0.5 + 0.5 * sin(uTime * ${(STAR_TWINKLE_SPEED * Math.PI * 2).toFixed(2)} + aTwinklePhase));`,
+                );
+
+                shader.fragmentShader = shader.fragmentShader.replace(
+                    '#include <common>',
+                    `#include <common>
+                    varying float vTwinkle;`,
+                );
+
+                shader.fragmentShader = shader.fragmentShader.replace(
+                    '#include <premultiplied_alpha_fragment>',
+                    `#include <premultiplied_alpha_fragment>
+                    gl_FragColor.a *= vTwinkle;`,
+                );
+            };
+            return mat;
+        },
+        type: 'points',
     });
-
-    // Patch shader to oscillate per-star opacity using the phase attribute
-    material.onBeforeCompile = (shader) => {
-        shader.uniforms.uTime = timeUniform;
-
-        shader.vertexShader = shader.vertexShader.replace(
-            '#include <common>',
-            `#include <common>
-            attribute float aTwinklePhase;
-            varying float vTwinkle;
-            uniform float uTime;`,
-        );
-
-        shader.vertexShader = shader.vertexShader.replace(
-            '#include <begin_vertex>',
-            `#include <begin_vertex>
-            vTwinkle = ${STAR_TWINKLE_MIN.toFixed(2)} + ${(1.0 - STAR_TWINKLE_MIN).toFixed(2)} * (0.5 + 0.5 * sin(uTime * ${(STAR_TWINKLE_SPEED * Math.PI * 2).toFixed(2)} + aTwinklePhase));`,
-        );
-
-        shader.fragmentShader = shader.fragmentShader.replace(
-            '#include <common>',
-            `#include <common>
-            varying float vTwinkle;`,
-        );
-
-        shader.fragmentShader = shader.fragmentShader.replace(
-            '#include <premultiplied_alpha_fragment>',
-            `#include <premultiplied_alpha_fragment>
-            gl_FragColor.a *= vTwinkle;`,
-        );
-    };
-
-    const points = new THREE.Points(geometry, material);
-    useObject3D(points);
+    const material = pointsMaterial as THREE.PointsMaterial;
 
     const { renderer } = useThreeContext();
     const spin = useAnimate({ rate: STAR_ROTATION_RATE });


### PR DESCRIPTION
## Summary
- Replace 5 manual DataTexture creation functions in PlatformNode with `createTexture`/`createTexture1D` utilities from `@pulse-ts/three`
- Migrate StarfieldNode (Points), NebulaNode (Plane+ShaderMaterial), and EnergyPillarsNode to `useCustomMesh` for automatic geometry/material lifecycle management
- Replace manual fixed-to-frame position interpolation in LocalPlayerNode with `useInterpolatedPosition` hook
- Replace manual Vector3 screen projection for indicator ring with `useScreenProjection` hook
- Pass normalMap, emissiveMap, normalScale directly via `useMesh` material extensions in PlatformNode
- Replace manual geometry/material creation for platform overlays (fill, energy, ring, glow) with `useCustomMesh`

## Test plan
- [x] All 259 arena tests pass (same as baseline)
- [x] Lint clean (`npx eslint demos/arena/src/`)
- [x] No manual DataTexture construction remains in PlatformNode
- [x] No manual `useObject3D` calls remain in migrated nodes
- [x] No manual interpolation code in LocalPlayerNode

🤖 Generated with [Claude Code](https://claude.com/claude-code)