### PR TITLE
TICKET-144: Split ReplayNode DOM overlay from playback logic

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-144-split-replay-node-dom-overlay.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-144-split-replay-node-dom-overlay.md
@@ -1,7 +1,7 @@
 ---
 id: TICKET-144
 title: Split ReplayNode DOM overlay from playback logic
-status: in-progress
+status: done
 epic: EPIC-026
 created: 2026-03-14
 updated: 2026-03-14
@@ -26,3 +26,4 @@ Split the DOM overlay (letterbox + label + flash + self-KO text) into a `ReplayO
 - `demos/arena/src/nodes/ReplayNode.ts`
 
 - **2026-03-14**: Starting implementation
+- **2026-03-14**: Implementation complete

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-144-split-replay-node-dom-overlay.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-144-split-replay-node-dom-overlay.md
@@ -1,9 +1,11 @@
 ---
 id: TICKET-144
 title: Split ReplayNode DOM overlay from playback logic
-status: todo
+status: in-progress
 epic: EPIC-026
 created: 2026-03-14
+updated: 2026-03-14
+branch: ticket-144-split-replay-node-dom-overlay
 priority: medium
 ---
 
@@ -22,3 +24,5 @@ Split the DOM overlay (letterbox + label + flash + self-KO text) into a `ReplayO
 ## Files
 
 - `demos/arena/src/nodes/ReplayNode.ts`
+
+- **2026-03-14**: Starting implementation

--- a/demos/arena/src/nodes/ArenaNode.ts
+++ b/demos/arena/src/nodes/ArenaNode.ts
@@ -24,6 +24,7 @@ import { TouchControlsNode } from './TouchControlsNode';
 import { CameraRigNode } from './CameraRigNode';
 import { VictoryEffectNode } from './VictoryEffectNode';
 import { ReplayNode } from './ReplayNode';
+import { ReplayOverlayNode } from './ReplayOverlayNode';
 import { ShockwaveNode } from './ShockwaveNode';
 import { NebulaNode } from './NebulaNode';
 import { StarfieldNode } from './StarfieldNode';
@@ -228,8 +229,11 @@ export function ArenaNode(props?: Readonly<ArenaNodeProps>) {
     // Camera rig — fixed overhead view
     useChild(CameraRigNode);
 
-    // Instant replay overlay — letterboxing + playback driver
+    // Instant replay — playback driver + VFX
     useChild(ReplayNode);
+
+    // Instant replay — DOM overlay (letterbox, flash, labels)
+    useChild(ReplayOverlayNode);
 
     // Shockwave distortion — screen-space ring on impact
     useChild(ShockwaveNode, { pass: props?.shockwavePass });

--- a/demos/arena/src/nodes/ReplayNode.test.ts
+++ b/demos/arena/src/nodes/ReplayNode.test.ts
@@ -1,86 +1,54 @@
-jest.mock(
-    '@pulse-ts/core',
-    () => ({
-        createContext: (name: string) => ({ name }),
-        useFrameUpdate: jest.fn(),
-        useDestroy: jest.fn(),
-        useContext: jest.fn(),
-        useWorld: jest.fn(),
-        defineStore: (name: string, factory: () => any) => ({
-            _key: Symbol(name),
-            _factory: factory,
-        }),
-        useStore: jest.fn(),
-    }),
-    { virtual: true },
-);
+import { vi, describe, it, expect } from 'vitest';
 
-jest.mock(
-    '@pulse-ts/three',
-    () => ({
-        useThreeContext: jest.fn(),
+vi.mock('@pulse-ts/core', () => ({
+    createContext: (name: string) => ({ name }),
+    useFrameUpdate: vi.fn(),
+    useDestroy: vi.fn(),
+    useContext: vi.fn(),
+    useWorld: vi.fn(() => ({ getService: vi.fn() })),
+    defineStore: (name: string, factory: () => unknown) => ({
+        _key: Symbol(name),
+        _factory: factory,
     }),
-    { virtual: true },
-);
-
-jest.mock(
-    '@pulse-ts/effects',
-    () => ({
-        useParticleBurst: jest.fn(),
-        useClearParticles: jest.fn(),
-        ParticlesService: {},
-        useEffectPool: jest.fn(),
-    }),
-    { virtual: true },
-);
-
-jest.mock(
-    '@pulse-ts/audio',
-    () => ({
-        useSound: jest.fn(() => jest.fn()),
-    }),
-    { virtual: true },
-);
-
-jest.mock('three/examples/jsm/postprocessing/ShaderPass.js', () => ({
-    ShaderPass: jest.fn(),
+    useStore: vi.fn(() => [{}]),
 }));
 
-import {
-    ReplayNode,
-    LETTERBOX_HEIGHT,
-    TRANSITION_FLASH_DURATION,
-    SELF_KO_MESSAGES,
-    SELF_KO_BOB_PERIOD,
-    SELF_KO_BOB_STAGGER,
-    SELF_KO_BOB_DISTANCE,
-} from './ReplayNode';
+vi.mock('@pulse-ts/three', () => ({
+    useThreeContext: vi.fn(() => ({ camera: {} })),
+}));
+
+vi.mock('@pulse-ts/effects', () => ({
+    useParticleBurst: vi.fn(() => vi.fn()),
+    useClearParticles: vi.fn(() => vi.fn()),
+    ParticlesService: {},
+    useEffectPool: vi.fn(() => ({ trigger: vi.fn() })),
+}));
+
+vi.mock('@pulse-ts/audio', () => ({
+    useSound: vi.fn(() => ({ play: vi.fn() })),
+}));
+
+vi.mock('three/examples/jsm/postprocessing/ShaderPass.js', () => ({
+    ShaderPass: vi.fn(),
+}));
+
+vi.mock('../shockwave', () => ({
+    useShockwavePool: vi.fn(() => ({ trigger: vi.fn() })),
+    worldToScreen: vi.fn(() => [0, 0]),
+}));
+
+vi.mock('../hitImpact', () => ({
+    useHitImpactPool: vi.fn(() => ({ trigger: vi.fn() })),
+}));
+
+vi.mock('./CameraRigNode', () => ({
+    triggerCameraShake: vi.fn(),
+}));
+
+import { ReplayNode } from './ReplayNode';
 
 describe('ReplayNode', () => {
     it('exports the node function', () => {
         expect(typeof ReplayNode).toBe('function');
-    });
-
-    it('letterbox height is a valid CSS value', () => {
-        expect(LETTERBOX_HEIGHT).toMatch(/^\d+%$/);
-    });
-
-    it('transition flash duration is a short positive value', () => {
-        expect(TRANSITION_FLASH_DURATION).toBeGreaterThan(0);
-        expect(TRANSITION_FLASH_DURATION).toBeLessThan(1);
-    });
-
-    it('has a non-empty array of self-KO messages', () => {
-        expect(SELF_KO_MESSAGES.length).toBeGreaterThan(0);
-        for (const msg of SELF_KO_MESSAGES) {
-            expect(typeof msg).toBe('string');
-            expect(msg.length).toBeGreaterThan(0);
-        }
-    });
-
-    it('self-KO bob animation constants are positive', () => {
-        expect(SELF_KO_BOB_PERIOD).toBeGreaterThan(0);
-        expect(SELF_KO_BOB_STAGGER).toBeGreaterThan(0);
-        expect(SELF_KO_BOB_DISTANCE).toBeGreaterThan(0);
     });
 });

--- a/demos/arena/src/nodes/ReplayNode.ts
+++ b/demos/arena/src/nodes/ReplayNode.ts
@@ -1,6 +1,5 @@
 import {
     useFrameUpdate,
-    useDestroy,
     useContext,
     useWorld,
     useStore,
@@ -22,148 +21,24 @@ import {
     getReplaySpeed,
     getReplayHitIndices,
     getReplayCursorPos,
-    hasReplayHit,
 } from '../replay';
 import { PLAYER_COLORS, TRAIL_BASE_INTERVAL } from '../config/arena';
 import { triggerCameraShake } from './CameraRigNode';
 import { useShockwavePool, worldToScreen } from '../shockwave';
 import { useHitImpactPool } from '../hitImpact';
 
-/** Height of each cinematic letterbox bar as a CSS value. */
-export const LETTERBOX_HEIGHT = '8%';
-
-/** Duration of the dark flash when entering/exiting replay (seconds). */
-export const TRANSITION_FLASH_DURATION = 0.4;
-
-/** Random messages displayed during a self-KO replay. */
-export const SELF_KO_MESSAGES = [
-    'Gravity wins!',
-    '...really?',
-    'Own goal!',
-    'Unforced error',
-    'Self-destruct!',
-    'Whoops!',
-    'Task failed successfully',
-    'No one to blame',
-];
-
-/** Per-letter bob animation period in seconds. */
-export const SELF_KO_BOB_PERIOD = 0.6;
-
-/** Delay between each letter's bob start in seconds. */
-export const SELF_KO_BOB_STAGGER = 0.05;
-
-/** Vertical bob distance in pixels. */
-export const SELF_KO_BOB_DISTANCE = 8;
-
 /**
- * DOM overlay that displays cinematic letterboxing, a "REPLAY" label,
- * and a dark flash transition during the replay phase. Drives replay
- * playback by calling `advanceReplay(dt)` each frame. Also emits
- * dash trail particles when players are moving fast during replay.
+ * Drives replay playback and VFX (particles, camera shake, sounds) during
+ * the replay phase. DOM overlay concerns (letterbox, flash, labels) are
+ * handled by {@link ReplayOverlayNode}.
  */
 export function ReplayNode() {
     const gameState = useContext(GameCtx);
-    const { renderer, camera } = useThreeContext();
+    const { camera } = useThreeContext();
 
     const [replay] = useStore(ReplayStore);
     const shockwavePool = useShockwavePool();
     const hitImpactPool = useHitImpactPool();
-    const container = renderer.domElement.parentElement ?? document.body;
-
-    // Dark flash overlay — masks the position jump entering/exiting replay
-    const flash = document.createElement('div');
-    Object.assign(flash.style, {
-        position: 'absolute',
-        inset: '0',
-        backgroundColor: 'rgba(0, 0, 0, 0.9)',
-        zIndex: '2015',
-        opacity: '0',
-        pointerEvents: 'none',
-    } as Partial<CSSStyleDeclaration>);
-    container.appendChild(flash);
-
-    // Top letterbox bar
-    const topBar = document.createElement('div');
-    Object.assign(topBar.style, {
-        position: 'absolute',
-        top: '0',
-        left: '0',
-        right: '0',
-        height: LETTERBOX_HEIGHT,
-        backgroundColor: 'rgba(0, 0, 0, 0.85)',
-        zIndex: '2010',
-        transition: 'opacity 0.3s ease-in-out',
-        opacity: '0',
-        pointerEvents: 'none',
-    } as Partial<CSSStyleDeclaration>);
-    container.appendChild(topBar);
-
-    // Bottom letterbox bar
-    const bottomBar = document.createElement('div');
-    Object.assign(bottomBar.style, {
-        position: 'absolute',
-        bottom: '0',
-        left: '0',
-        right: '0',
-        height: LETTERBOX_HEIGHT,
-        backgroundColor: 'rgba(0, 0, 0, 0.85)',
-        zIndex: '2010',
-        transition: 'opacity 0.3s ease-in-out',
-        opacity: '0',
-        pointerEvents: 'none',
-    } as Partial<CSSStyleDeclaration>);
-    container.appendChild(bottomBar);
-
-    // "REPLAY" label — positioned in the top-right corner
-    const label = document.createElement('div');
-    Object.assign(label.style, {
-        position: 'absolute',
-        top: '12%',
-        right: '4%',
-        zIndex: '2011',
-        font: 'bold clamp(10px, 2.5vw, 32px) monospace',
-        color: 'rgba(255, 240, 140, 0.85)',
-        letterSpacing: '0.2em',
-        textShadow: '0 0 6px rgba(0,0,0,0.6)',
-        transition: 'opacity 0.3s ease-in-out',
-        opacity: '0',
-        pointerEvents: 'none',
-        animation: 'replayBlink 1.2s step-end infinite',
-    } as Partial<CSSStyleDeclaration>);
-    label.textContent = '\u25B6 REPLAY';
-    container.appendChild(label);
-
-    // Replay blink + Self-KO bob animations — injected as a <style> element
-    const selfKoStyle = document.createElement('style');
-    selfKoStyle.textContent = `
-        @keyframes replayBlink {
-            0%, 80% { visibility: visible; }
-            80.01%, 100% { visibility: hidden; }
-        }
-        @keyframes selfKoBob {
-            0%, 100% { transform: translateY(0); }
-            50% { transform: translateY(-${SELF_KO_BOB_DISTANCE}px); }
-        }
-    `;
-    container.appendChild(selfKoStyle);
-
-    // Self-KO text — displayed when no collision hit occurred
-    const selfKoText = document.createElement('div');
-    Object.assign(selfKoText.style, {
-        position: 'absolute',
-        top: '12%',
-        left: '4%',
-        zIndex: '2012',
-        font: 'bold clamp(16px, 4vw, 32px) monospace',
-        color: 'rgba(255, 200, 100, 0.9)',
-        textShadow: '0 0 10px rgba(0,0,0,0.7)',
-        transition: 'opacity 0.3s ease-in-out',
-        opacity: '0',
-        pointerEvents: 'none',
-        whiteSpace: 'nowrap',
-    } as Partial<CSSStyleDeclaration>);
-    container.appendChild(selfKoText);
 
     // Hit impact burst — white particles at the collision point
     const hitImpactBurst = useParticleBurst({
@@ -218,38 +93,17 @@ export function ReplayNode() {
 
     // Transition state
     let wasReplay = false;
-    let flashTimer = 0;
     let trailAccum = 0;
     const hitBurstsEmitted = new Set<number>();
-    let selfKoMessagePicked = false;
 
     useFrameUpdate((dt) => {
         const isReplay = gameState.phase === 'replay' && isReplayActive(replay);
 
-        // Detect transition into replay — trigger dark flash and clear particles
+        // Detect transition into replay — clear lingering particles
         if (isReplay && !wasReplay) {
-            flashTimer = TRANSITION_FLASH_DURATION;
             clearParticles();
         }
-        // Detect transition out of replay — trigger exit flash
-        if (!isReplay && wasReplay) {
-            flashTimer = TRANSITION_FLASH_DURATION * 0.6;
-        }
         wasReplay = isReplay;
-
-        // Animate flash overlay
-        if (flashTimer > 0) {
-            flashTimer -= dt;
-            const t = Math.max(flashTimer, 0) / TRANSITION_FLASH_DURATION;
-            flash.style.opacity = String(t);
-        } else {
-            flash.style.opacity = '0';
-        }
-
-        // Letterbox and label
-        topBar.style.opacity = isReplay ? '1' : '0';
-        bottomBar.style.opacity = isReplay ? '1' : '0';
-        label.style.opacity = isReplay ? '1' : '0';
 
         // Scale particle aging to match replay speed
         if (particleService) {
@@ -259,29 +113,6 @@ export function ReplayNode() {
         // Drive replay playback
         if (isReplay) {
             advanceReplay(replay, dt);
-
-            // Self-KO text — per-letter bobbing animation
-            if (!hasReplayHit(replay)) {
-                if (!selfKoMessagePicked) {
-                    const msg =
-                        SELF_KO_MESSAGES[
-                            Math.floor(Math.random() * SELF_KO_MESSAGES.length)
-                        ];
-                    selfKoText.innerHTML = '';
-                    for (let i = 0; i < msg.length; i++) {
-                        const span = document.createElement('span');
-                        span.textContent = msg[i] === ' ' ? '\u00A0' : msg[i];
-                        span.style.display = 'inline-block';
-                        span.style.animation = `selfKoBob ${SELF_KO_BOB_PERIOD}s ease-in-out infinite`;
-                        span.style.animationDelay = `${i * SELF_KO_BOB_STAGGER}s`;
-                        selfKoText.appendChild(span);
-                    }
-                    selfKoMessagePicked = true;
-                }
-                selfKoText.style.opacity = '1';
-            } else {
-                selfKoText.style.opacity = '0';
-            }
 
             // Hit impact bursts + camera shake at each collision moment
             const cursor = getReplayCursorPos(replay);
@@ -326,19 +157,8 @@ export function ReplayNode() {
                 }
             }
         } else {
-            selfKoText.style.opacity = '0';
             trailAccum = 0;
             hitBurstsEmitted.clear();
-            selfKoMessagePicked = false;
         }
-    });
-
-    useDestroy(() => {
-        flash.remove();
-        topBar.remove();
-        bottomBar.remove();
-        label.remove();
-        selfKoText.remove();
-        selfKoStyle.remove();
     });
 }

--- a/demos/arena/src/nodes/ReplayOverlayNode.test.ts
+++ b/demos/arena/src/nodes/ReplayOverlayNode.test.ts
@@ -1,0 +1,72 @@
+import { vi, describe, it, expect } from 'vitest';
+
+vi.mock('@pulse-ts/core', () => ({
+    createContext: (name: string) => ({ name }),
+    useFrameUpdate: vi.fn(),
+    useDestroy: vi.fn(),
+    useContext: vi.fn(),
+    useWorld: vi.fn(() => ({ getService: vi.fn() })),
+    defineStore: (name: string, factory: () => unknown) => ({
+        _key: Symbol(name),
+        _factory: factory,
+    }),
+    useStore: vi.fn(() => [{}]),
+}));
+
+vi.mock('@pulse-ts/three', () => ({
+    useThreeContext: vi.fn(() => ({ renderer: { domElement: { parentElement: document.body } } })),
+}));
+
+vi.mock('@pulse-ts/effects', () => ({
+    useParticleBurst: vi.fn(() => vi.fn()),
+    useClearParticles: vi.fn(() => vi.fn()),
+    ParticlesService: {},
+    useEffectPool: vi.fn(() => ({ trigger: vi.fn() })),
+}));
+
+vi.mock('@pulse-ts/audio', () => ({
+    useSound: vi.fn(() => ({ play: vi.fn() })),
+}));
+
+vi.mock('three/examples/jsm/postprocessing/ShaderPass.js', () => ({
+    ShaderPass: vi.fn(),
+}));
+
+import {
+    ReplayOverlayNode,
+    LETTERBOX_HEIGHT,
+    TRANSITION_FLASH_DURATION,
+    SELF_KO_MESSAGES,
+    SELF_KO_BOB_PERIOD,
+    SELF_KO_BOB_STAGGER,
+    SELF_KO_BOB_DISTANCE,
+} from './ReplayOverlayNode';
+
+describe('ReplayOverlayNode', () => {
+    it('exports the node function', () => {
+        expect(typeof ReplayOverlayNode).toBe('function');
+    });
+
+    it('letterbox height is a valid CSS value', () => {
+        expect(LETTERBOX_HEIGHT).toMatch(/^\d+%$/);
+    });
+
+    it('transition flash duration is a short positive value', () => {
+        expect(TRANSITION_FLASH_DURATION).toBeGreaterThan(0);
+        expect(TRANSITION_FLASH_DURATION).toBeLessThan(1);
+    });
+
+    it('has a non-empty array of self-KO messages', () => {
+        expect(SELF_KO_MESSAGES.length).toBeGreaterThan(0);
+        for (const msg of SELF_KO_MESSAGES) {
+            expect(typeof msg).toBe('string');
+            expect(msg.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('self-KO bob animation constants are positive', () => {
+        expect(SELF_KO_BOB_PERIOD).toBeGreaterThan(0);
+        expect(SELF_KO_BOB_STAGGER).toBeGreaterThan(0);
+        expect(SELF_KO_BOB_DISTANCE).toBeGreaterThan(0);
+    });
+});

--- a/demos/arena/src/nodes/ReplayOverlayNode.ts
+++ b/demos/arena/src/nodes/ReplayOverlayNode.ts
@@ -1,0 +1,219 @@
+import {
+    useFrameUpdate,
+    useDestroy,
+    useContext,
+    useStore,
+} from '@pulse-ts/core';
+import { useThreeContext } from '@pulse-ts/three';
+import { GameCtx } from '../contexts';
+import {
+    ReplayStore,
+    isReplayActive,
+    hasReplayHit,
+} from '../replay';
+
+/** Height of each cinematic letterbox bar as a CSS value. */
+export const LETTERBOX_HEIGHT = '8%';
+
+/** Duration of the dark flash when entering/exiting replay (seconds). */
+export const TRANSITION_FLASH_DURATION = 0.4;
+
+/** Random messages displayed during a self-KO replay. */
+export const SELF_KO_MESSAGES = [
+    'Gravity wins!',
+    '...really?',
+    'Own goal!',
+    'Unforced error',
+    'Self-destruct!',
+    'Whoops!',
+    'Task failed successfully',
+    'No one to blame',
+];
+
+/** Per-letter bob animation period in seconds. */
+export const SELF_KO_BOB_PERIOD = 0.6;
+
+/** Delay between each letter's bob start in seconds. */
+export const SELF_KO_BOB_STAGGER = 0.05;
+
+/** Vertical bob distance in pixels. */
+export const SELF_KO_BOB_DISTANCE = 8;
+
+/**
+ * DOM overlay that displays cinematic letterboxing, a "REPLAY" label,
+ * a dark flash transition, and self-KO text during the replay phase.
+ *
+ * This node handles only DOM/visual overlay concerns. Playback advancement
+ * and VFX (particles, camera shake, sounds) remain in {@link ReplayNode}.
+ */
+export function ReplayOverlayNode() {
+    const gameState = useContext(GameCtx);
+    const { renderer } = useThreeContext();
+
+    const [replay] = useStore(ReplayStore);
+    const container = renderer.domElement.parentElement ?? document.body;
+
+    // Dark flash overlay — masks the position jump entering/exiting replay
+    const flash = document.createElement('div');
+    Object.assign(flash.style, {
+        position: 'absolute',
+        inset: '0',
+        backgroundColor: 'rgba(0, 0, 0, 0.9)',
+        zIndex: '2015',
+        opacity: '0',
+        pointerEvents: 'none',
+    } as Partial<CSSStyleDeclaration>);
+    container.appendChild(flash);
+
+    // Top letterbox bar
+    const topBar = document.createElement('div');
+    Object.assign(topBar.style, {
+        position: 'absolute',
+        top: '0',
+        left: '0',
+        right: '0',
+        height: LETTERBOX_HEIGHT,
+        backgroundColor: 'rgba(0, 0, 0, 0.85)',
+        zIndex: '2010',
+        transition: 'opacity 0.3s ease-in-out',
+        opacity: '0',
+        pointerEvents: 'none',
+    } as Partial<CSSStyleDeclaration>);
+    container.appendChild(topBar);
+
+    // Bottom letterbox bar
+    const bottomBar = document.createElement('div');
+    Object.assign(bottomBar.style, {
+        position: 'absolute',
+        bottom: '0',
+        left: '0',
+        right: '0',
+        height: LETTERBOX_HEIGHT,
+        backgroundColor: 'rgba(0, 0, 0, 0.85)',
+        zIndex: '2010',
+        transition: 'opacity 0.3s ease-in-out',
+        opacity: '0',
+        pointerEvents: 'none',
+    } as Partial<CSSStyleDeclaration>);
+    container.appendChild(bottomBar);
+
+    // "REPLAY" label — positioned in the top-right corner
+    const label = document.createElement('div');
+    Object.assign(label.style, {
+        position: 'absolute',
+        top: '12%',
+        right: '4%',
+        zIndex: '2011',
+        font: 'bold clamp(10px, 2.5vw, 32px) monospace',
+        color: 'rgba(255, 240, 140, 0.85)',
+        letterSpacing: '0.2em',
+        textShadow: '0 0 6px rgba(0,0,0,0.6)',
+        transition: 'opacity 0.3s ease-in-out',
+        opacity: '0',
+        pointerEvents: 'none',
+        animation: 'replayBlink 1.2s step-end infinite',
+    } as Partial<CSSStyleDeclaration>);
+    label.textContent = '\u25B6 REPLAY';
+    container.appendChild(label);
+
+    // Replay blink + Self-KO bob animations — injected as a <style> element
+    const selfKoStyle = document.createElement('style');
+    selfKoStyle.textContent = `
+        @keyframes replayBlink {
+            0%, 80% { visibility: visible; }
+            80.01%, 100% { visibility: hidden; }
+        }
+        @keyframes selfKoBob {
+            0%, 100% { transform: translateY(0); }
+            50% { transform: translateY(-${SELF_KO_BOB_DISTANCE}px); }
+        }
+    `;
+    container.appendChild(selfKoStyle);
+
+    // Self-KO text — displayed when no collision hit occurred
+    const selfKoText = document.createElement('div');
+    Object.assign(selfKoText.style, {
+        position: 'absolute',
+        top: '12%',
+        left: '4%',
+        zIndex: '2012',
+        font: 'bold clamp(16px, 4vw, 32px) monospace',
+        color: 'rgba(255, 200, 100, 0.9)',
+        textShadow: '0 0 10px rgba(0,0,0,0.7)',
+        transition: 'opacity 0.3s ease-in-out',
+        opacity: '0',
+        pointerEvents: 'none',
+        whiteSpace: 'nowrap',
+    } as Partial<CSSStyleDeclaration>);
+    container.appendChild(selfKoText);
+
+    // Transition state
+    let wasReplay = false;
+    let flashTimer = 0;
+    let selfKoMessagePicked = false;
+
+    useFrameUpdate((dt) => {
+        const isReplay = gameState.phase === 'replay' && isReplayActive(replay);
+
+        // Detect transition into replay — trigger dark flash
+        if (isReplay && !wasReplay) {
+            flashTimer = TRANSITION_FLASH_DURATION;
+        }
+        // Detect transition out of replay — trigger exit flash
+        if (!isReplay && wasReplay) {
+            flashTimer = TRANSITION_FLASH_DURATION * 0.6;
+        }
+        wasReplay = isReplay;
+
+        // Animate flash overlay
+        if (flashTimer > 0) {
+            flashTimer -= dt;
+            const t = Math.max(flashTimer, 0) / TRANSITION_FLASH_DURATION;
+            flash.style.opacity = String(t);
+        } else {
+            flash.style.opacity = '0';
+        }
+
+        // Letterbox and label
+        topBar.style.opacity = isReplay ? '1' : '0';
+        bottomBar.style.opacity = isReplay ? '1' : '0';
+        label.style.opacity = isReplay ? '1' : '0';
+
+        // Self-KO text — per-letter bobbing animation
+        if (isReplay) {
+            if (!hasReplayHit(replay)) {
+                if (!selfKoMessagePicked) {
+                    const msg =
+                        SELF_KO_MESSAGES[
+                            Math.floor(Math.random() * SELF_KO_MESSAGES.length)
+                        ];
+                    selfKoText.innerHTML = '';
+                    for (let i = 0; i < msg.length; i++) {
+                        const span = document.createElement('span');
+                        span.textContent = msg[i] === ' ' ? '\u00A0' : msg[i];
+                        span.style.display = 'inline-block';
+                        span.style.animation = `selfKoBob ${SELF_KO_BOB_PERIOD}s ease-in-out infinite`;
+                        span.style.animationDelay = `${i * SELF_KO_BOB_STAGGER}s`;
+                        selfKoText.appendChild(span);
+                    }
+                    selfKoMessagePicked = true;
+                }
+                selfKoText.style.opacity = '1';
+            } else {
+                selfKoText.style.opacity = '0';
+            }
+        } else {
+            selfKoText.style.opacity = '0';
+            selfKoMessagePicked = false;
+        }
+    });
+
+    useDestroy(() => {
+        flash.remove();
+        topBar.remove();
+        bottomBar.remove();
+        label.remove();
+        selfKoText.remove();
+        selfKoStyle.remove();
+    });
+}


### PR DESCRIPTION
## Description

Split ReplayNode DOM overlay (letterbox, flash, label, self-KO text) into ReplayOverlayNode. ReplayNode keeps playback + VFX logic (particle bursts, trail emission, camera shake, sounds).

Also fixed tests to use `vi.mock` instead of `jest.mock` for vitest compatibility.

## Files Changed

- `demos/arena/src/nodes/ReplayNode.ts` (refactored — removed DOM concerns, kept playback + VFX)
- `demos/arena/src/nodes/ReplayOverlayNode.ts` (new — DOM overlay concerns)
- `demos/arena/src/nodes/ReplayNode.test.ts` (updated — fixed vitest compat, scoped to ReplayNode)
- `demos/arena/src/nodes/ReplayOverlayNode.test.ts` (new — tests for overlay constants)
- `demos/arena/src/nodes/ArenaNode.ts` (mounts both ReplayNode and ReplayOverlayNode)

Part of EPIC-026: Arena Demo Refactoring & Cleanup