### PR TITLE
TICKET-151: Consolidate menu button hover logic

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-151-consolidate-menu-button-hover.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-151-consolidate-menu-button-hover.md
@@ -1,7 +1,7 @@
 ---
 id: TICKET-151
 title: Consolidate menu button hover logic
-status: in-progress
+status: done
 epic: EPIC-026
 created: 2026-03-14
 updated: 2026-03-14
@@ -27,3 +27,4 @@ Consolidate button styling into the `Button` component's accent behavior or a sh
 ## Notes
 
 - **2026-03-14**: Starting implementation
+- **2026-03-14**: Implementation complete

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-151-consolidate-menu-button-hover.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-151-consolidate-menu-button-hover.md
@@ -1,9 +1,11 @@
 ---
 id: TICKET-151
 title: Consolidate menu button hover logic
-status: todo
+status: in-progress
 epic: EPIC-026
 created: 2026-03-14
+updated: 2026-03-14
+branch: ticket-151-consolidate-menu-button-hover
 priority: low
 ---
 
@@ -21,3 +23,7 @@ Consolidate button styling into the `Button` component's accent behavior or a sh
 
 - `demos/arena/src/menu.tsx`
 - `demos/arena/src/overlayAnimations.ts`
+
+## Notes
+
+- **2026-03-14**: Starting implementation

--- a/demos/arena/src/menu.tsx
+++ b/demos/arena/src/menu.tsx
@@ -94,7 +94,6 @@ export function showMainMenu(container: HTMLElement): Promise<MenuChoice> {
         const subtitle = overlay.children[1] as HTMLElement;
         const buttonRow = overlay.children[2] as HTMLElement;
 
-        // Create buttons using native DOM for event handling
         function createMenuButton(
             label: string,
             color: string,
@@ -109,41 +108,12 @@ export function showMainMenu(container: HTMLElement): Promise<MenuChoice> {
                         padding: '12px 32px',
                         minWidth: 'min(200px, 70vw)',
                         minHeight: '44px',
-                        background:
-                            'linear-gradient(180deg, rgba(255,255,255,0.12), rgba(255,255,255,0.04))',
                     }}
                 >
                     {label}
                 </Button>,
             );
-            const btn = btnRoot as HTMLButtonElement;
-
-            // Override hover effects for gradient buttons
-            const defaultBg =
-                'linear-gradient(180deg, rgba(255,255,255,0.12), rgba(255,255,255,0.04))';
-            const defaultBorder = 'rgba(255,255,255,0.2)';
-            btn.addEventListener('pointerenter', () => {
-                btn.style.borderColor = color;
-                btn.style.boxShadow = `0 0 15px ${color}44, inset 0 0 8px ${color}22`;
-            });
-            btn.addEventListener('pointerdown', () => {
-                btn.style.background =
-                    'linear-gradient(180deg, rgba(255,255,255,0.18), rgba(255,255,255,0.08))';
-                btn.style.borderColor = color;
-                btn.style.boxShadow = `0 0 20px ${color}66, inset 0 0 12px ${color}33`;
-            });
-            btn.addEventListener('pointerup', () => {
-                btn.style.background = defaultBg;
-                btn.style.borderColor = color;
-                btn.style.boxShadow = `0 0 15px ${color}44, inset 0 0 8px ${color}22`;
-            });
-            btn.addEventListener('pointerleave', () => {
-                btn.style.background = defaultBg;
-                btn.style.borderColor = defaultBorder;
-                btn.style.boxShadow = 'none';
-            });
-
-            return btn;
+            return btnRoot as HTMLButtonElement;
         }
 
         const btnSolo = createMenuButton('Solo Play', '#f1c40f');


### PR DESCRIPTION
## Description

Consolidate menu button hover/press styling to use the shared Button component pattern from @pulse-ts/dom, eliminating manual pointer event handlers.

The `createMenuButton` function in `menu.tsx` had 4 manual pointer event handlers (`pointerenter`, `pointerdown`, `pointerup`, `pointerleave`) that duplicated hover/press feedback already built into the `Button` component. These handlers managed border color, box-shadow, and background gradient changes.

The Button component already provides:
- Background color change on hover (via `accent` prop)
- Scale transform on press (`mousedown`/`mouseup`)

Combined with `applyButtonHoverScale` (which was already being applied), the menu buttons now use the same pattern as the lobby's `createBtn`.

## Files Changed

- `demos/arena/src/menu.tsx` — Removed 30 lines of manual pointer event handlers from `createMenuButton`

Part of EPIC-026: Arena Demo Refactoring & Cleanup