### PR TITLE
TICKET-141: Split PlatformNode into focused concerns

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-141-split-platform-node.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-141-split-platform-node.md
@@ -1,7 +1,7 @@
 ---
 id: TICKET-141
 title: Split PlatformNode into focused concerns
-status: in-progress
+status: done
 epic: EPIC-026
 created: 2026-03-14
 updated: 2026-03-14
@@ -34,3 +34,4 @@ Extract into focused modules:
 - `demos/arena/src/nodes/PlatformNode.ts`
 
 - **2026-03-14**: Starting implementation
+- **2026-03-14**: Implementation complete

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-141-split-platform-node.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-141-split-platform-node.md
@@ -1,10 +1,12 @@
 ---
 id: TICKET-141
 title: Split PlatformNode into focused concerns
-status: todo
+status: in-progress
 epic: EPIC-026
 created: 2026-03-14
+updated: 2026-03-14
 priority: high
+branch: ticket-141-split-platform-node
 ---
 
 ## Problem
@@ -30,3 +32,5 @@ Extract into focused modules:
 ## Files
 
 - `demos/arena/src/nodes/PlatformNode.ts`
+
+- **2026-03-14**: Starting implementation

--- a/demos/arena/src/nodes/PlatformNode.ts
+++ b/demos/arena/src/nodes/PlatformNode.ts
@@ -4,8 +4,6 @@ import {
     useMesh,
     useCustomMesh,
     useThreeContext,
-    createTexture,
-    createTexture1D,
 } from '@pulse-ts/three';
 import { useAnimate } from '@pulse-ts/effects';
 import * as THREE from 'three';
@@ -13,11 +11,60 @@ import { ARENA_RADIUS } from '../config/arena';
 import { isMobile } from '@pulse-ts/platform';
 import {
     useHitImpactPool,
-    HIT_RIPPLE_DISPLACEMENT,
     HIT_RIPPLE_MAX_RADIUS,
     HIT_RIPPLE_EXPAND_DURATION,
-    HIT_RIPPLE_RING_WIDTH,
 } from '../hitImpact';
+import {
+    createGridNormalMap,
+    createGridEmissiveMap,
+    createEnergyLineMap,
+    createRingGlowMap,
+    createWakeMap,
+    GRID_MAP_SIZE,
+    GRID_SPACING,
+    GRID_LINE_WIDTH,
+} from './platform/textures';
+import {
+    rasterizeWake,
+    worldToUV,
+    WAKE_MAP_SIZE,
+    WAKE_MAP_SIZE_MOBILE,
+    WAKE_RADIUS,
+    WAKE_MIN_DISTANCE,
+    WAKE_TRAIL_INTERVAL,
+    WAKE_TRAIL_DECAY,
+    WAKE_MAX_TRAIL,
+} from './platform/wake';
+import type { WakeTrailPoint } from './platform/wake';
+import {
+    createPlatformShaderUniforms,
+    RIPPLE_INTENSITY,
+} from './platform/shaderPatch';
+import { applyPlatformShaderPatch } from './platform/shaderPatch';
+
+// Re-export all public symbols so existing imports from './PlatformNode' continue to work
+export {
+    createGridNormalMap,
+    createGridEmissiveMap,
+    createEnergyLineMap,
+    createRingGlowMap,
+    createWakeMap,
+} from './platform/textures';
+export {
+    rasterizeWake,
+    worldToUV,
+    WAKE_MAP_SIZE,
+    WAKE_MAP_SIZE_MOBILE,
+    WAKE_DISPLACEMENT,
+    WAKE_MIN_DISTANCE,
+    WAKE_RADIUS,
+    WAKE_THIN_START,
+    WAKE_TRAIL_INTERVAL,
+    WAKE_TRAIL_DECAY,
+    WAKE_MAX_TRAIL,
+} from './platform/wake';
+export type { WakeTrailPoint } from './platform/wake';
+export { RIPPLE_INTENSITY } from './platform/shaderPatch';
 
 /** Radius of the arena cylinder (sourced from arena config). */
 export const PLATFORM_RADIUS = ARENA_RADIUS;
@@ -31,24 +78,6 @@ const PLATFORM_COLOR = 0x0a0c1a;
 /** Color of the emissive edge ring. */
 const RING_COLOR = 0x00ccff;
 
-/** Size (width and height) of generated grid textures in pixels. */
-const GRID_MAP_SIZE = 512;
-
-/** Spacing between grid lines in pixels. */
-const GRID_SPACING = 64;
-
-/** Width of emissive grid lines in pixels. */
-const GRID_LINE_WIDTH = 1;
-
-/** Size of the energy line map in pixels. */
-const ENERGY_MAP_SIZE = 512;
-
-/** Number of radial spokes in the energy line map. */
-const ENERGY_SPOKE_COUNT = 12;
-
-/** Size of the ring glow texture in pixels. */
-const RING_GLOW_MAP_SIZE = 256;
-
 /** Clockwise rotation speed of the ring glow (revolutions per second). */
 const RING_GLOW_SPEED = 0.15;
 
@@ -60,380 +89,6 @@ export const RIPPLE_INTERVAL = 4;
 
 /** How long each ripple takes to expand from center to edge (seconds). */
 export const RIPPLE_DURATION = 2.5;
-
-/** Peak emissive boost multiplier for the ripple (applied on top of base). */
-export const RIPPLE_INTENSITY = 5;
-
-/** Resolution of the CPU-rasterized wake influence map (desktop). */
-export const WAKE_MAP_SIZE = 64;
-
-/** Resolution of the wake influence map on mobile (reduced for CPU savings). */
-export const WAKE_MAP_SIZE_MOBILE = 32;
-
-/** Maximum UV displacement applied by the wake effect (UV units). */
-export const WAKE_DISPLACEMENT = 0.06;
-
-/** Minimum world-space distance between trail samples to register a wake point. */
-export const WAKE_MIN_DISTANCE = 0.05;
-
-/** World-space radius of each wake splat at full expansion (units). */
-export const WAKE_RADIUS = 4;
-
-/** Fraction of WAKE_RADIUS used for fresh trail points (0..1). Grows to 1.0 as strength decays. */
-export const WAKE_THIN_START = 0.25;
-
-/** Seconds between trail point samples for the wake effect. */
-export const WAKE_TRAIL_INTERVAL = 0.05;
-
-/** Strength decay rate per second for trail points. */
-export const WAKE_TRAIL_DECAY = 1.2;
-
-/** Maximum number of trail points stored for the wake effect. */
-export const WAKE_MAX_TRAIL = 80;
-
-/**
- * Generate a procedural grid normal map as a `DataTexture`.
- * Lines at regular intervals perturb the normal slightly,
- * giving the flat surface a subtle tiled look under lighting.
- *
- * @param size - Texture width and height in pixels.
- * @param spacing - Pixel spacing between grid lines.
- * @returns A `THREE.DataTexture` encoded as an RGBA normal map.
- *
- * @example
- * ```ts
- * const tex = createGridNormalMap(256, 32);
- * material.normalMap = tex;
- * ```
- */
-export function createGridNormalMap(
-    size: number = GRID_MAP_SIZE,
-    spacing: number = GRID_SPACING,
-): THREE.DataTexture {
-    return createTexture(
-        size,
-        (x, y) => {
-            let nx = 128;
-            let ny = 128;
-            if (x % spacing === 0) nx = 96;
-            if (y % spacing === 0) ny = 96;
-            return [nx, ny, 255, 255];
-        },
-        { wrap: 'repeat', filter: 'linear' },
-    );
-}
-
-/**
- * Generate a grid emissive map — thin bright lines on a dark background.
- * Applied as the platform surface `emissiveMap` so the grid is
- * self-illuminated and visible from any camera angle.
- *
- * @param size - Texture width and height in pixels.
- * @param spacing - Pixel spacing between grid lines.
- * @param lineWidth - Width of each grid line in pixels.
- * @param radialFade - When true, lines fade from dark at center to bright at edge.
- * @returns A `THREE.DataTexture` with cyan grid lines on black.
- *
- * @example
- * ```ts
- * const tex = createGridEmissiveMap(256, 32, 2);
- * material.emissiveMap = tex;
- * ```
- */
-export function createGridEmissiveMap(
-    size: number = GRID_MAP_SIZE,
-    spacing: number = GRID_SPACING,
-    lineWidth: number = GRID_LINE_WIDTH,
-    radialFade: boolean = false,
-): THREE.DataTexture {
-    const half = Math.floor(lineWidth / 2);
-    const center = size / 2;
-
-    return createTexture(
-        size,
-        (x, y) => {
-            const onVertical =
-                x % spacing <= half || x % spacing >= spacing - half;
-            const onHorizontal =
-                y % spacing <= half || y % spacing >= spacing - half;
-
-            if (onVertical || onHorizontal) {
-                let fade = 1;
-                if (radialFade) {
-                    const dx = (x - center) / center;
-                    const dy = (y - center) / center;
-                    fade = Math.min(1, Math.sqrt(dx * dx + dy * dy));
-                }
-                return [
-                    Math.floor(50 * fade),
-                    Math.floor(180 * fade),
-                    Math.floor(220 * fade),
-                    255,
-                ];
-            }
-            return [0, 0, 0, 255];
-        },
-        { wrap: 'repeat', filter: 'linear' },
-    );
-}
-
-/**
- * Generate a procedural radial-spoke energy line map as a `DataTexture`.
- * Used as an emissive map on a transparent overlay to create flowing
- * energy lines across the platform surface.
- *
- * @param size - Texture width and height in pixels.
- * @param spokeCount - Number of radial spokes.
- * @returns A `THREE.DataTexture` with cyan energy lines on black.
- *
- * @example
- * ```ts
- * const tex = createEnergyLineMap(256, 12);
- * material.emissiveMap = tex;
- * ```
- */
-export function createEnergyLineMap(
-    size: number = ENERGY_MAP_SIZE,
-    spokeCount: number = ENERGY_SPOKE_COUNT,
-): THREE.DataTexture {
-    const center = size / 2;
-
-    return createTexture(
-        size,
-        (px, py) => {
-            const dx = px - center;
-            const dy = py - center;
-            const dist = Math.sqrt(dx * dx + dy * dy) / center;
-
-            const angle = Math.atan2(dy, dx);
-            const spokePhase = Math.abs(Math.sin(angle * spokeCount * 0.5));
-
-            const spokeEdge = Math.max(0, (spokePhase - 0.9) / 0.1);
-            const radialFade = Math.min(1, dist);
-            const intensity = spokeEdge * spokeEdge * radialFade * 0.8;
-
-            return [
-                Math.floor(intensity * 128),
-                Math.floor(intensity * 220),
-                Math.floor(intensity * 255),
-                255,
-            ];
-        },
-        { wrap: 'repeat' },
-    );
-}
-
-/**
- * Generate a 1D gradient texture for the ring glow that rotates around the torus.
- * The texture has a smooth bright region (~25% of the ring) that fades
- * to a dim base, creating a traveling highlight when UV-scrolled.
- *
- * @param size - Texture width in pixels (height is 1).
- * @returns A `THREE.DataTexture` with a smooth falloff gradient.
- *
- * @example
- * ```ts
- * const tex = createRingGlowMap(256);
- * ringMaterial.emissiveMap = tex;
- * ```
- */
-export function createRingGlowMap(
-    size: number = RING_GLOW_MAP_SIZE,
-): THREE.DataTexture {
-    return createTexture1D(
-        size,
-        (x, width) => {
-            const t = x / width;
-            const dist = Math.min(t, 1 - t) * 2;
-            const glow = Math.pow(Math.max(0, 1 - dist * 3), 2);
-            const base = 0.08;
-            const intensity = base + (1 - base) * glow;
-            const v = Math.floor(intensity * 255);
-            return [v, v, v, 255];
-        },
-        { wrap: 'repeat', filter: 'linear' },
-    );
-}
-
-/**
- * Create a blank single-channel wake influence map as a `DataTexture`.
- * The red channel stores wake intensity; the shader samples it to boost
- * emissive grid lines beneath and behind moving players.
- *
- * @param size - Texture width and height in pixels.
- * @returns A `THREE.DataTexture` initialized to zero with `LinearFilter`.
- *
- * @example
- * ```ts
- * const wake = createWakeMap(64);
- * material.userData.wakeMap = wake;
- * ```
- */
-export function createWakeMap(size: number = WAKE_MAP_SIZE): THREE.DataTexture {
-    return createTexture(size, () => [0, 0, 0, 0], { filter: 'linear' });
-}
-
-/**
- * Trail point used by the wake rasterizer.
- */
-export interface WakeTrailPoint {
-    /** World-space X position. */
-    x: number;
-    /** World-space Z position. */
-    z: number;
-    /** Intensity in 0..1 (1 = fresh, decays toward 0). */
-    strength: number;
-    /** Normalized movement direction X (world space). */
-    dirX: number;
-    /** Normalized movement direction Z (world space). */
-    dirZ: number;
-}
-
-/**
- * Rasterize wake trail displacement into an RGBA `Uint8Array`.
- * Each trail point splats a 2D displacement vector perpendicular to the
- * player's movement direction, creating a boat-wake distortion that pushes
- * grid lines outward from the trail path.
- *
- * Encoding: R = 128 + du*127, G = 128 + dv*127, B = 0, A = 255.
- * 128 = no displacement; signed direction encoded around midpoint.
- *
- * @param data - RGBA pixel buffer (`size * size * 4` bytes). Cleared then filled.
- * @param size - Width and height of the texture in pixels.
- * @param trail - Array of trail points with world-space positions, strength, and direction.
- * @param arenaRadius - World-space radius of the arena (maps to texture extent).
- * @param wakeRadius - World-space radius of each wake splat.
- *
- * @example
- * ```ts
- * rasterizeWake(wakeMap.image.data, 64, trail, ARENA_RADIUS, WAKE_RADIUS);
- * wakeMap.needsUpdate = true;
- * ```
- */
-export function rasterizeWake(
-    data: Uint8Array,
-    size: number,
-    trail: readonly WakeTrailPoint[],
-    arenaRadius: number,
-    wakeRadius: number,
-): void {
-    const texelCount = size * size;
-
-    // Initialize output: R=128, G=128, B=0, A=255 (no displacement)
-    for (let i = 0; i < texelCount; i++) {
-        const idx = i * 4;
-        data[idx] = 128;
-        data[idx + 1] = 128;
-        data[idx + 2] = 0;
-        data[idx + 3] = 255;
-    }
-
-    if (trail.length === 0) return;
-
-    // Float32 scratch buffer for clean accumulation (2 floats per texel: du, dv)
-    const scratch = new Float32Array(texelCount * 2);
-
-    // Precompute base pixel radius
-    const texelsPerUnit = size / (arenaRadius * 2);
-    const maxSplatRadius = wakeRadius * texelsPerUnit;
-
-    for (const pt of trail) {
-        // Wake starts thin (WAKE_THIN_START fraction) and expands as
-        // strength decays toward 0, reaching full radius at end of life.
-        const widthFraction =
-            WAKE_THIN_START + (1 - WAKE_THIN_START) * (1 - pt.strength);
-        const splatRadius = maxSplatRadius * widthFraction;
-        const splatRadiusSq = splatRadius * splatRadius;
-
-        // World to texel: center of arena = (size/2, size/2).
-        // Three.js CylinderGeometry cap UVs: u = (z/R+1)*0.5, v = (x/R+1)*0.5
-        // so texel column (cx) maps from world Z, texel row (cy) from world X.
-        const cx = (pt.z / arenaRadius + 1) * 0.5 * size;
-        const cy = (pt.x / arenaRadius + 1) * 0.5 * size;
-
-        // Movement direction mapped to texel space:
-        // texel X proportional to world Z, texel Y proportional to world X
-        const movTexX = pt.dirZ;
-        const movTexY = pt.dirX;
-
-        // Perpendicular to movement in texel space
-        const perpTexX = -movTexY;
-        const perpTexY = movTexX;
-
-        const minX = Math.max(0, Math.floor(cx - splatRadius));
-        const maxX = Math.min(size - 1, Math.ceil(cx + splatRadius));
-        const minY = Math.max(0, Math.floor(cy - splatRadius));
-        const maxY = Math.min(size - 1, Math.ceil(cy + splatRadius));
-
-        for (let py = minY; py <= maxY; py++) {
-            for (let px = minX; px <= maxX; px++) {
-                const dx = px - cx;
-                const dy = py - cy;
-                const distSq = dx * dx + dy * dy;
-                if (distSq >= splatRadiusSq) continue;
-
-                const dist = Math.sqrt(distSq);
-                if (dist < 0.001) continue;
-
-                // Smoothstep radial falloff: 1 at center, 0 at edge
-                const t = dist / splatRadius;
-                const radialFalloff = 1 - t * t * (3 - 2 * t);
-
-                // Signed perpendicular distance from the trail line.
-                // Positive = one side, negative = other side.
-                // Normalized by splatRadius so the factor stays in [-1, 1].
-                const perpDot = dx * perpTexX + dy * perpTexY;
-                const perpFactor = perpDot / splatRadius;
-
-                // Displacement is perpendicular to movement, scaled by
-                // how far off the trail line this texel is (perpFactor)
-                // and the radial falloff. Zero ON the trail line, peaks
-                // to the sides, then falls off at the splat edge.
-                const mag = perpFactor * radialFalloff * pt.strength;
-                const si = (py * size + px) * 2;
-                scratch[si] += perpTexX * mag;
-                scratch[si + 1] += perpTexY * mag;
-            }
-        }
-    }
-
-    // Encode accumulated displacement to RGBA uint8
-    for (let i = 0; i < texelCount; i++) {
-        const si = i * 2;
-        const du = scratch[si];
-        const dv = scratch[si + 1];
-        const idx = i * 4;
-        data[idx] = Math.min(255, Math.max(0, Math.round(128 + du * 127)));
-        data[idx + 1] = Math.min(255, Math.max(0, Math.round(128 + dv * 127)));
-    }
-}
-
-/**
- * Convert a world-space XZ position to UV coordinates matching
- * Three.js CylinderGeometry's top-cap UV layout.
- *
- * UV mapping: `u = (z / R + 1) * 0.5`, `v = (x / R + 1) * 0.5`.
- *
- * @param worldX - World-space X coordinate.
- * @param worldZ - World-space Z coordinate.
- * @param arenaRadius - Radius of the arena cylinder.
- * @returns `[u, v]` in 0–1 UV space.
- *
- * @example
- * ```ts
- * worldToUV(0, 0, 10); // [0.5, 0.5] — center
- * worldToUV(10, 0, 10); // [0.5, 1.0] — edge
- * ```
- */
-export function worldToUV(
-    worldX: number,
-    worldZ: number,
-    arenaRadius: number,
-): [number, number] {
-    const u = (worldZ / arenaRadius + 1) * 0.5;
-    const v = (worldX / arenaRadius + 1) * 0.5;
-    return [u, v];
-}
 
 /**
  * Circular arena platform — a flat cylinder with a glowing grid surface,
@@ -464,7 +119,6 @@ export function PlatformNode() {
     );
 
     // Visual — cylinder mesh for the platform surface (opaque dark base)
-    // with texture maps passed directly via useMesh extensions
     const { material: platformMat } = useMesh('cylinder', {
         radius: PLATFORM_RADIUS,
         height: PLATFORM_HEIGHT,
@@ -572,104 +226,12 @@ export function PlatformNode() {
     const lastPlayerPositions: Array<{ x: number; z: number }> = [];
     let wakeFrameSkip = 0;
 
-    // --- Ripple + wake shader patch (radial emissive boost on grid lines) ---
-    // Patches the platform fragment shader to add ripple and wake multipliers.
-    // Up to RIPPLE_COUNT concurrent ripples tracked via a vec4 uniform
-    // where each component is a normalized radius (0=center, 1=edge, -1=inactive).
-    // The wake map samples a DataTexture to boost grid lines beneath/behind players.
-    const rippleRadii = new THREE.Vector4(-1, -1, -1, -1);
-    const rippleUniforms = {
-        uRippleRadii: { value: rippleRadii },
-        uRippleBoost: { value: RIPPLE_INTENSITY },
-    };
-    const wakeUniforms = {
-        uWakeMap: { value: wakeMap },
-        uWakeDisplacement: { value: WAKE_DISPLACEMENT },
-    };
-
-    // Hit ripple uniforms — expanding displacement rings from hit positions
-    const hitRippleRadii = new THREE.Vector4(-1, -1, -1, -1);
-    const hitRippleCenterX = new THREE.Vector4(0, 0, 0, 0);
-    const hitRippleCenterY = new THREE.Vector4(0, 0, 0, 0);
-    const hitRippleUniforms = {
-        uHitRippleRadii: { value: hitRippleRadii },
-        uHitRippleCenterX: { value: hitRippleCenterX },
-        uHitRippleCenterY: { value: hitRippleCenterY },
-        uHitRippleDisp: { value: HIT_RIPPLE_DISPLACEMENT },
-        uHitRippleWidth: { value: HIT_RIPPLE_RING_WIDTH },
-    };
-
-    platformMat.onBeforeCompile = (shader) => {
-        shader.uniforms.uRippleRadii = rippleUniforms.uRippleRadii;
-        shader.uniforms.uRippleBoost = rippleUniforms.uRippleBoost;
-        shader.uniforms.uWakeMap = wakeUniforms.uWakeMap;
-        shader.uniforms.uWakeDisplacement = wakeUniforms.uWakeDisplacement;
-        shader.uniforms.uHitRippleRadii = hitRippleUniforms.uHitRippleRadii;
-        shader.uniforms.uHitRippleCenterX = hitRippleUniforms.uHitRippleCenterX;
-        shader.uniforms.uHitRippleCenterY = hitRippleUniforms.uHitRippleCenterY;
-        shader.uniforms.uHitRippleDisp = hitRippleUniforms.uHitRippleDisp;
-        shader.uniforms.uHitRippleWidth = hitRippleUniforms.uHitRippleWidth;
-
-        shader.fragmentShader = shader.fragmentShader.replace(
-            '#include <common>',
-            `#include <common>
-            uniform vec4 uRippleRadii;
-            uniform float uRippleBoost;
-            uniform sampler2D uWakeMap;
-            uniform float uWakeDisplacement;
-            uniform vec4 uHitRippleRadii;
-            uniform vec4 uHitRippleCenterX;
-            uniform vec4 uHitRippleCenterY;
-            uniform float uHitRippleDisp;
-            uniform float uHitRippleWidth;`,
-        );
-
-        // Replace the emissivemap_fragment entirely: sample wake displacement,
-        // offset emissive UVs, then sample the emissive map at displaced coords.
-        shader.fragmentShader = shader.fragmentShader.replace(
-            '#include <emissivemap_fragment>',
-            `{
-                // Decode wake displacement from RG channels (128 = zero)
-                vec4 wakeSample = texture2D(uWakeMap, vEmissiveMapUv);
-                vec2 wakeDisp = (wakeSample.rg - 0.5) * 2.0;
-                vec2 displacedUv = vEmissiveMapUv + wakeDisp * uWakeDisplacement;
-
-                // Hit ripple displacement — expanding rings from hit positions
-                for (int i = 0; i < 4; i++) {
-                    float hr = uHitRippleRadii[i];
-                    if (hr < 0.0) continue;
-                    vec2 hitCenter = vec2(uHitRippleCenterX[i], uHitRippleCenterY[i]);
-                    vec2 toFrag = displacedUv - hitCenter;
-                    float fragDist = length(toFrag);
-                    float band = abs(fragDist - hr);
-                    if (band < uHitRippleWidth && fragDist > 0.001) {
-                        float ringFalloff = 1.0 - band / uHitRippleWidth;
-                        // Age fade: hr / maxRadius gives progress; fade out as it expands
-                        float ageFade = 1.0 - smoothstep(0.0, 1.0, hr / ${HIT_RIPPLE_MAX_RADIUS.toFixed(1)});
-                        vec2 dir = toFrag / fragDist;
-                        displacedUv += dir * ringFalloff * ageFade * uHitRippleDisp;
-                    }
-                }
-
-                // Sample emissive map at displaced UVs (replaces standard include)
-                vec4 emissiveColor = texture2D(emissiveMap, displacedUv);
-                totalEmissiveRadiance *= emissiveColor.rgb;
-
-                // Ripple boost on top of displaced grid
-                float uvDist = length(vEmissiveMapUv - vec2(0.5)) * 2.0;
-                float rippleBoost = 0.0;
-                for (int i = 0; i < 4; i++) {
-                    float rr = uRippleRadii[i];
-                    if (rr >= 0.0) {
-                        float bandWidth = min(0.45, rr);
-                        float d = abs(uvDist - rr);
-                        rippleBoost += smoothstep(bandWidth, 0.0, d);
-                    }
-                }
-                totalEmissiveRadiance *= (1.0 + rippleBoost * uRippleBoost);
-            }`,
-        );
-    };
+    // --- Ripple + wake shader patch ---
+    const shaderUniforms = createPlatformShaderUniforms(wakeMap);
+    applyPlatformShaderPatch(
+        platformMat as THREE.MeshStandardMaterial,
+        shaderUniforms,
+    );
 
     const rippleAges: number[] = new Array(RIPPLE_COUNT).fill(-1);
     let rippleTimer = 0;
@@ -694,7 +256,10 @@ export function PlatformNode() {
 
     useFrameUpdate((dt) => {
         // Sync hit ripple uniforms from active pool slots
-        // Reset all ripple slots first
+        const hitRippleRadii = shaderUniforms.uHitRippleRadii.value;
+        const hitRippleCenterX = shaderUniforms.uHitRippleCenterX.value;
+        const hitRippleCenterY = shaderUniforms.uHitRippleCenterY.value;
+
         for (let i = 0; i < 4; i++) {
             hitRippleRadii.setComponent(i, -1);
         }
@@ -708,7 +273,6 @@ export function PlatformNode() {
             );
             hitRippleCenterX.setComponent(hitSlotIdx, u);
             hitRippleCenterY.setComponent(hitSlotIdx, v);
-            // Expanding radius: age / expand_duration, clamped to max
             const progress = Math.min(slot.age / HIT_RIPPLE_EXPAND_DURATION, 1);
             hitRippleRadii.setComponent(
                 hitSlotIdx,
@@ -724,7 +288,6 @@ export function PlatformNode() {
         energyMesh.rotation.y = energySpin.value;
 
         // Rotate ring glow clockwise by scrolling emissiveMap UV offset
-        // Negative offset = clockwise when torus is viewed from above
         const glowOffset = -ringGlowSpin.value;
         ringGlowMap.offset.x = glowOffset;
         glowGlowMap.offset.x = glowOffset;
@@ -737,10 +300,9 @@ export function PlatformNode() {
             nextRipple = (nextRipple + 1) % RIPPLE_COUNT;
         }
 
-        // Update ripple uniforms — each is a normalized radius expanding outward.
-        // Overshoot past 1.0 by the smoothstep band width (0.12) so the ripple
-        // fully fades out at the edge instead of clipping.
+        // Update ripple uniforms
         const RIPPLE_OVERSHOOT = 1.45;
+        const rippleRadii = shaderUniforms.uRippleRadii.value;
         for (let i = 0; i < RIPPLE_COUNT; i++) {
             if (rippleAges[i] < 0) continue;
             rippleAges[i] += dt;
@@ -754,10 +316,8 @@ export function PlatformNode() {
         }
 
         // --- Wake trail tracking ---
-        // Find current player positions via scene traversal
-        // (same pattern as AtmosphericDustNode)
         const currentPlayers: { x: number; z: number }[] = [];
-        scene.traverse((child) => {
+        scene.traverse((child: THREE.Object3D) => {
             if (child.type === 'Group' && child.parent !== scene) {
                 const p = child.position;
                 const xzDistSq = p.x * p.x + p.z * p.z;
@@ -775,8 +335,7 @@ export function PlatformNode() {
             }
         }
 
-        // Sample current player positions into trail at fixed interval.
-        // Only record wake points for players that are actually moving.
+        // Sample current player positions into trail at fixed interval
         wakeTrailTimer += dt;
         if (wakeTrailTimer >= WAKE_TRAIL_INTERVAL) {
             wakeTrailTimer = 0;
@@ -803,12 +362,10 @@ export function PlatformNode() {
                 }
                 lastPlayerPositions[i] = { x: pos.x, z: pos.z };
             }
-            // Trim if players left the scene
             lastPlayerPositions.length = currentPlayers.length;
         }
 
-        // Rasterize wake influence and flag texture for upload.
-        // On mobile, skip every other frame to halve CPU cost.
+        // Rasterize wake influence and flag texture for upload
         const shouldRasterize = !mobile || ++wakeFrameSkip % 2 === 0;
         if (shouldRasterize) {
             const wakeData = wakeMap.image.data as Uint8Array;

--- a/demos/arena/src/nodes/platform/shaderPatch.ts
+++ b/demos/arena/src/nodes/platform/shaderPatch.ts
@@ -1,0 +1,152 @@
+import * as THREE from 'three';
+import {
+    HIT_RIPPLE_DISPLACEMENT,
+    HIT_RIPPLE_MAX_RADIUS,
+    HIT_RIPPLE_RING_WIDTH,
+} from '../../hitImpact';
+import { WAKE_DISPLACEMENT } from './wake';
+
+/** Peak emissive boost multiplier for the ripple (applied on top of base). */
+export const RIPPLE_INTENSITY = 5;
+
+/**
+ * Uniforms required by the platform ripple/wake/hit-ripple shader patch.
+ */
+export interface PlatformShaderUniforms {
+    /** Ripple normalized radii (up to 4 concurrent, -1 = inactive). */
+    uRippleRadii: { value: THREE.Vector4 };
+    /** Peak emissive boost multiplier for the ripple. */
+    uRippleBoost: { value: number };
+    /** CPU-rasterized wake influence DataTexture. */
+    uWakeMap: { value: THREE.DataTexture };
+    /** Maximum UV displacement applied by the wake effect. */
+    uWakeDisplacement: { value: number };
+    /** Hit ripple normalized radii (up to 4 concurrent, -1 = inactive). */
+    uHitRippleRadii: { value: THREE.Vector4 };
+    /** Hit ripple center U coordinates (up to 4). */
+    uHitRippleCenterX: { value: THREE.Vector4 };
+    /** Hit ripple center V coordinates (up to 4). */
+    uHitRippleCenterY: { value: THREE.Vector4 };
+    /** Hit ripple displacement magnitude. */
+    uHitRippleDisp: { value: number };
+    /** Hit ripple ring width. */
+    uHitRippleWidth: { value: number };
+}
+
+/**
+ * Create the full set of uniforms for the platform shader patch.
+ *
+ * @param wakeMap - The CPU-rasterized wake influence DataTexture.
+ * @returns All uniforms needed by {@link applyPlatformShaderPatch}.
+ *
+ * @example
+ * ```ts
+ * const uniforms = createPlatformShaderUniforms(wakeMap);
+ * ```
+ */
+export function createPlatformShaderUniforms(
+    wakeMap: THREE.DataTexture,
+): PlatformShaderUniforms {
+    return {
+        uRippleRadii: { value: new THREE.Vector4(-1, -1, -1, -1) },
+        uRippleBoost: { value: RIPPLE_INTENSITY },
+        uWakeMap: { value: wakeMap },
+        uWakeDisplacement: { value: WAKE_DISPLACEMENT },
+        uHitRippleRadii: { value: new THREE.Vector4(-1, -1, -1, -1) },
+        uHitRippleCenterX: { value: new THREE.Vector4(0, 0, 0, 0) },
+        uHitRippleCenterY: { value: new THREE.Vector4(0, 0, 0, 0) },
+        uHitRippleDisp: { value: HIT_RIPPLE_DISPLACEMENT },
+        uHitRippleWidth: { value: HIT_RIPPLE_RING_WIDTH },
+    };
+}
+
+/**
+ * Apply the ripple/wake/hit-ripple shader patch to a platform material.
+ * Patches `onBeforeCompile` to inject custom uniforms and fragment shader
+ * code that adds wake displacement, hit ripple rings, and emissive ripple boosts.
+ *
+ * @param material - The platform `MeshStandardMaterial` to patch.
+ * @param uniforms - Uniforms created by {@link createPlatformShaderUniforms}.
+ *
+ * @example
+ * ```ts
+ * const uniforms = createPlatformShaderUniforms(wakeMap);
+ * applyPlatformShaderPatch(platformMat, uniforms);
+ * ```
+ */
+export function applyPlatformShaderPatch(
+    material: THREE.MeshStandardMaterial,
+    uniforms: PlatformShaderUniforms,
+): void {
+    material.onBeforeCompile = (shader) => {
+        shader.uniforms.uRippleRadii = uniforms.uRippleRadii;
+        shader.uniforms.uRippleBoost = uniforms.uRippleBoost;
+        shader.uniforms.uWakeMap = uniforms.uWakeMap;
+        shader.uniforms.uWakeDisplacement = uniforms.uWakeDisplacement;
+        shader.uniforms.uHitRippleRadii = uniforms.uHitRippleRadii;
+        shader.uniforms.uHitRippleCenterX = uniforms.uHitRippleCenterX;
+        shader.uniforms.uHitRippleCenterY = uniforms.uHitRippleCenterY;
+        shader.uniforms.uHitRippleDisp = uniforms.uHitRippleDisp;
+        shader.uniforms.uHitRippleWidth = uniforms.uHitRippleWidth;
+
+        shader.fragmentShader = shader.fragmentShader.replace(
+            '#include <common>',
+            `#include <common>
+            uniform vec4 uRippleRadii;
+            uniform float uRippleBoost;
+            uniform sampler2D uWakeMap;
+            uniform float uWakeDisplacement;
+            uniform vec4 uHitRippleRadii;
+            uniform vec4 uHitRippleCenterX;
+            uniform vec4 uHitRippleCenterY;
+            uniform float uHitRippleDisp;
+            uniform float uHitRippleWidth;`,
+        );
+
+        // Replace the emissivemap_fragment entirely: sample wake displacement,
+        // offset emissive UVs, then sample the emissive map at displaced coords.
+        shader.fragmentShader = shader.fragmentShader.replace(
+            '#include <emissivemap_fragment>',
+            `{
+                // Decode wake displacement from RG channels (128 = zero)
+                vec4 wakeSample = texture2D(uWakeMap, vEmissiveMapUv);
+                vec2 wakeDisp = (wakeSample.rg - 0.5) * 2.0;
+                vec2 displacedUv = vEmissiveMapUv + wakeDisp * uWakeDisplacement;
+
+                // Hit ripple displacement — expanding rings from hit positions
+                for (int i = 0; i < 4; i++) {
+                    float hr = uHitRippleRadii[i];
+                    if (hr < 0.0) continue;
+                    vec2 hitCenter = vec2(uHitRippleCenterX[i], uHitRippleCenterY[i]);
+                    vec2 toFrag = displacedUv - hitCenter;
+                    float fragDist = length(toFrag);
+                    float band = abs(fragDist - hr);
+                    if (band < uHitRippleWidth && fragDist > 0.001) {
+                        float ringFalloff = 1.0 - band / uHitRippleWidth;
+                        // Age fade: hr / maxRadius gives progress; fade out as it expands
+                        float ageFade = 1.0 - smoothstep(0.0, 1.0, hr / ${HIT_RIPPLE_MAX_RADIUS.toFixed(1)});
+                        vec2 dir = toFrag / fragDist;
+                        displacedUv += dir * ringFalloff * ageFade * uHitRippleDisp;
+                    }
+                }
+
+                // Sample emissive map at displaced UVs (replaces standard include)
+                vec4 emissiveColor = texture2D(emissiveMap, displacedUv);
+                totalEmissiveRadiance *= emissiveColor.rgb;
+
+                // Ripple boost on top of displaced grid
+                float uvDist = length(vEmissiveMapUv - vec2(0.5)) * 2.0;
+                float rippleBoost = 0.0;
+                for (int i = 0; i < 4; i++) {
+                    float rr = uRippleRadii[i];
+                    if (rr >= 0.0) {
+                        float bandWidth = min(0.45, rr);
+                        float d = abs(uvDist - rr);
+                        rippleBoost += smoothstep(bandWidth, 0.0, d);
+                    }
+                }
+                totalEmissiveRadiance *= (1.0 + rippleBoost * uRippleBoost);
+            }`,
+        );
+    };
+}

--- a/demos/arena/src/nodes/platform/textures.ts
+++ b/demos/arena/src/nodes/platform/textures.ts
@@ -1,0 +1,202 @@
+import * as THREE from 'three';
+import { createTexture, createTexture1D } from '@pulse-ts/three';
+
+/** Size (width and height) of generated grid textures in pixels. */
+export const GRID_MAP_SIZE = 512;
+
+/** Spacing between grid lines in pixels. */
+export const GRID_SPACING = 64;
+
+/** Width of emissive grid lines in pixels. */
+export const GRID_LINE_WIDTH = 1;
+
+/** Size of the energy line map in pixels. */
+export const ENERGY_MAP_SIZE = 512;
+
+/** Number of radial spokes in the energy line map. */
+export const ENERGY_SPOKE_COUNT = 12;
+
+/** Size of the ring glow texture in pixels. */
+export const RING_GLOW_MAP_SIZE = 256;
+
+/**
+ * Generate a procedural grid normal map as a `DataTexture`.
+ * Lines at regular intervals perturb the normal slightly,
+ * giving the flat surface a subtle tiled look under lighting.
+ *
+ * @param size - Texture width and height in pixels.
+ * @param spacing - Pixel spacing between grid lines.
+ * @returns A `THREE.DataTexture` encoded as an RGBA normal map.
+ *
+ * @example
+ * ```ts
+ * const tex = createGridNormalMap(256, 32);
+ * material.normalMap = tex;
+ * ```
+ */
+export function createGridNormalMap(
+    size: number = GRID_MAP_SIZE,
+    spacing: number = GRID_SPACING,
+): THREE.DataTexture {
+    return createTexture(
+        size,
+        (x, y) => {
+            let nx = 128;
+            let ny = 128;
+            if (x % spacing === 0) nx = 96;
+            if (y % spacing === 0) ny = 96;
+            return [nx, ny, 255, 255];
+        },
+        { wrap: 'repeat', filter: 'linear' },
+    );
+}
+
+/**
+ * Generate a grid emissive map — thin bright lines on a dark background.
+ * Applied as the platform surface `emissiveMap` so the grid is
+ * self-illuminated and visible from any camera angle.
+ *
+ * @param size - Texture width and height in pixels.
+ * @param spacing - Pixel spacing between grid lines.
+ * @param lineWidth - Width of each grid line in pixels.
+ * @param radialFade - When true, lines fade from dark at center to bright at edge.
+ * @returns A `THREE.DataTexture` with cyan grid lines on black.
+ *
+ * @example
+ * ```ts
+ * const tex = createGridEmissiveMap(256, 32, 2);
+ * material.emissiveMap = tex;
+ * ```
+ */
+export function createGridEmissiveMap(
+    size: number = GRID_MAP_SIZE,
+    spacing: number = GRID_SPACING,
+    lineWidth: number = GRID_LINE_WIDTH,
+    radialFade: boolean = false,
+): THREE.DataTexture {
+    const half = Math.floor(lineWidth / 2);
+    const center = size / 2;
+
+    return createTexture(
+        size,
+        (x, y) => {
+            const onVertical =
+                x % spacing <= half || x % spacing >= spacing - half;
+            const onHorizontal =
+                y % spacing <= half || y % spacing >= spacing - half;
+
+            if (onVertical || onHorizontal) {
+                let fade = 1;
+                if (radialFade) {
+                    const dx = (x - center) / center;
+                    const dy = (y - center) / center;
+                    fade = Math.min(1, Math.sqrt(dx * dx + dy * dy));
+                }
+                return [
+                    Math.floor(50 * fade),
+                    Math.floor(180 * fade),
+                    Math.floor(220 * fade),
+                    255,
+                ];
+            }
+            return [0, 0, 0, 255];
+        },
+        { wrap: 'repeat', filter: 'linear' },
+    );
+}
+
+/**
+ * Generate a procedural radial-spoke energy line map as a `DataTexture`.
+ * Used as an emissive map on a transparent overlay to create flowing
+ * energy lines across the platform surface.
+ *
+ * @param size - Texture width and height in pixels.
+ * @param spokeCount - Number of radial spokes.
+ * @returns A `THREE.DataTexture` with cyan energy lines on black.
+ *
+ * @example
+ * ```ts
+ * const tex = createEnergyLineMap(256, 12);
+ * material.emissiveMap = tex;
+ * ```
+ */
+export function createEnergyLineMap(
+    size: number = ENERGY_MAP_SIZE,
+    spokeCount: number = ENERGY_SPOKE_COUNT,
+): THREE.DataTexture {
+    const center = size / 2;
+
+    return createTexture(
+        size,
+        (px, py) => {
+            const dx = px - center;
+            const dy = py - center;
+            const dist = Math.sqrt(dx * dx + dy * dy) / center;
+
+            const angle = Math.atan2(dy, dx);
+            const spokePhase = Math.abs(Math.sin(angle * spokeCount * 0.5));
+
+            const spokeEdge = Math.max(0, (spokePhase - 0.9) / 0.1);
+            const radialFade = Math.min(1, dist);
+            const intensity = spokeEdge * spokeEdge * radialFade * 0.8;
+
+            return [
+                Math.floor(intensity * 128),
+                Math.floor(intensity * 220),
+                Math.floor(intensity * 255),
+                255,
+            ];
+        },
+        { wrap: 'repeat' },
+    );
+}
+
+/**
+ * Generate a 1D gradient texture for the ring glow that rotates around the torus.
+ * The texture has a smooth bright region (~25% of the ring) that fades
+ * to a dim base, creating a traveling highlight when UV-scrolled.
+ *
+ * @param size - Texture width in pixels (height is 1).
+ * @returns A `THREE.DataTexture` with a smooth falloff gradient.
+ *
+ * @example
+ * ```ts
+ * const tex = createRingGlowMap(256);
+ * ringMaterial.emissiveMap = tex;
+ * ```
+ */
+export function createRingGlowMap(
+    size: number = RING_GLOW_MAP_SIZE,
+): THREE.DataTexture {
+    return createTexture1D(
+        size,
+        (x, width) => {
+            const t = x / width;
+            const dist = Math.min(t, 1 - t) * 2;
+            const glow = Math.pow(Math.max(0, 1 - dist * 3), 2);
+            const base = 0.08;
+            const intensity = base + (1 - base) * glow;
+            const v = Math.floor(intensity * 255);
+            return [v, v, v, 255];
+        },
+        { wrap: 'repeat', filter: 'linear' },
+    );
+}
+
+/**
+ * Create a blank single-channel wake influence map as a `DataTexture`.
+ * The red channel stores wake intensity; the shader samples it to boost
+ * emissive grid lines beneath and behind moving players.
+ *
+ * @param size - Texture width and height in pixels.
+ * @returns A `THREE.DataTexture` initialized to zero with `LinearFilter`.
+ *
+ * @example
+ * ```ts
+ * const wake = createWakeMap(64);
+ * material.userData.wakeMap = wake;
+ * ```
+ */
+export function createWakeMap(size: number): THREE.DataTexture {
+    return createTexture(size, () => [0, 0, 0, 0], { filter: 'linear' });
+}

--- a/demos/arena/src/nodes/platform/wake.ts
+++ b/demos/arena/src/nodes/platform/wake.ts
@@ -1,0 +1,188 @@
+/** Resolution of the CPU-rasterized wake influence map (desktop). */
+export const WAKE_MAP_SIZE = 64;
+
+/** Resolution of the wake influence map on mobile (reduced for CPU savings). */
+export const WAKE_MAP_SIZE_MOBILE = 32;
+
+/** Maximum UV displacement applied by the wake effect (UV units). */
+export const WAKE_DISPLACEMENT = 0.06;
+
+/** Minimum world-space distance between trail samples to register a wake point. */
+export const WAKE_MIN_DISTANCE = 0.05;
+
+/** World-space radius of each wake splat at full expansion (units). */
+export const WAKE_RADIUS = 4;
+
+/** Fraction of WAKE_RADIUS used for fresh trail points (0..1). Grows to 1.0 as strength decays. */
+export const WAKE_THIN_START = 0.25;
+
+/** Seconds between trail point samples for the wake effect. */
+export const WAKE_TRAIL_INTERVAL = 0.05;
+
+/** Strength decay rate per second for trail points. */
+export const WAKE_TRAIL_DECAY = 1.2;
+
+/** Maximum number of trail points stored for the wake effect. */
+export const WAKE_MAX_TRAIL = 80;
+
+/**
+ * Trail point used by the wake rasterizer.
+ */
+export interface WakeTrailPoint {
+    /** World-space X position. */
+    x: number;
+    /** World-space Z position. */
+    z: number;
+    /** Intensity in 0..1 (1 = fresh, decays toward 0). */
+    strength: number;
+    /** Normalized movement direction X (world space). */
+    dirX: number;
+    /** Normalized movement direction Z (world space). */
+    dirZ: number;
+}
+
+/**
+ * Rasterize wake trail displacement into an RGBA `Uint8Array`.
+ * Each trail point splats a 2D displacement vector perpendicular to the
+ * player's movement direction, creating a boat-wake distortion that pushes
+ * grid lines outward from the trail path.
+ *
+ * Encoding: R = 128 + du*127, G = 128 + dv*127, B = 0, A = 255.
+ * 128 = no displacement; signed direction encoded around midpoint.
+ *
+ * @param data - RGBA pixel buffer (`size * size * 4` bytes). Cleared then filled.
+ * @param size - Width and height of the texture in pixels.
+ * @param trail - Array of trail points with world-space positions, strength, and direction.
+ * @param arenaRadius - World-space radius of the arena (maps to texture extent).
+ * @param wakeRadius - World-space radius of each wake splat.
+ *
+ * @example
+ * ```ts
+ * rasterizeWake(wakeMap.image.data, 64, trail, ARENA_RADIUS, WAKE_RADIUS);
+ * wakeMap.needsUpdate = true;
+ * ```
+ */
+export function rasterizeWake(
+    data: Uint8Array,
+    size: number,
+    trail: readonly WakeTrailPoint[],
+    arenaRadius: number,
+    wakeRadius: number,
+): void {
+    const texelCount = size * size;
+
+    // Initialize output: R=128, G=128, B=0, A=255 (no displacement)
+    for (let i = 0; i < texelCount; i++) {
+        const idx = i * 4;
+        data[idx] = 128;
+        data[idx + 1] = 128;
+        data[idx + 2] = 0;
+        data[idx + 3] = 255;
+    }
+
+    if (trail.length === 0) return;
+
+    // Float32 scratch buffer for clean accumulation (2 floats per texel: du, dv)
+    const scratch = new Float32Array(texelCount * 2);
+
+    // Precompute base pixel radius
+    const texelsPerUnit = size / (arenaRadius * 2);
+    const maxSplatRadius = wakeRadius * texelsPerUnit;
+
+    for (const pt of trail) {
+        // Wake starts thin (WAKE_THIN_START fraction) and expands as
+        // strength decays toward 0, reaching full radius at end of life.
+        const widthFraction =
+            WAKE_THIN_START + (1 - WAKE_THIN_START) * (1 - pt.strength);
+        const splatRadius = maxSplatRadius * widthFraction;
+        const splatRadiusSq = splatRadius * splatRadius;
+
+        // World to texel: center of arena = (size/2, size/2).
+        // Three.js CylinderGeometry cap UVs: u = (z/R+1)*0.5, v = (x/R+1)*0.5
+        // so texel column (cx) maps from world Z, texel row (cy) from world X.
+        const cx = (pt.z / arenaRadius + 1) * 0.5 * size;
+        const cy = (pt.x / arenaRadius + 1) * 0.5 * size;
+
+        // Movement direction mapped to texel space:
+        // texel X proportional to world Z, texel Y proportional to world X
+        const movTexX = pt.dirZ;
+        const movTexY = pt.dirX;
+
+        // Perpendicular to movement in texel space
+        const perpTexX = -movTexY;
+        const perpTexY = movTexX;
+
+        const minX = Math.max(0, Math.floor(cx - splatRadius));
+        const maxX = Math.min(size - 1, Math.ceil(cx + splatRadius));
+        const minY = Math.max(0, Math.floor(cy - splatRadius));
+        const maxY = Math.min(size - 1, Math.ceil(cy + splatRadius));
+
+        for (let py = minY; py <= maxY; py++) {
+            for (let px = minX; px <= maxX; px++) {
+                const dx = px - cx;
+                const dy = py - cy;
+                const distSq = dx * dx + dy * dy;
+                if (distSq >= splatRadiusSq) continue;
+
+                const dist = Math.sqrt(distSq);
+                if (dist < 0.001) continue;
+
+                // Smoothstep radial falloff: 1 at center, 0 at edge
+                const t = dist / splatRadius;
+                const radialFalloff = 1 - t * t * (3 - 2 * t);
+
+                // Signed perpendicular distance from the trail line.
+                // Positive = one side, negative = other side.
+                // Normalized by splatRadius so the factor stays in [-1, 1].
+                const perpDot = dx * perpTexX + dy * perpTexY;
+                const perpFactor = perpDot / splatRadius;
+
+                // Displacement is perpendicular to movement, scaled by
+                // how far off the trail line this texel is (perpFactor)
+                // and the radial falloff. Zero ON the trail line, peaks
+                // to the sides, then falls off at the splat edge.
+                const mag = perpFactor * radialFalloff * pt.strength;
+                const si = (py * size + px) * 2;
+                scratch[si] += perpTexX * mag;
+                scratch[si + 1] += perpTexY * mag;
+            }
+        }
+    }
+
+    // Encode accumulated displacement to RGBA uint8
+    for (let i = 0; i < texelCount; i++) {
+        const si = i * 2;
+        const du = scratch[si];
+        const dv = scratch[si + 1];
+        const idx = i * 4;
+        data[idx] = Math.min(255, Math.max(0, Math.round(128 + du * 127)));
+        data[idx + 1] = Math.min(255, Math.max(0, Math.round(128 + dv * 127)));
+    }
+}
+
+/**
+ * Convert a world-space XZ position to UV coordinates matching
+ * Three.js CylinderGeometry's top-cap UV layout.
+ *
+ * UV mapping: `u = (z / R + 1) * 0.5`, `v = (x / R + 1) * 0.5`.
+ *
+ * @param worldX - World-space X coordinate.
+ * @param worldZ - World-space Z coordinate.
+ * @param arenaRadius - Radius of the arena cylinder.
+ * @returns `[u, v]` in 0–1 UV space.
+ *
+ * @example
+ * ```ts
+ * worldToUV(0, 0, 10); // [0.5, 0.5] — center
+ * worldToUV(10, 0, 10); // [0.5, 1.0] — edge
+ * ```
+ */
+export function worldToUV(
+    worldX: number,
+    worldZ: number,
+    arenaRadius: number,
+): [number, number] {
+    const u = (worldZ / arenaRadius + 1) * 0.5;
+    const v = (worldX / arenaRadius + 1) * 0.5;
+    return [u, v];
+}


### PR DESCRIPTION
## Description

Split the 825-line PlatformNode into focused modules: platform/textures.ts, platform/wake.ts, platform/shaderPatch.ts. PlatformNode becomes a concise orchestrator.

## Files Changed

- demos/arena/src/nodes/PlatformNode.ts (refactored to orchestrator, re-exports all public symbols)
- demos/arena/src/nodes/platform/textures.ts (new — 5 texture generator functions)
- demos/arena/src/nodes/platform/wake.ts (new — wake trail tracking, rasterizeWake, WakeTrailPoint)
- demos/arena/src/nodes/platform/shaderPatch.ts (new — ripple/wake/hit-ripple shader patching)

Part of EPIC-026: Arena Demo Refactoring & Cleanup