### PR TITLE
TICKET-148: Create generic shared effect pool factory

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-148-generic-shared-effect-pool-factory.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-148-generic-shared-effect-pool-factory.md
@@ -1,7 +1,7 @@
 ---
 id: TICKET-148
 title: Create generic shared effect pool factory
-status: in-progress
+status: done
 epic: EPIC-026
 created: 2026-03-14
 updated: 2026-03-14
@@ -37,3 +37,4 @@ export const { Store: ShockwaveStore, usePool: useShockwavePool } =
 ## Notes
 
 - **2026-03-14**: Starting implementation
+- **2026-03-14**: Implementation complete

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-148-generic-shared-effect-pool-factory.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-148-generic-shared-effect-pool-factory.md
@@ -1,10 +1,12 @@
 ---
 id: TICKET-148
 title: Create generic shared effect pool factory
-status: todo
+status: in-progress
 epic: EPIC-026
 created: 2026-03-14
+updated: 2026-03-14
 priority: low
+branch: ticket-148-generic-shared-effect-pool-factory
 ---
 
 ## Problem
@@ -31,3 +33,7 @@ export const { Store: ShockwaveStore, usePool: useShockwavePool } =
 
 - `demos/arena/src/shockwave.ts`
 - `demos/arena/src/hitImpact.ts`
+
+## Notes
+
+- **2026-03-14**: Starting implementation

--- a/demos/arena/src/createSharedPool.test.ts
+++ b/demos/arena/src/createSharedPool.test.ts
@@ -1,0 +1,57 @@
+jest.mock(
+    '@pulse-ts/core',
+    () => ({
+        defineStore: (name: string, factory: () => any) => ({
+            _key: Symbol(name),
+            _factory: factory,
+        }),
+        useStore: jest.fn(),
+    }),
+    { virtual: true },
+);
+
+jest.mock(
+    '@pulse-ts/effects',
+    () => ({
+        useEffectPool: jest.fn(),
+    }),
+    { virtual: true },
+);
+
+import { createSharedPool } from './createSharedPool';
+
+describe('createSharedPool', () => {
+    it('returns an object with Store and usePool', () => {
+        const result = createSharedPool('test', {
+            size: 2,
+            duration: 1,
+            create: () => ({ x: 0 }),
+        });
+
+        expect(result).toHaveProperty('Store');
+        expect(result).toHaveProperty('usePool');
+        expect(typeof result.usePool).toBe('function');
+    });
+
+    it('Store factory produces an object with null pool', () => {
+        const { Store } = createSharedPool('test2', {
+            size: 2,
+            duration: 1,
+            create: () => ({ x: 0 }),
+        });
+
+        const state = (Store as any)._factory();
+        expect(state.pool).toBeNull();
+    });
+
+    it('Store has a _key symbol', () => {
+        const { Store } = createSharedPool('myName', {
+            size: 1,
+            duration: 0.5,
+            create: () => ({ v: 0 }),
+        });
+
+        expect((Store as any)._key).toBeDefined();
+        expect(typeof (Store as any)._key).toBe('symbol');
+    });
+});

--- a/demos/arena/src/createSharedPool.ts
+++ b/demos/arena/src/createSharedPool.ts
@@ -1,0 +1,82 @@
+import { defineStore, useStore } from '@pulse-ts/core';
+import { useEffectPool, type EffectPoolHandle } from '@pulse-ts/effects';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration for {@link createSharedPool}.
+ *
+ * @typeParam T - Shape of user data stored in each pool slot.
+ */
+export interface SharedPoolConfig<T> {
+    /** Maximum concurrent effects. */
+    size: number;
+    /** Duration in seconds before auto-deactivation. */
+    duration: number;
+    /** Factory for slot data. Called once per slot at pool creation. */
+    create: () => T;
+}
+
+/**
+ * Return type of {@link createSharedPool}.
+ *
+ * @typeParam T - Shape of user data stored in each pool slot.
+ */
+export interface SharedPool<T> {
+    /** The world-scoped store holding the pool handle. */
+    Store: ReturnType<typeof defineStore>;
+    /** Hook that lazily creates or retrieves the shared pool. */
+    usePool: () => EffectPoolHandle<T>;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a world-scoped shared effect pool backed by a store.
+ *
+ * The first caller of the returned `usePool` hook creates the pool via
+ * `useEffectPool`; subsequent callers in the same world receive the same
+ * handle.
+ *
+ * @typeParam T - Shape of user data stored in each pool slot.
+ * @param name - Unique store name for this pool.
+ * @param config - Pool configuration (size, duration, slot factory).
+ * @returns An object containing the `Store` definition and the `usePool` hook.
+ *
+ * @example
+ * ```ts
+ * import { createSharedPool } from './createSharedPool';
+ *
+ * interface MyData { x: number; y: number; }
+ *
+ * export const { Store: MyStore, usePool: useMyPool } =
+ *     createSharedPool<MyData>('myEffect', {
+ *         size: 4, duration: 0.5, create: () => ({ x: 0, y: 0 }),
+ *     });
+ * ```
+ */
+export function createSharedPool<T>(
+    name: string,
+    config: SharedPoolConfig<T>,
+): SharedPool<T> {
+    const Store = defineStore(name, () => ({
+        pool: null as EffectPoolHandle<T> | null,
+    }));
+
+    function usePool(): EffectPoolHandle<T> {
+        const [store, setStore] = useStore(Store);
+
+        if (!store.pool) {
+            const pool = useEffectPool<T>(config);
+            setStore({ pool });
+        }
+
+        return store.pool!;
+    }
+
+    return { Store, usePool };
+}

--- a/demos/arena/src/hitImpact.ts
+++ b/demos/arena/src/hitImpact.ts
@@ -1,5 +1,4 @@
-import { defineStore, useStore } from '@pulse-ts/core';
-import { useEffectPool, type EffectPoolHandle } from '@pulse-ts/effects';
+import { createSharedPool } from './createSharedPool';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -42,28 +41,14 @@ export interface HitImpactData {
 }
 
 // ---------------------------------------------------------------------------
-// Store — shares the pool handle across nodes
+// Shared pool (store + hook via factory)
 // ---------------------------------------------------------------------------
 
 /**
- * World-scoped store holding the hit impact effect pool handle.
- * The pool is created by the first node that calls {@link useHitImpactPool},
- * and shared with all subsequent callers in the same world.
- */
-export const HitImpactStore = defineStore('hitImpact', () => ({
-    pool: null as EffectPoolHandle<HitImpactData> | null,
-}));
-
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
-
-/**
- * Create or retrieve the shared hit impact effect pool for this world.
- * The first caller creates the pool (and registers its `useFixedUpdate`
- * tick); subsequent callers in the same world receive the same handle.
+ * World-scoped store and hook for the hit impact effect pool.
  *
- * @returns The shared {@link EffectPoolHandle} for hit impacts.
+ * `HitImpactStore` holds the pool handle; `useHitImpactPool` lazily creates
+ * it on first call and shares it with all subsequent callers in the same world.
  *
  * @example
  * ```ts
@@ -76,17 +61,9 @@ export const HitImpactStore = defineStore('hitImpact', () => ({
  * }
  * ```
  */
-export function useHitImpactPool(): EffectPoolHandle<HitImpactData> {
-    const [store, setStore] = useStore(HitImpactStore);
-
-    if (!store.pool) {
-        const pool = useEffectPool<HitImpactData>({
-            size: HIT_IMPACT_POOL_SIZE,
-            duration: HIT_IMPACT_DURATION,
-            create: () => ({ worldX: 0, worldZ: 0 }),
-        });
-        setStore({ pool });
-    }
-
-    return store.pool!;
-}
+export const { Store: HitImpactStore, usePool: useHitImpactPool } =
+    createSharedPool<HitImpactData>('hitImpact', {
+        size: HIT_IMPACT_POOL_SIZE,
+        duration: HIT_IMPACT_DURATION,
+        create: () => ({ worldX: 0, worldZ: 0 }),
+    });

--- a/demos/arena/src/shockwave.ts
+++ b/demos/arena/src/shockwave.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
-import { defineStore, useStore } from '@pulse-ts/core';
-import { useEffectPool, type EffectPoolHandle } from '@pulse-ts/effects';
+import type { EffectPoolHandle } from '@pulse-ts/effects';
+import { createSharedPool } from './createSharedPool';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -35,27 +35,14 @@ export interface ShockwaveData {
 }
 
 // ---------------------------------------------------------------------------
-// Store — shares the pool handle across nodes
+// Shared pool (store + hook via factory)
 // ---------------------------------------------------------------------------
 
 /**
- * World-scoped store holding the shockwave effect pool handle.
- * The pool is created by the first node that calls {@link useShockwavePool},
- * and shared with all subsequent callers in the same world.
- */
-export const ShockwaveStore = defineStore('shockwave', () => ({
-    pool: null as EffectPoolHandle<ShockwaveData> | null,
-}));
-
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
-
-/**
- * Create or retrieve the shared shockwave effect pool for this world.
- * The first caller creates the pool; subsequent callers receive the same handle.
+ * World-scoped store and hook for the shockwave effect pool.
  *
- * @returns The shared {@link EffectPoolHandle} for shockwaves.
+ * `ShockwaveStore` holds the pool handle; `useShockwavePool` lazily creates
+ * it on first call and shares it with all subsequent callers in the same world.
  *
  * @example
  * ```ts
@@ -63,20 +50,12 @@ export const ShockwaveStore = defineStore('shockwave', () => ({
  * shockwaves.trigger({ centerX: 0.5, centerY: 0.5 });
  * ```
  */
-export function useShockwavePool(): EffectPoolHandle<ShockwaveData> {
-    const [store, setStore] = useStore(ShockwaveStore);
-
-    if (!store.pool) {
-        const pool = useEffectPool<ShockwaveData>({
-            size: MAX_SHOCKWAVES,
-            duration: SHOCKWAVE_DURATION,
-            create: () => ({ centerX: 0, centerY: 0 }),
-        });
-        setStore({ pool });
-    }
-
-    return store.pool!;
-}
+export const { Store: ShockwaveStore, usePool: useShockwavePool } =
+    createSharedPool<ShockwaveData>('shockwave', {
+        size: MAX_SHOCKWAVES,
+        duration: SHOCKWAVE_DURATION,
+        create: () => ({ centerX: 0, centerY: 0 }),
+    });
 
 // ---------------------------------------------------------------------------
 // Uniform sync


### PR DESCRIPTION
## Description

Create a generic `createSharedPool<T>(name, config)` factory to eliminate duplicated boilerplate between `shockwave.ts` and `hitImpact.ts`. Both files previously duplicated the same pattern: define a store holding `pool: EffectPoolHandle<T> | null`, then define a hook that lazily creates the pool. The factory encapsulates this pattern into a single reusable call.

## Files Changed

- `demos/arena/src/createSharedPool.ts` (new) - Generic factory
- `demos/arena/src/createSharedPool.test.ts` (new) - Tests for the factory
- `demos/arena/src/shockwave.ts` (refactored) - Uses `createSharedPool`
- `demos/arena/src/hitImpact.ts` (refactored) - Uses `createSharedPool`

Part of EPIC-026: Arena Demo Refactoring & Cleanup