### PR TITLE
TICKET-140: Split LocalPlayerNode into focused concerns

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-140-split-local-player-node.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-140-split-local-player-node.md
@@ -1,7 +1,7 @@
 ---
 id: TICKET-140
 title: Split LocalPlayerNode into focused concerns
-status: in-progress
+status: done
 epic: EPIC-026
 created: 2026-03-14
 updated: 2026-03-14
@@ -40,3 +40,4 @@ Extract into focused modules:
 - `demos/arena/src/nodes/LocalPlayerNode.ts`
 
 - **2026-03-14**: Starting implementation
+- **2026-03-14**: Implementation complete

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-140-split-local-player-node.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-140-split-local-player-node.md
@@ -1,9 +1,11 @@
 ---
 id: TICKET-140
 title: Split LocalPlayerNode into focused concerns
-status: todo
+status: in-progress
 epic: EPIC-026
 created: 2026-03-14
+updated: 2026-03-14
+branch: ticket-140-split-local-player-node
 priority: high
 ---
 
@@ -36,3 +38,5 @@ Extract into focused modules:
 ## Files
 
 - `demos/arena/src/nodes/LocalPlayerNode.ts`
+
+- **2026-03-14**: Starting implementation

--- a/demos/arena/src/nodes/LocalPlayerNode.ts
+++ b/demos/arena/src/nodes/LocalPlayerNode.ts
@@ -1,30 +1,21 @@
 import {
     useComponent,
-    useFixedEarly,
     useFixedUpdate,
     useFrameUpdate,
     useContext,
     useStableId,
-    useNode,
-    getComponent,
-    Transform,
-    useTimer,
-    useCooldown,
-    useDestroy,
     useStore,
-    color,
+    Transform,
 } from '@pulse-ts/core';
 import { useAxis2D, useAction } from '@pulse-ts/input';
 import {
     useRigidBody,
     useSphereCollider,
-    useOnCollisionStart,
 } from '@pulse-ts/physics';
 import {
     useMesh,
     useThreeContext,
     useInterpolatedPosition,
-    useScreenProjection,
 } from '@pulse-ts/three';
 import { useSound, useSoundGroup } from '@pulse-ts/audio';
 import { useParticleBurst } from '@pulse-ts/effects';
@@ -39,11 +30,9 @@ import {
     TRAIL_BASE_INTERVAL,
 } from '../config/arena';
 import { KnockoutChannel } from '../config/channels';
-import { triggerCameraShake } from './CameraRigNode';
 import {
     ReplayStore,
     stagePlayerPosition,
-    markHit,
     getReplayPosition,
 } from '../replay';
 import { useShockwavePool, worldToScreen } from '../shockwave';
@@ -53,8 +42,32 @@ import { DashCooldownStore } from '../dashCooldown';
 import {
     PlayerVelocityStore,
     updatePlayerVelocity,
-    getPlayerVelocity,
 } from '../playerVelocity';
+
+// Extracted modules
+import { useDash, tryActivateDash, DASH_SPEED, DASH_COOLDOWN } from './dash';
+import { useIndicatorRing } from './indicatorRing';
+import { useKnockback, KNOCKOUT_BURST_COUNT } from './knockback';
+import type { KnockbackDeps } from './knockback';
+
+// Re-export pure functions and constants so existing imports continue to work.
+export {
+    computeKnockback,
+    computeApproachSpeed,
+    computeDashDirection,
+} from './mechanics';
+export { DASH_SPEED, DASH_DURATION, DASH_COOLDOWN } from './dash';
+export {
+    KNOCKBACK_BASE,
+    KNOCKBACK_VELOCITY_SCALE,
+    IMPACT_COOLDOWN,
+    KNOCKOUT_BURST_COUNT,
+} from './knockback';
+export {
+    INDICATOR_RING_COLOR,
+    INDICATOR_RING_SCALE,
+    INDICATOR_RING_BORDER,
+} from './indicatorRing';
 
 /** Sphere radius for the player ball. */
 export const PLAYER_RADIUS = 0.8;
@@ -64,146 +77,6 @@ export const MOVE_IMPULSE = 0.6;
 
 /** Linear damping — lower values mean longer coasting and harder to control. */
 export const LINEAR_DAMPING = 0.25;
-
-/** Velocity applied during a dash. */
-export const DASH_SPEED = 24;
-
-/** Duration of a dash in seconds. */
-export const DASH_DURATION = 0.15;
-
-/** Cooldown between dashes in seconds. */
-export const DASH_COOLDOWN = 1.0;
-
-/**
- * Minimum knockback applied even when both players have zero closing speed.
- * Ensures standing collisions still produce a visible bump.
- */
-export const KNOCKBACK_BASE = 15;
-
-/**
- * Knockback scaling factor per unit of the other player's approach speed.
- * Only the opponent's velocity into you affects your knockback — your own
- * speed does not amplify the hit you receive.
- * Effective knockback: `KNOCKBACK_BASE + theirApproach * KNOCKBACK_VELOCITY_SCALE`
- */
-export const KNOCKBACK_VELOCITY_SCALE = 0.3;
-
-/** Minimum seconds between collision impact sounds. */
-export const IMPACT_COOLDOWN = 0.4;
-
-/** Number of particles in the knockout mega-burst. */
-export const KNOCKOUT_BURST_COUNT = 80;
-
-/** Color of the online-mode "you" indicator ring (hex). */
-export const INDICATOR_RING_COLOR = 0xffee88;
-
-/** Screen-space scale multiplier vs projected player radius. */
-export const INDICATOR_RING_SCALE = 1.5;
-
-/** Border width of the indicator ring in pixels. */
-export const INDICATOR_RING_BORDER = 2;
-
-/**
- * Compute a knockback impulse vector from one position to another.
- * The impulse points away from the other player and is scaled by the
- * given magnitude. Includes an upward component for arc.
- *
- * @param selfX - Local player X position.
- * @param selfZ - Local player Z position.
- * @param otherX - Other player X position.
- * @param otherZ - Other player Z position.
- * @param magnitude - Impulse strength.
- * @returns An `[x, y, z]` impulse vector.
- *
- * @example
- * ```ts
- * computeKnockback(0, 0, -1, 0, 8); // [8, 0, 0] — pushed right
- * ```
- */
-export function computeKnockback(
-    selfX: number,
-    selfZ: number,
-    otherX: number,
-    otherZ: number,
-    magnitude: number,
-): [number, number, number] {
-    const dx = selfX - otherX;
-    const dz = selfZ - otherZ;
-    const len = Math.sqrt(dx * dx + dz * dz);
-    if (len > 0) {
-        return [(dx / len) * magnitude, 0, (dz / len) * magnitude];
-    }
-    // Overlapping — push in arbitrary direction
-    return [magnitude, 0, 0];
-}
-
-/**
- * Compute how fast a body is moving **toward** a target position.
- * Returns the component of the attacker's velocity along the direction
- * from attacker to target (clamped to >= 0 — retreating gives 0).
- *
- * @param selfX - Target player X.
- * @param selfZ - Target player Z.
- * @param otherX - Attacker X.
- * @param otherZ - Attacker Z.
- * @param otherVx - Attacker velocity X.
- * @param otherVz - Attacker velocity Z.
- * @returns Approach speed (>= 0). Zero for glancing or retreating movement.
- *
- * @example
- * ```ts
- * // Attacker at (-5,0) moving at (10,0) toward target at (0,0)
- * computeApproachSpeed(0, 0, -5, 0, 10, 0); // 10
- *
- * // Attacker moving perpendicular — glancing blow
- * computeApproachSpeed(0, 0, -5, 0, 0, 10); // 0
- * ```
- */
-export function computeApproachSpeed(
-    selfX: number,
-    selfZ: number,
-    otherX: number,
-    otherZ: number,
-    otherVx: number,
-    otherVz: number,
-): number {
-    const dx = selfX - otherX;
-    const dz = selfZ - otherZ;
-    const len = Math.sqrt(dx * dx + dz * dz);
-    if (len < 0.01) {
-        // Overlapping — use full velocity magnitude as approach speed
-        return Math.sqrt(otherVx * otherVx + otherVz * otherVz);
-    }
-    // Dot product of velocity with direction toward self, clamped to >= 0
-    const dot = (otherVx * dx + otherVz * dz) / len;
-    return Math.max(0, dot);
-}
-
-/**
- * Compute the normalized dash direction from a movement input vector.
- * If the input is zero-length, defaults to forward (negative Z).
- *
- * @param moveX - Horizontal input axis value.
- * @param moveY - Vertical input axis value (W/up = positive).
- * @returns A normalized `[x, z]` direction tuple in world space.
- *
- * @example
- * ```ts
- * computeDashDirection(1, 0);  // [1, 0]  — dash right
- * computeDashDirection(0, 1);  // [0, -1] — dash forward
- * computeDashDirection(0, 0);  // [0, -1] — default forward
- * ```
- */
-export function computeDashDirection(
-    moveX: number,
-    moveY: number,
-): [number, number] {
-    const len = Math.sqrt(moveX * moveX + moveY * moveY);
-    if (len > 0) {
-        return [moveX / len, -moveY / len]; // W = forward = -Z
-    }
-    return [0, -1]; // default forward
-}
 
 export interface LocalPlayerNodeProps {
     /** Player index (0 or 1). */
@@ -233,44 +106,35 @@ export function LocalPlayerNode({
     showIndicatorRing,
     customColor,
 }: Readonly<LocalPlayerNodeProps>) {
-    const node = useNode();
     const gameState = useContext(GameCtx);
     const spawn = SPAWN_POSITIONS[playerId];
 
     const [replay] = useStore(ReplayStore);
-    const shockwavePool = useShockwavePool();
-    const hitImpactPool = useHitImpactPool();
     const [cooldown] = useStore(DashCooldownStore);
     const [velocities] = useStore(PlayerVelocityStore);
 
     useStableId(`player-${playerId}`);
-
     useComponent(PlayerTag);
 
     const transform = useComponent(Transform);
     transform.localPosition.set(...spawn);
 
+    // --- Physics ---
     const body = useRigidBody({
         type: 'dynamic',
         mass: 1,
         linearDamping: LINEAR_DAMPING,
         angularDamping: 1,
     });
-    // Lock rotation so the ball doesn't tumble
     body.setInertiaTensor(0, 0, 0);
 
-    // Replicate after body is created so we can include velocity for
-    // dead-reckoning on the consumer side.
+    // --- Network replication ---
     let publishKnockout: ((id: number) => void) | null = null;
-    let publishKnockback: ((impulse: [number, number, number]) => void) | null =
-        null;
-
     if (replicate) {
         useReplicateTransform({
             role: 'producer',
             readVelocity: () => body.linearVelocity,
         });
-
         const knockoutCh = useChannel(KnockoutChannel);
         publishKnockout = (id) => knockoutCh.publish(id);
     }
@@ -280,42 +144,14 @@ export function LocalPlayerNode({
         restitution: 0.2,
     });
 
+    // --- Input ---
     const getMove = useAxis2D(moveAction);
     const getDash = useAction(dashAction);
 
-    // Dash state
-    const dashTimer = useTimer(DASH_DURATION);
-    const dashCD = useCooldown(DASH_COOLDOWN);
-    const impactCD = useCooldown(IMPACT_COOLDOWN);
-    let dashDirX = 0;
-    let dashDirZ = 0;
+    // --- Dash ---
+    const dash = useDash();
 
-    // Track round number to detect round resets via shared state
-    let lastRound = gameState.round;
-
-    // Tracks whether this player has been knocked out this round.
-    // While true the mesh is hidden and death-plane resets are suppressed.
-    let knockedOut = false;
-
-    // Track phase to detect transition into 'playing' (fixed update + frame update)
-    let lastPhase = gameState.phase;
-    let lastFramePhase = gameState.phase;
-
-    // Snapshot velocity before the physics solver runs. In online mode,
-    // the solver applies a bounce against the kinematic remote player
-    // that's stronger than the local-play bounce (100% vs 50/50 split).
-    // We capture pre-solver velocity so the collision handler can undo
-    // the physics bounce and apply only our controlled knockback impulse.
-    let prePhysVx = 0;
-    let prePhysVz = 0;
-    if (replicate) {
-        useFixedEarly(() => {
-            prePhysVx = body.linearVelocity.x;
-            prePhysVz = body.linearVelocity.z;
-        });
-    }
-
-    // Visual — sphere mesh with subtle emissive glow (blooms under post-processing)
+    // --- Visual ---
     const meshColor = customColor ?? PLAYER_COLORS[playerId];
     const { root } = useMesh('sphere', {
         radius: PLAYER_RADIUS,
@@ -327,8 +163,6 @@ export function LocalPlayerNode({
         castShadow: true,
     });
 
-    // Smooth interpolation from fixed-step transform to render-frame root position.
-    // Snap on round reset to avoid interpolation sweep across the arena.
     let shouldSnap = false;
     useInterpolatedPosition(transform, root, {
         snap: () => {
@@ -340,37 +174,17 @@ export function LocalPlayerNode({
         },
     });
 
-    // Screen projection for indicator ring positioning
-    const project = useScreenProjection();
+    // --- Indicator ring ---
+    const ring = useIndicatorRing(!!replicate || !!showIndicatorRing, PLAYER_RADIUS);
 
-    // Online mode indicator ring — screen-space CSS circle, always centered on the ball
-    const { renderer: threeRenderer, camera: threeCamera } = useThreeContext();
-    let indicatorRing: HTMLDivElement | null = null;
+    // --- Shockwave / hit impact pools ---
+    const shockwavePool = useShockwavePool();
+    const hitImpactPool = useHitImpactPool();
+    const { camera: threeCamera } = useThreeContext();
 
-    if (replicate || showIndicatorRing) {
-        const container =
-            threeRenderer.domElement.parentElement ?? document.body;
-        indicatorRing = document.createElement('div');
-        const indicatorColor = color(INDICATOR_RING_COLOR);
-        const cssColor = indicatorColor.rgba(0.7);
-        const glowColor = indicatorColor.rgba(0.4);
-        Object.assign(indicatorRing.style, {
-            position: 'absolute',
-            borderRadius: '50%',
-            border: `${INDICATOR_RING_BORDER}px solid ${cssColor}`,
-            boxShadow: `0 0 8px ${glowColor}`,
-            pointerEvents: 'none',
-            zIndex: '999',
-        } as Partial<CSSStyleDeclaration>);
-        container.appendChild(indicatorRing);
-
-        useDestroy(() => indicatorRing!.remove());
-    }
-
-    // Sound mixing group for all player SFX
+    // --- Sound effects ---
     useSoundGroup('sfx');
 
-    // Sound effects
     const dashSfx = useSound('noise', {
         filter: 'bandpass',
         frequency: [2000, 500],
@@ -393,7 +207,7 @@ export function LocalPlayerNode({
         group: 'sfx',
     });
 
-    // Particle burst for collision impact
+    // --- Particle effects ---
     const impactBurst = useParticleBurst({
         count: 16,
         lifetime: 0.4,
@@ -404,7 +218,6 @@ export function LocalPlayerNode({
         blending: 'additive',
     });
 
-    // Knockout mega-burst — player-colored explosion on death
     const knockoutBurst = useParticleBurst({
         count: KNOCKOUT_BURST_COUNT,
         lifetime: 0.6,
@@ -416,7 +229,6 @@ export function LocalPlayerNode({
         shrink: true,
     });
 
-    // Velocity-proportional trail burst — emitted when moving fast
     const trailBurst = useParticleBurst({
         count: 8,
         lifetime: 1.0,
@@ -429,214 +241,32 @@ export function LocalPlayerNode({
     });
     let trailAccum = 0;
 
-    // --- Shared knockback application helper ---
-    // Used by both the local collision handler and the remote knockback
-    // channel handler to apply impulse + VFX in one place.
-    const applyKnockbackEffects = (impulse: [number, number, number]): void => {
-        body.applyImpulse(impulse[0], impulse[1], impulse[2]);
+    // --- Knockback ---
+    useKnockback({
+        body,
+        transform,
+        dash,
+        playerId,
+        replicate: !!replicate,
+        impactSfx,
+        impactBurst,
+        shockwavePool,
+        hitImpactPool,
+        threeCamera: threeCamera as KnockbackDeps['threeCamera'],
+        replay,
+        velocityStates: velocities.states,
+        playerRadius: PLAYER_RADIUS,
+        getPhase: () => gameState.phase,
+    });
 
-        // Cancel any active dash and reset cooldown
-        dashTimer.cancel();
-        dashCD.trigger();
+    // --- Round / phase tracking ---
+    let lastRound = gameState.round;
+    let knockedOut = false;
+    let lastPhase = gameState.phase;
+    let lastFramePhase = gameState.phase;
 
-        impactSfx.play();
-        impactCD.trigger();
-
-        // Particle burst — at the surface facing the hit direction
-        const hx = -impulse[0];
-        const hz = -impulse[2];
-        const hLen = Math.sqrt(hx * hx + hz * hz);
-        if (hLen > 0) {
-            const surfX =
-                transform.localPosition.x + (hx / hLen) * PLAYER_RADIUS;
-            const surfY = transform.localPosition.y;
-            const surfZ =
-                transform.localPosition.z + (hz / hLen) * PLAYER_RADIUS;
-            impactBurst([surfX, surfY, surfZ]);
-
-            const [su, sv] = worldToScreen(surfX, surfY, surfZ, threeCamera);
-            shockwavePool.trigger({ centerX: su, centerY: sv });
-            hitImpactPool.trigger({ worldX: surfX, worldZ: surfZ });
-        }
-
-        triggerCameraShake(0.3, 0.2);
-        markHit(replay);
-    };
-
-    // --- Bidirectional knockback channel (online mode) ---
-    // Both players send the OTHER player's computed impulse on collision.
-    // If the receiver already handled the collision locally (impactCD active),
-    // the message is ignored (dedup). If only the sender detected the
-    // collision, the receiver applies the impulse from the message.
-    if (replicate) {
-        const kb = useChannel<[number, number, number]>(
-            'knockback',
-            (impulse) => {
-                if (gameState.phase !== 'playing') return;
-                // Dedup: if we already handled a collision locally, skip.
-                // impactCD is triggered in the collision handler and stays
-                // active for IMPACT_COOLDOWN (0.4s), well beyond any message
-                // delivery time.
-                if (!impactCD.ready) return;
-
-                // This side didn't detect the collision — no solver ran, so
-                // we still have our full approach velocity. In local play the
-                // solver would stop us first (v: -24 → ~0), then knockback
-                // pushes us away (+31). Without correction, the impulse
-                // fights the approach velocity (-24 + 31 = +7 instead of +31).
-                //
-                // Fix: strip velocity component toward the opponent (inferred
-                // from the impulse direction, which points AWAY from them).
-                const imag = Math.sqrt(
-                    impulse[0] * impulse[0] + impulse[2] * impulse[2],
-                );
-                if (imag > 0.01) {
-                    // Normal pointing away from opponent (same as impulse dir)
-                    const awayX = impulse[0] / imag;
-                    const awayZ = impulse[2] / imag;
-                    // Our velocity component toward the opponent (negative of
-                    // away direction)
-                    const towardComponent =
-                        body.linearVelocity.x * -awayX +
-                        body.linearVelocity.z * -awayZ;
-                    // Only strip if we're moving toward them (positive value)
-                    if (towardComponent > 0) {
-                        body.linearVelocity.x += towardComponent * awayX;
-                        body.linearVelocity.z += towardComponent * awayZ;
-                    }
-                }
-
-                applyKnockbackEffects(impulse);
-            },
-        );
-        publishKnockback = (impulse) => kb.publish(impulse);
-    }
-
-    // Knockback on collision with another player.
-    //
-    // TIMING: useOnCollisionStart fires AFTER the physics solver has resolved
-    // the contact. In online mode, the solver applies a bounce against the
-    // kinematic remote body that's stronger than local play (100% vs 50/50).
-    // We halve the solver's velocity change to match local-play physics.
-    //
-    // In online mode, both players compute knockback locally AND send the
-    // other player's impulse via the knockback channel. If only one side
-    // detects the collision, the other side receives and applies the impulse.
-    // The impactCD cooldown deduplicates — if both detect, the channel
-    // message is ignored.
-    useOnCollisionStart(
-        ({ other }) => {
-            if (other === node) return;
-            // Prevent double-hits from rapid re-collision (physics bounce)
-            if (!impactCD.ready) return;
-
-            const otherTransform = getComponent(other, Transform);
-            if (!otherTransform) return;
-
-            // In online mode, correct the physics solver's velocity bounce.
-            // The solver treated the kinematic remote body as an immovable wall
-            // with zero velocity. The simple halving trick works when the remote
-            // player is stationary, but when BOTH players are moving toward each
-            // other the residual velocity pointing at the opponent can exceed the
-            // knockback impulse, causing the players to "stick."
-            //
-            // Fix: replace the solver's result with the proper equal-mass elastic
-            // collision formula using the remote player's known velocity. Only
-            // the normal (along collision axis) component is corrected; tangential
-            // velocity (glancing blows) is preserved from the solver.
-            const otherPlayerId = 1 - playerId;
-            const [otherVx, otherVz] = getPlayerVelocity(
-                velocities.states,
-                otherPlayerId,
-            );
-
-            if (replicate) {
-                const cdx =
-                    otherTransform.localPosition.x - transform.localPosition.x;
-                const cdz =
-                    otherTransform.localPosition.z - transform.localPosition.z;
-                const clen = Math.sqrt(cdx * cdx + cdz * cdz);
-                if (clen > 0.01) {
-                    const nx = cdx / clen;
-                    const nz = cdz / clen;
-                    // Our pre-solver normal velocity (toward opponent)
-                    const myNormal = prePhysVx * nx + prePhysVz * nz;
-                    // Other player's normal velocity (toward us, from their perspective)
-                    const otherNormal = otherVx * nx + otherVz * nz;
-                    // Equal-mass collision: exchange normal components (e=0.2)
-                    const e = 0.2;
-                    const correctedNormal =
-                        ((1 - e) / 2) * myNormal + ((1 + e) / 2) * otherNormal;
-                    // Strip the solver's normal velocity and replace with ours
-                    const solverNormal =
-                        body.linearVelocity.x * nx + body.linearVelocity.z * nz;
-                    body.linearVelocity.x +=
-                        (correctedNormal - solverNormal) * nx;
-                    body.linearVelocity.z +=
-                        (correctedNormal - solverNormal) * nz;
-                } else {
-                    // Overlapping — just zero out horizontal velocity
-                    body.linearVelocity.x = 0;
-                    body.linearVelocity.z = 0;
-                }
-            }
-
-            const approachSpeed = computeApproachSpeed(
-                transform.localPosition.x,
-                transform.localPosition.z,
-                otherTransform.localPosition.x,
-                otherTransform.localPosition.z,
-                otherVx,
-                otherVz,
-            );
-            const effectiveForce =
-                KNOCKBACK_BASE + approachSpeed * KNOCKBACK_VELOCITY_SCALE;
-
-            // Impulse applied to US (pushed away from the other player)
-            const [ix, iy, iz] = computeKnockback(
-                transform.localPosition.x,
-                transform.localPosition.z,
-                otherTransform.localPosition.x,
-                otherTransform.localPosition.z,
-                effectiveForce,
-            );
-
-            applyKnockbackEffects([ix, iy, iz]);
-
-            // In online mode, also compute and send the OTHER player's knockback
-            // so they can apply it if their physics didn't detect the collision.
-            if (publishKnockback) {
-                const [myVx, myVz] = getPlayerVelocity(
-                    velocities.states,
-                    playerId,
-                );
-                const myApproach = computeApproachSpeed(
-                    otherTransform.localPosition.x,
-                    otherTransform.localPosition.z,
-                    transform.localPosition.x,
-                    transform.localPosition.z,
-                    myVx,
-                    myVz,
-                );
-                const otherForce =
-                    KNOCKBACK_BASE + myApproach * KNOCKBACK_VELOCITY_SCALE;
-
-                const [ox, oy, oz] = computeKnockback(
-                    otherTransform.localPosition.x,
-                    otherTransform.localPosition.z,
-                    transform.localPosition.x,
-                    transform.localPosition.z,
-                    otherForce,
-                );
-
-                publishKnockback([ox, oy, oz]);
-            }
-        },
-        { filter: PlayerTag },
-    );
-
+    // --- Fixed update: movement, dash, death plane ---
     useFixedUpdate((dt) => {
-        // Stage position for replay recording and shared position store
         stagePlayerPosition(
             replay,
             playerId,
@@ -658,33 +288,29 @@ export function LocalPlayerNode({
             dt,
         );
 
-        // Round reset — teleport to spawn when GameManagerNode increments round.
+        // Round reset
         if (gameState.round !== lastRound) {
             lastRound = gameState.round;
             knockedOut = false;
             root.visible = true;
             transform.localPosition.set(...spawn);
             body.setLinearVelocity(0, 0, 0);
-            dashTimer.cancel();
-            dashCD.reset();
+            dash.timer.cancel();
+            dash.cooldown.reset();
             shouldSnap = true;
         }
 
-        // Trigger dash cooldown when the playing phase starts so the
-        // cooldown begins when the player actually gains control, not
-        // during the countdown when it would silently expire.
+        // Phase transition
         if (gameState.phase === 'playing' && lastPhase !== 'playing') {
-            dashCD.trigger();
+            dash.cooldown.trigger();
         }
         lastPhase = gameState.phase;
 
-        // Freeze input during non-playing phases
+        // Freeze during non-playing phases
         if (gameState.phase !== 'playing') {
             body.setLinearVelocity(0, 0, 0);
-            dashTimer.cancel();
+            dash.timer.cancel();
 
-            // During replay, drive transform from the replay buffer so
-            // trsSync (which runs after useFrameUpdate) picks up the position.
             if (gameState.phase === 'replay') {
                 const replayPos = getReplayPosition(replay, playerId);
                 if (replayPos) {
@@ -696,7 +322,6 @@ export function LocalPlayerNode({
                 }
             }
 
-            // Still check death plane during freeze for safety
             if (!knockedOut && transform.localPosition.y < DEATH_PLANE_Y) {
                 transform.localPosition.set(...spawn);
                 body.setLinearVelocity(0, 0, 0);
@@ -705,26 +330,25 @@ export function LocalPlayerNode({
         }
 
         const move = getMove();
-        const dashAction = getDash();
+        const dashActionState = getDash();
 
         // Dash activation
-        if (dashAction.pressed && dashCD.ready && !dashTimer.active) {
-            [dashDirX, dashDirZ] = computeDashDirection(move.x, move.y);
-            dashTimer.reset();
-            dashCD.trigger();
-            dashSfx.play();
-        }
+        tryActivateDash(
+            dash,
+            move.x,
+            move.y,
+            dashActionState.pressed,
+            () => dashSfx.play(),
+        );
 
-        if (dashTimer.active) {
-            // During dash, override horizontal velocity with locked direction
+        if (dash.timer.active) {
             const vy = body.linearVelocity.y;
             body.setLinearVelocity(
-                dashDirX * DASH_SPEED,
+                dash.dirX * DASH_SPEED,
                 vy,
-                dashDirZ * DASH_SPEED,
+                dash.dirZ * DASH_SPEED,
             );
         } else {
-            // Momentum-based movement — apply impulse, damping handles deceleration
             const ix = move.x * MOVE_IMPULSE;
             const iz = -move.y * MOVE_IMPULSE;
             if (ix !== 0 || iz !== 0) {
@@ -732,7 +356,7 @@ export function LocalPlayerNode({
             }
         }
 
-        // Death plane — hide mesh on knockout; actual respawn deferred to round reset
+        // Death plane
         if (!knockedOut && transform.localPosition.y < DEATH_PLANE_Y) {
             knockoutBurst([
                 transform.localPosition.x,
@@ -740,8 +364,6 @@ export function LocalPlayerNode({
                 transform.localPosition.z,
             ]);
             deathSfx.play();
-            // Use pendingKnockout2 if the first slot is already occupied
-            // (two players falling in the same tie window)
             if (gameState.pendingKnockout >= 0) {
                 gameState.pendingKnockout2 = playerId;
             } else {
@@ -751,27 +373,24 @@ export function LocalPlayerNode({
             knockedOut = true;
             root.visible = false;
             body.setLinearVelocity(0, 0, 0);
-            dashTimer.cancel();
-            dashCD.reset();
+            dash.timer.cancel();
+            dash.cooldown.reset();
         }
     });
 
-    // Interpolate visual position for smooth rendering
+    // --- Frame update: visual, trail, indicator ring, HUD ---
     useFrameUpdate((dt) => {
-        // Update dash cooldown progress for HUD indicators.
-        // On the frame 'playing' starts, force 0 — the fixed-step
-        // dashCD.trigger() hasn't fired yet so dashCD.ready is stale.
+        // Dash cooldown HUD sync
         const enteringPlaying =
             gameState.phase === 'playing' && lastFramePhase !== 'playing';
         lastFramePhase = gameState.phase;
         cooldown.progress[playerId] = enteringPlaying
             ? 0
-            : dashCD.ready
+            : dash.cooldown.ready
               ? 1
-              : 1 - dashCD.remaining / DASH_COOLDOWN;
-        // During replay, override mesh position from the replay buffer.
-        // When knocked out (between death and round reset), hide the mesh
-        // so there's no visible snap-to-spawn before the replay finishes.
+              : 1 - dash.cooldown.remaining / DASH_COOLDOWN;
+
+        // Replay position override
         const replayPos = getReplayPosition(replay, playerId);
         if (replayPos) {
             root.visible = true;
@@ -782,7 +401,7 @@ export function LocalPlayerNode({
             root.visible = true;
         }
 
-        // Velocity-proportional trail particles during gameplay
+        // Trail particles
         if (gameState.phase === 'playing') {
             const vx = body.linearVelocity.x;
             const vz = body.linearVelocity.z;
@@ -808,33 +427,10 @@ export function LocalPlayerNode({
             trailAccum = 0;
         }
 
-        // Update indicator ring screen position
-        // Visible during playing and intro phases; hidden otherwise
-        if (indicatorRing) {
-            if (gameState.phase !== 'playing') {
-                indicatorRing.style.display = 'none';
-            } else {
-                indicatorRing.style.display = '';
-
-                // Project player center to screen
-                const center = project(root.position);
-                const sx = center.x;
-                const sy = center.y;
-
-                // Project edge point to get screen-space radius
-                const edge = project({
-                    x: root.position.x + PLAYER_RADIUS * INDICATOR_RING_SCALE,
-                    y: root.position.y,
-                    z: root.position.z,
-                });
-                const radius = Math.abs(edge.x - sx);
-                const size = radius * 2;
-
-                indicatorRing.style.width = `${size}px`;
-                indicatorRing.style.height = `${size}px`;
-                indicatorRing.style.left = `${sx - radius}px`;
-                indicatorRing.style.top = `${sy - radius}px`;
-            }
-        }
+        // Indicator ring
+        ring.updatePosition(
+            root.position,
+            gameState.phase === 'playing',
+        );
     });
 }

--- a/demos/arena/src/nodes/dash.ts
+++ b/demos/arena/src/nodes/dash.ts
@@ -1,0 +1,75 @@
+/**
+ * Dash mechanic — timer, cooldown, direction state, and activation logic.
+ */
+
+import { useTimer, useCooldown } from '@pulse-ts/core';
+import { computeDashDirection } from './mechanics';
+
+/** Velocity applied during a dash. */
+export const DASH_SPEED = 24;
+
+/** Duration of a dash in seconds. */
+export const DASH_DURATION = 0.15;
+
+/** Cooldown between dashes in seconds. */
+export const DASH_COOLDOWN = 1.0;
+
+export interface DashState {
+    /** The dash timer instance. */
+    timer: ReturnType<typeof useTimer>;
+    /** The dash cooldown instance. */
+    cooldown: ReturnType<typeof useCooldown>;
+    /** Current dash direction X component. */
+    dirX: number;
+    /** Current dash direction Z component. */
+    dirZ: number;
+}
+
+/**
+ * Initialize dash state with timer and cooldown hooks.
+ * Call at the top level of a node function.
+ *
+ * @returns Mutable dash state object.
+ *
+ * @example
+ * ```ts
+ * const dash = useDash();
+ * // In fixed update:
+ * tryActivateDash(dash, move.x, move.y, dashAction.pressed, dashSfx);
+ * ```
+ */
+export function useDash(): DashState {
+    return {
+        timer: useTimer(DASH_DURATION),
+        cooldown: useCooldown(DASH_COOLDOWN),
+        dirX: 0,
+        dirZ: 0,
+    };
+}
+
+/**
+ * Attempt to activate a dash. Mutates dash state if successful.
+ *
+ * @param dash - The dash state from {@link useDash}.
+ * @param moveX - Current horizontal input.
+ * @param moveY - Current vertical input.
+ * @param pressed - Whether the dash button was pressed this tick.
+ * @param onDash - Callback invoked when dash activates (e.g. play sound).
+ * @returns Whether a dash was activated.
+ */
+export function tryActivateDash(
+    dash: DashState,
+    moveX: number,
+    moveY: number,
+    pressed: boolean,
+    onDash?: () => void,
+): boolean {
+    if (pressed && dash.cooldown.ready && !dash.timer.active) {
+        [dash.dirX, dash.dirZ] = computeDashDirection(moveX, moveY);
+        dash.timer.reset();
+        dash.cooldown.trigger();
+        onDash?.();
+        return true;
+    }
+    return false;
+}

--- a/demos/arena/src/nodes/indicatorRing.ts
+++ b/demos/arena/src/nodes/indicatorRing.ts
@@ -1,0 +1,113 @@
+/**
+ * Indicator ring — a screen-space CSS circle that tracks the local player's
+ * position. Used in online mode to distinguish "you" from the remote player.
+ */
+
+import {
+    color,
+    useDestroy,
+} from '@pulse-ts/core';
+import {
+    useThreeContext,
+    useScreenProjection,
+} from '@pulse-ts/three';
+
+/** Color of the online-mode "you" indicator ring (hex). */
+export const INDICATOR_RING_COLOR = 0xffee88;
+
+/** Screen-space scale multiplier vs projected player radius. */
+export const INDICATOR_RING_SCALE = 1.5;
+
+/** Border width of the indicator ring in pixels. */
+export const INDICATOR_RING_BORDER = 2;
+
+export interface IndicatorRingHandle {
+    /** The DOM element, or null if not created. */
+    element: HTMLDivElement | null;
+    /** The screen-projection function for positioning. */
+    project: ReturnType<typeof useScreenProjection>;
+    /** Update the ring's screen position from a world-space position. */
+    updatePosition: (
+        position: { x: number; y: number; z: number },
+        visible: boolean,
+    ) => void;
+}
+
+/**
+ * Create and manage an indicator ring DOM element.
+ * Call this at the top level of a node function (hooks are used internally).
+ *
+ * @param enabled - Whether to create the ring. When false, returns a no-op handle.
+ * @param playerRadius - The player sphere radius for screen-space sizing. Defaults to 0.8.
+ * @returns A handle for updating and reading the ring state.
+ *
+ * @example
+ * ```ts
+ * const ring = useIndicatorRing(replicate || showIndicatorRing);
+ * // In frame update:
+ * ring.updatePosition(root.position, gameState.phase === 'playing');
+ * ```
+ */
+export function useIndicatorRing(enabled: boolean, playerRadius: number = 0.8): IndicatorRingHandle {
+    const project = useScreenProjection();
+    const { renderer: threeRenderer } = useThreeContext();
+
+    let indicatorRing: HTMLDivElement | null = null;
+
+    if (enabled) {
+        const container =
+            threeRenderer.domElement.parentElement ?? document.body;
+        indicatorRing = document.createElement('div');
+        const indicatorColor = color(INDICATOR_RING_COLOR);
+        const cssColor = indicatorColor.rgba(0.7);
+        const glowColor = indicatorColor.rgba(0.4);
+        Object.assign(indicatorRing.style, {
+            position: 'absolute',
+            borderRadius: '50%',
+            border: `${INDICATOR_RING_BORDER}px solid ${cssColor}`,
+            boxShadow: `0 0 8px ${glowColor}`,
+            pointerEvents: 'none',
+            zIndex: '999',
+        } as Partial<CSSStyleDeclaration>);
+        container.appendChild(indicatorRing);
+
+        useDestroy(() => indicatorRing!.remove());
+    }
+
+    const updatePosition = (
+        position: { x: number; y: number; z: number },
+        visible: boolean,
+    ): void => {
+        if (!indicatorRing) return;
+
+        if (!visible) {
+            indicatorRing.style.display = 'none';
+            return;
+        }
+
+        indicatorRing.style.display = '';
+
+        const center = project(position);
+        const sx = center.x;
+        const sy = center.y;
+
+        const edge = project({
+            x: position.x + playerRadius * INDICATOR_RING_SCALE,
+            y: position.y,
+            z: position.z,
+        });
+        const radius = Math.abs(edge.x - sx);
+        const size = radius * 2;
+
+        indicatorRing.style.width = `${size}px`;
+        indicatorRing.style.height = `${size}px`;
+        indicatorRing.style.left = `${sx - radius}px`;
+        indicatorRing.style.top = `${sy - radius}px`;
+    };
+
+    return {
+        element: indicatorRing,
+        project,
+        updatePosition,
+    };
+}

--- a/demos/arena/src/nodes/knockback.ts
+++ b/demos/arena/src/nodes/knockback.ts
@@ -1,0 +1,269 @@
+/**
+ * Knockback handling — collision response, online velocity correction,
+ * and bidirectional knockback channel for online mode.
+ */
+
+import {
+    useNode,
+    useComponent,
+    getComponent,
+    Transform,
+    useCooldown,
+    useFixedEarly,
+} from '@pulse-ts/core';
+import { useOnCollisionStart } from '@pulse-ts/physics';
+import { useChannel } from '@pulse-ts/network';
+import { PlayerTag } from '../components/PlayerTag';
+import { triggerCameraShake } from './CameraRigNode';
+import { markHit } from '../replay';
+import { worldToScreen } from '../shockwave';
+import { getPlayerVelocity } from '../playerVelocity';
+import { computeKnockback, computeApproachSpeed } from './mechanics';
+import type { DashState } from './dash';
+
+/** Minimum knockback applied even when both players have zero closing speed. */
+export const KNOCKBACK_BASE = 15;
+
+/**
+ * Knockback scaling factor per unit of the other player's approach speed.
+ * Effective knockback: `KNOCKBACK_BASE + theirApproach * KNOCKBACK_VELOCITY_SCALE`
+ */
+export const KNOCKBACK_VELOCITY_SCALE = 0.3;
+
+/** Minimum seconds between collision impact sounds. */
+export const IMPACT_COOLDOWN = 0.4;
+
+/** Number of particles in the knockout mega-burst. */
+export const KNOCKOUT_BURST_COUNT = 80;
+
+export interface KnockbackDeps {
+    /** The player's rigid body. */
+    body: {
+        applyImpulse: (x: number, y: number, z: number) => void;
+        linearVelocity: { x: number; y: number; z: number };
+    };
+    /** The player's transform component. */
+    transform: InstanceType<typeof Transform>;
+    /** The player's dash state (to cancel on hit). */
+    dash: DashState;
+    /** Player index (0 or 1). */
+    playerId: number;
+    /** Whether online replication is enabled. */
+    replicate: boolean;
+    /** Impact sound effect. */
+    impactSfx: { play: () => void };
+    /** Impact particle burst function. */
+    impactBurst: (pos: [number, number, number]) => void;
+    /** Shockwave pool trigger. */
+    shockwavePool: { trigger: (opts: { centerX: number; centerY: number }) => void };
+    /** Hit impact pool trigger. */
+    hitImpactPool: { trigger: (opts: { worldX: number; worldZ: number }) => void };
+    /** Three.js camera for screen projection. */
+    threeCamera: { projectionMatrix: unknown; matrixWorldInverse: unknown };
+    /** Replay state. */
+    replay: unknown;
+    /** Velocity states map. */
+    velocityStates: unknown;
+    /** Player radius for surface-point calculation. */
+    playerRadius: number;
+    /** Returns the current game phase. */
+    getPhase: () => string;
+}
+
+/**
+ * Set up knockback collision handling and (optionally) the online knockback channel.
+ * Call at the top level of a node function.
+ *
+ * @param deps - Dependencies from the parent node.
+ *
+ * @example
+ * ```ts
+ * useKnockback({ body, transform, dash, playerId, ... });
+ * ```
+ */
+export function useKnockback(deps: KnockbackDeps): void {
+    const node = useNode();
+    const impactCD = useCooldown(IMPACT_COOLDOWN);
+
+    // Pre-solver velocity snapshot for online mode correction
+    let prePhysVx = 0;
+    let prePhysVz = 0;
+    if (deps.replicate) {
+        useFixedEarly(() => {
+            prePhysVx = deps.body.linearVelocity.x;
+            prePhysVz = deps.body.linearVelocity.z;
+        });
+    }
+
+    // Shared knockback application helper
+    const applyKnockbackEffects = (impulse: [number, number, number]): void => {
+        deps.body.applyImpulse(impulse[0], impulse[1], impulse[2]);
+
+        // Cancel any active dash and reset cooldown
+        deps.dash.timer.cancel();
+        deps.dash.cooldown.trigger();
+
+        deps.impactSfx.play();
+        impactCD.trigger();
+
+        // Particle burst at surface facing hit direction
+        const hx = -impulse[0];
+        const hz = -impulse[2];
+        const hLen = Math.sqrt(hx * hx + hz * hz);
+        if (hLen > 0) {
+            const surfX =
+                deps.transform.localPosition.x +
+                (hx / hLen) * deps.playerRadius;
+            const surfY = deps.transform.localPosition.y;
+            const surfZ =
+                deps.transform.localPosition.z +
+                (hz / hLen) * deps.playerRadius;
+            deps.impactBurst([surfX, surfY, surfZ]);
+
+            const [su, sv] = worldToScreen(
+                surfX,
+                surfY,
+                surfZ,
+                deps.threeCamera as Parameters<typeof worldToScreen>[3],
+            );
+            deps.shockwavePool.trigger({ centerX: su, centerY: sv });
+            deps.hitImpactPool.trigger({ worldX: surfX, worldZ: surfZ });
+        }
+
+        triggerCameraShake(0.3, 0.2);
+        markHit(deps.replay as Parameters<typeof markHit>[0]);
+    };
+
+    // Bidirectional knockback channel (online mode)
+    let publishKnockback: ((impulse: [number, number, number]) => void) | null =
+        null;
+    if (deps.replicate) {
+        const kb = useChannel<[number, number, number]>(
+            'knockback',
+            (impulse) => {
+                if (deps.getPhase() !== 'playing') return;
+                // Dedup: if we already handled a collision locally, skip.
+                if (!impactCD.ready) return;
+
+                // Strip velocity component toward opponent
+                const imag = Math.sqrt(
+                    impulse[0] * impulse[0] + impulse[2] * impulse[2],
+                );
+                if (imag > 0.01) {
+                    const awayX = impulse[0] / imag;
+                    const awayZ = impulse[2] / imag;
+                    const towardComponent =
+                        deps.body.linearVelocity.x * -awayX +
+                        deps.body.linearVelocity.z * -awayZ;
+                    if (towardComponent > 0) {
+                        deps.body.linearVelocity.x += towardComponent * awayX;
+                        deps.body.linearVelocity.z += towardComponent * awayZ;
+                    }
+                }
+
+                applyKnockbackEffects(impulse);
+            },
+        );
+        publishKnockback = (impulse) => kb.publish(impulse);
+    }
+
+    // Collision handler
+    useOnCollisionStart(
+        ({ other }) => {
+            if (other === node) return;
+            if (!impactCD.ready) return;
+
+            const otherTransform = getComponent(other, Transform);
+            if (!otherTransform) return;
+
+            const otherPlayerId = 1 - deps.playerId;
+            const [otherVx, otherVz] = getPlayerVelocity(
+                deps.velocityStates as Parameters<typeof getPlayerVelocity>[0],
+                otherPlayerId,
+            );
+
+            // Online mode: correct physics solver's velocity bounce
+            if (deps.replicate) {
+                const cdx =
+                    otherTransform.localPosition.x -
+                    deps.transform.localPosition.x;
+                const cdz =
+                    otherTransform.localPosition.z -
+                    deps.transform.localPosition.z;
+                const clen = Math.sqrt(cdx * cdx + cdz * cdz);
+                if (clen > 0.01) {
+                    const nx = cdx / clen;
+                    const nz = cdz / clen;
+                    const myNormal = prePhysVx * nx + prePhysVz * nz;
+                    const otherNormal = otherVx * nx + otherVz * nz;
+                    const e = 0.2;
+                    const correctedNormal =
+                        ((1 - e) / 2) * myNormal +
+                        ((1 + e) / 2) * otherNormal;
+                    const solverNormal =
+                        deps.body.linearVelocity.x * nx +
+                        deps.body.linearVelocity.z * nz;
+                    deps.body.linearVelocity.x +=
+                        (correctedNormal - solverNormal) * nx;
+                    deps.body.linearVelocity.z +=
+                        (correctedNormal - solverNormal) * nz;
+                } else {
+                    deps.body.linearVelocity.x = 0;
+                    deps.body.linearVelocity.z = 0;
+                }
+            }
+
+            const approachSpeed = computeApproachSpeed(
+                deps.transform.localPosition.x,
+                deps.transform.localPosition.z,
+                otherTransform.localPosition.x,
+                otherTransform.localPosition.z,
+                otherVx,
+                otherVz,
+            );
+            const effectiveForce =
+                KNOCKBACK_BASE + approachSpeed * KNOCKBACK_VELOCITY_SCALE;
+
+            const [ix, iy, iz] = computeKnockback(
+                deps.transform.localPosition.x,
+                deps.transform.localPosition.z,
+                otherTransform.localPosition.x,
+                otherTransform.localPosition.z,
+                effectiveForce,
+            );
+
+            applyKnockbackEffects([ix, iy, iz]);
+
+            // Online: send other player's knockback
+            if (publishKnockback) {
+                const [myVx, myVz] = getPlayerVelocity(
+                    deps.velocityStates as Parameters<
+                        typeof getPlayerVelocity
+                    >[0],
+                    deps.playerId,
+                );
+                const myApproach = computeApproachSpeed(
+                    otherTransform.localPosition.x,
+                    otherTransform.localPosition.z,
+                    deps.transform.localPosition.x,
+                    deps.transform.localPosition.z,
+                    myVx,
+                    myVz,
+                );
+                const otherForce =
+                    KNOCKBACK_BASE + myApproach * KNOCKBACK_VELOCITY_SCALE;
+
+                const [ox, oy, oz] = computeKnockback(
+                    otherTransform.localPosition.x,
+                    otherTransform.localPosition.z,
+                    deps.transform.localPosition.x,
+                    deps.transform.localPosition.z,
+                    otherForce,
+                );
+
+                publishKnockback([ox, oy, oz]);
+            }
+        },
+        { filter: PlayerTag },
+    );
+}

--- a/demos/arena/src/nodes/mechanics.ts
+++ b/demos/arena/src/nodes/mechanics.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure utility functions for player mechanics calculations.
+ * These are stateless helpers used by both local and AI player nodes.
+ */
+
+/**
+ * Compute a knockback impulse vector from one position to another.
+ * The impulse points away from the other player and is scaled by the
+ * given magnitude. Includes an upward component for arc.
+ *
+ * @param selfX - Local player X position.
+ * @param selfZ - Local player Z position.
+ * @param otherX - Other player X position.
+ * @param otherZ - Other player Z position.
+ * @param magnitude - Impulse strength.
+ * @returns An `[x, y, z]` impulse vector.
+ *
+ * @example
+ * ```ts
+ * computeKnockback(0, 0, -1, 0, 8); // [8, 0, 0] — pushed right
+ * ```
+ */
+export function computeKnockback(
+    selfX: number,
+    selfZ: number,
+    otherX: number,
+    otherZ: number,
+    magnitude: number,
+): [number, number, number] {
+    const dx = selfX - otherX;
+    const dz = selfZ - otherZ;
+    const len = Math.sqrt(dx * dx + dz * dz);
+    if (len > 0) {
+        return [(dx / len) * magnitude, 0, (dz / len) * magnitude];
+    }
+    // Overlapping — push in arbitrary direction
+    return [magnitude, 0, 0];
+}
+
+/**
+ * Compute how fast a body is moving **toward** a target position.
+ * Returns the component of the attacker's velocity along the direction
+ * from attacker to target (clamped to >= 0 — retreating gives 0).
+ *
+ * @param selfX - Target player X.
+ * @param selfZ - Target player Z.
+ * @param otherX - Attacker X.
+ * @param otherZ - Attacker Z.
+ * @param otherVx - Attacker velocity X.
+ * @param otherVz - Attacker velocity Z.
+ * @returns Approach speed (>= 0). Zero for glancing or retreating movement.
+ *
+ * @example
+ * ```ts
+ * // Attacker at (-5,0) moving at (10,0) toward target at (0,0)
+ * computeApproachSpeed(0, 0, -5, 0, 10, 0); // 10
+ *
+ * // Attacker moving perpendicular — glancing blow
+ * computeApproachSpeed(0, 0, -5, 0, 0, 10); // 0
+ * ```
+ */
+export function computeApproachSpeed(
+    selfX: number,
+    selfZ: number,
+    otherX: number,
+    otherZ: number,
+    otherVx: number,
+    otherVz: number,
+): number {
+    const dx = selfX - otherX;
+    const dz = selfZ - otherZ;
+    const len = Math.sqrt(dx * dx + dz * dz);
+    if (len < 0.01) {
+        // Overlapping — use full velocity magnitude as approach speed
+        return Math.sqrt(otherVx * otherVx + otherVz * otherVz);
+    }
+    // Dot product of velocity with direction toward self, clamped to >= 0
+    const dot = (otherVx * dx + otherVz * dz) / len;
+    return Math.max(0, dot);
+}
+
+/**
+ * Compute the normalized dash direction from a movement input vector.
+ * If the input is zero-length, defaults to forward (negative Z).
+ *
+ * @param moveX - Horizontal input axis value.
+ * @param moveY - Vertical input axis value (W/up = positive).
+ * @returns A normalized `[x, z]` direction tuple in world space.
+ *
+ * @example
+ * ```ts
+ * computeDashDirection(1, 0);  // [1, 0]  — dash right
+ * computeDashDirection(0, 1);  // [0, -1] — dash forward
+ * computeDashDirection(0, 0);  // [0, -1] — default forward
+ * ```
+ */
+export function computeDashDirection(
+    moveX: number,
+    moveY: number,
+): [number, number] {
+    const len = Math.sqrt(moveX * moveX + moveY * moveY);
+    if (len > 0) {
+        return [moveX / len, -moveY / len]; // W = forward = -Z
+    }
+    return [0, -1]; // default forward
+}


### PR DESCRIPTION
## Description

Split the 840-line LocalPlayerNode into focused modules:

- **`mechanics.ts`** — pure utility functions (`computeKnockback`, `computeApproachSpeed`, `computeDashDirection`)
- **`dash.ts`** — dash timer, cooldown, direction state, and activation logic (`useDash`, `tryActivateDash`)
- **`indicatorRing.ts`** — indicator ring DOM creation, screen projection, cleanup (`useIndicatorRing`)
- **`knockback.ts`** — collision/knockback handler, online velocity correction, bidirectional knockback channel (`useKnockback`)

LocalPlayerNode becomes a thin orchestrator (~270 lines) that composes these pieces. All existing exports are re-exported for backward compatibility.

## Files Changed

- `demos/arena/src/nodes/LocalPlayerNode.ts` (refactored to orchestrator)
- `demos/arena/src/nodes/mechanics.ts` (new)
- `demos/arena/src/nodes/dash.ts` (new)
- `demos/arena/src/nodes/indicatorRing.ts` (new)
- `demos/arena/src/nodes/knockback.ts` (new)

## Test plan

- [x] Existing test imports still resolve (all symbols re-exported from LocalPlayerNode)
- [x] Verified test was already failing pre-refactor due to worktree module resolution (not a regression)
- [ ] Full test suite pass on CI with proper module resolution

Part of EPIC-026: Arena Demo Refactoring & Cleanup