### PR TITLE
TICKET-137: Extract shared trail particle emission logic

### DIFF
--- a/.claude/ticket-tracker/swimlanes/done/EPIC-026-arena-demo-refactoring-cleanup/TICKET-137-extract-shared-trail-particle-emission.md
+++ b/.claude/ticket-tracker/swimlanes/done/EPIC-026-arena-demo-refactoring-cleanup/TICKET-137-extract-shared-trail-particle-emission.md
@@ -1,7 +1,7 @@
 ---
 id: TICKET-137
 title: Extract shared trail particle emission logic
-status: in-progress
+status: done
 epic: EPIC-026
 created: 2026-03-14
 updated: 2026-03-14

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/TICKET-137-extract-shared-trail-particle-emission.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/TICKET-137-extract-shared-trail-particle-emission.md
@@ -1,10 +1,12 @@
 ---
 id: TICKET-137
 title: Extract shared trail particle emission logic
-status: todo
+status: in-progress
 epic: EPIC-026
 created: 2026-03-14
+updated: 2026-03-14
 priority: medium
+branch: ticket-137-extract-shared-trail-particle-emission
 ---
 
 ## Problem

--- a/demos/arena/src/nodes/LocalPlayerNode.ts
+++ b/demos/arena/src/nodes/LocalPlayerNode.ts
@@ -26,8 +26,6 @@ import {
     SPAWN_POSITIONS,
     DEATH_PLANE_Y,
     PLAYER_COLORS,
-    TRAIL_VELOCITY_REFERENCE,
-    TRAIL_BASE_INTERVAL,
 } from '../config/arena';
 import { KnockoutChannel } from '../config/channels';
 import {
@@ -49,6 +47,7 @@ import { useDash, tryActivateDash, DASH_SPEED, DASH_COOLDOWN } from './dash';
 import { useIndicatorRing } from './indicatorRing';
 import { useKnockback, KNOCKOUT_BURST_COUNT } from './knockback';
 import type { KnockbackDeps } from './knockback';
+import { createTrailEmitter } from './trailEmitter';
 
 // Re-export pure functions and constants so existing imports continue to work.
 export {
@@ -239,7 +238,7 @@ export function LocalPlayerNode({
         blending: 'additive',
         shrink: true,
     });
-    let trailAccum = 0;
+    const trail = createTrailEmitter();
 
     // --- Knockback ---
     useKnockback({
@@ -402,30 +401,12 @@ export function LocalPlayerNode({
         }
 
         // Trail particles
-        if (gameState.phase === 'playing') {
-            const vx = body.linearVelocity.x;
-            const vz = body.linearVelocity.z;
-            const vmag = Math.sqrt(vx * vx + vz * vz);
-            if (vmag > 0.1) {
-                trailAccum += dt;
-                const interval = Math.max(
-                    0.01,
-                    TRAIL_BASE_INTERVAL / (vmag / TRAIL_VELOCITY_REFERENCE),
-                );
-                if (trailAccum >= interval) {
-                    trailAccum = 0;
-                    trailBurst([
-                        root.position.x,
-                        root.position.y,
-                        root.position.z,
-                    ]);
-                }
-            } else {
-                trailAccum = 0;
-            }
-        } else {
-            trailAccum = 0;
-        }
+        const vx = body.linearVelocity.x;
+        const vz = body.linearVelocity.z;
+        const vmag = Math.sqrt(vx * vx + vz * vz);
+        trail.update(dt, vmag, gameState.phase === 'playing', () => {
+            trailBurst([root.position.x, root.position.y, root.position.z]);
+        });
 
         // Indicator ring
         ring.updatePosition(

--- a/demos/arena/src/nodes/RemotePlayerNode.ts
+++ b/demos/arena/src/nodes/RemotePlayerNode.ts
@@ -18,9 +18,8 @@ import {
     SPAWN_POSITIONS,
     DEATH_PLANE_Y,
     PLAYER_COLORS,
-    TRAIL_VELOCITY_REFERENCE,
-    TRAIL_BASE_INTERVAL,
 } from '../config/arena';
+import { createTrailEmitter } from './trailEmitter';
 import { ReplayStore, stagePlayerPosition, getReplayPosition } from '../replay';
 import { PlayerVelocityStore, setPlayerVelocity } from '../playerVelocity';
 
@@ -90,7 +89,7 @@ export function RemotePlayerNode({
         blending: 'additive',
         shrink: true,
     });
-    let trailAccum = 0;
+    const trail = createTrailEmitter();
     let prevTrailX = spawn[0];
     let prevTrailZ = spawn[2];
 
@@ -173,30 +172,20 @@ export function RemotePlayerNode({
 
     // Emit velocity-proportional trail particles during gameplay.
     useFrameUpdate((dt) => {
-        // Velocity-proportional trail particles during gameplay
-        if (gameState.phase === 'playing' && dt > 0) {
+        const active = gameState.phase === 'playing' && dt > 0;
+        if (active) {
             const cx = root.position.x;
             const cz = root.position.z;
             const vx = (cx - prevTrailX) / dt;
             const vz = (cz - prevTrailZ) / dt;
             const vmag = Math.sqrt(vx * vx + vz * vz);
-            if (vmag > 0.1) {
-                trailAccum += dt;
-                const interval = Math.max(
-                    0.01,
-                    TRAIL_BASE_INTERVAL / (vmag / TRAIL_VELOCITY_REFERENCE),
-                );
-                if (trailAccum >= interval) {
-                    trailAccum = 0;
-                    trailBurst([cx, root.position.y, cz]);
-                }
-            } else {
-                trailAccum = 0;
-            }
+            trail.update(dt, vmag, true, () => {
+                trailBurst([cx, root.position.y, cz]);
+            });
             prevTrailX = cx;
             prevTrailZ = cz;
         } else {
-            trailAccum = 0;
+            trail.update(0, 0, false, () => {});
         }
     });
 }

--- a/demos/arena/src/nodes/ReplayNode.ts
+++ b/demos/arena/src/nodes/ReplayNode.ts
@@ -22,7 +22,8 @@ import {
     getReplayHitIndices,
     getReplayCursorPos,
 } from '../replay';
-import { PLAYER_COLORS, TRAIL_BASE_INTERVAL } from '../config/arena';
+import { PLAYER_COLORS, TRAIL_VELOCITY_REFERENCE } from '../config/arena';
+import { createTrailEmitter } from './trailEmitter';
 import { triggerCameraShake } from './CameraRigNode';
 import { useShockwavePool, worldToScreen } from '../shockwave';
 import { useHitImpactPool } from '../hitImpact';
@@ -93,7 +94,7 @@ export function ReplayNode() {
 
     // Transition state
     let wasReplay = false;
-    let trailAccum = 0;
+    const replayTrail = createTrailEmitter();
     const hitBurstsEmitted = new Set<number>();
 
     useFrameUpdate((dt) => {
@@ -137,17 +138,21 @@ export function ReplayNode() {
                 }
             }
 
-            // Velocity-proportional trail particles
-            trailAccum += dt;
+            // Velocity-proportional trail particles — use replay speed
+            // scaled by TRAIL_VELOCITY_REFERENCE as effective vmag so the
+            // shared emitter produces the same interval as the old formula:
+            // TRAIL_BASE_INTERVAL / speed.
             const speed = getReplaySpeed(replay);
-            const trailInterval =
-                speed > 0 ? TRAIL_BASE_INTERVAL / speed : TRAIL_BASE_INTERVAL;
-            if (trailAccum >= trailInterval) {
-                trailAccum = 0;
+            const effectiveVmag = speed > 0
+                ? speed * TRAIL_VELOCITY_REFERENCE
+                : 0;
+            replayTrail.update(dt, effectiveVmag, true, () => {
                 for (let pid = 0; pid < 2; pid++) {
                     const vel = getReplayVelocity(replay, pid);
                     if (!vel) continue;
-                    const vmag = Math.sqrt(vel[0] * vel[0] + vel[2] * vel[2]);
+                    const vmag = Math.sqrt(
+                        vel[0] * vel[0] + vel[2] * vel[2],
+                    );
                     if (vmag > 0.1) {
                         const pos = getReplayPosition(replay, pid);
                         if (pos) {
@@ -155,9 +160,9 @@ export function ReplayNode() {
                         }
                     }
                 }
-            }
+            });
         } else {
-            trailAccum = 0;
+            replayTrail.update(0, 0, false, () => {});
             hitBurstsEmitted.clear();
         }
     });

--- a/demos/arena/src/nodes/trailEmitter.test.ts
+++ b/demos/arena/src/nodes/trailEmitter.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createTrailEmitter } from './trailEmitter';
+
+describe('createTrailEmitter', () => {
+    it('emits when velocity exceeds threshold and interval elapses', () => {
+        const emitter = createTrailEmitter();
+        const emit = vi.fn();
+
+        // vmag = 3 (matches TRAIL_VELOCITY_REFERENCE), interval = 0.015
+        emitter.update(0.02, 3, true, emit);
+        expect(emit).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not emit when velocity is below threshold', () => {
+        const emitter = createTrailEmitter();
+        const emit = vi.fn();
+
+        emitter.update(0.1, 0.05, true, emit);
+        expect(emit).not.toHaveBeenCalled();
+    });
+
+    it('does not emit when inactive', () => {
+        const emitter = createTrailEmitter();
+        const emit = vi.fn();
+
+        emitter.update(0.1, 10, false, emit);
+        expect(emit).not.toHaveBeenCalled();
+    });
+
+    it('resets accumulator when velocity drops below threshold', () => {
+        const emitter = createTrailEmitter();
+        const emit = vi.fn();
+
+        // Accumulate some time at high speed but not enough to emit
+        emitter.update(0.005, 3, true, emit);
+        expect(emit).not.toHaveBeenCalled();
+
+        // Drop below threshold — accumulator should reset
+        emitter.update(0.001, 0.01, true, emit);
+
+        // Now high speed again — should need full interval to emit
+        emitter.update(0.005, 3, true, emit);
+        expect(emit).not.toHaveBeenCalled();
+    });
+
+    it('resets accumulator when going inactive', () => {
+        const emitter = createTrailEmitter();
+        const emit = vi.fn();
+
+        // Accumulate some time
+        emitter.update(0.005, 3, true, emit);
+
+        // Go inactive — accumulator resets
+        emitter.update(0.001, 3, false, emit);
+
+        // Back to active — needs full interval again
+        emitter.update(0.005, 3, true, emit);
+        expect(emit).not.toHaveBeenCalled();
+    });
+
+    it('emits faster at higher velocities', () => {
+        const slowEmitter = createTrailEmitter();
+        const fastEmitter = createTrailEmitter();
+        const slowEmit = vi.fn();
+        const fastEmit = vi.fn();
+
+        // At vmag=1 (below reference), interval = 0.015 / (1/3) = 0.045
+        // At vmag=9 (3x reference), interval = 0.015 / (9/3) = 0.005
+        const dt = 0.01;
+        slowEmitter.update(dt, 1, true, slowEmit);
+        fastEmitter.update(dt, 9, true, fastEmit);
+
+        // Fast should emit (0.01 >= 0.005), slow should not (0.01 < 0.045)
+        expect(fastEmit).toHaveBeenCalledTimes(1);
+        expect(slowEmit).not.toHaveBeenCalled();
+    });
+
+    it('reset() clears the accumulator', () => {
+        const emitter = createTrailEmitter();
+        const emit = vi.fn();
+
+        // Accumulate some time
+        emitter.update(0.01, 3, true, emit);
+        emit.mockClear();
+
+        // Reset
+        emitter.reset();
+
+        // Should need a full interval again
+        emitter.update(0.005, 3, true, emit);
+        expect(emit).not.toHaveBeenCalled();
+    });
+
+    it('accumulates across multiple updates before emitting', () => {
+        const emitter = createTrailEmitter();
+        const emit = vi.fn();
+
+        // vmag=3, interval=0.015. Three small ticks.
+        emitter.update(0.004, 3, true, emit);
+        expect(emit).not.toHaveBeenCalled();
+
+        emitter.update(0.004, 3, true, emit);
+        expect(emit).not.toHaveBeenCalled();
+
+        emitter.update(0.004, 3, true, emit);
+        expect(emit).not.toHaveBeenCalled();
+
+        emitter.update(0.004, 3, true, emit);
+        expect(emit).toHaveBeenCalledTimes(1);
+    });
+});

--- a/demos/arena/src/nodes/trailEmitter.ts
+++ b/demos/arena/src/nodes/trailEmitter.ts
@@ -1,0 +1,90 @@
+import { TRAIL_BASE_INTERVAL, TRAIL_VELOCITY_REFERENCE } from '../config/arena';
+
+/**
+ * Minimum velocity magnitude (units/sec) required to emit trail particles.
+ * Below this threshold, the accumulator resets to avoid spurious bursts
+ * when the player is nearly stationary.
+ */
+const VELOCITY_THRESHOLD = 0.1;
+
+/**
+ * Minimum emission interval (seconds). Caps the emission rate even at
+ * very high velocities so the particle system isn't overwhelmed.
+ */
+const MIN_INTERVAL = 0.01;
+
+/**
+ * Encapsulates velocity-proportional trail particle emission logic.
+ *
+ * Three arena nodes (LocalPlayer, RemotePlayer, Replay) all share the same
+ * accumulator / interval / guard / reset pattern. This utility captures that
+ * shared behavior so each consumer only provides a velocity magnitude and an
+ * emit callback.
+ *
+ * @example
+ * ```ts
+ * const trail = createTrailEmitter();
+ *
+ * useFrameUpdate((dt) => {
+ *   const vmag = Math.sqrt(vx * vx + vz * vz);
+ *   trail.update(dt, vmag, isActive, () => {
+ *     burst([x, y, z]);
+ *   });
+ * });
+ * ```
+ */
+export interface TrailEmitter {
+    /**
+     * Advance the trail accumulator and emit when the interval elapses.
+     *
+     * @param dt - Frame delta time in seconds.
+     * @param vmag - Current velocity magnitude (units/sec).
+     * @param active - Whether trail emission is enabled (e.g. playing phase).
+     * @param emit - Callback invoked when a trail particle should be emitted.
+     */
+    update(dt: number, vmag: number, active: boolean, emit: () => void): void;
+
+    /** Reset the accumulator to zero (e.g. on round reset). */
+    reset(): void;
+}
+
+/**
+ * Create a new trail emitter with its own accumulator state.
+ *
+ * @returns A {@link TrailEmitter} instance.
+ *
+ * @example
+ * ```ts
+ * const trail = createTrailEmitter();
+ * trail.update(dt, vmag, true, () => burst(pos));
+ * ```
+ */
+export function createTrailEmitter(): TrailEmitter {
+    let accum = 0;
+
+    return {
+        update(dt: number, vmag: number, active: boolean, emit: () => void) {
+            if (!active) {
+                accum = 0;
+                return;
+            }
+            if (vmag > VELOCITY_THRESHOLD) {
+                accum += dt;
+                const interval = Math.max(
+                    MIN_INTERVAL,
+                    TRAIL_BASE_INTERVAL / (vmag / TRAIL_VELOCITY_REFERENCE),
+                );
+                if (accum >= interval) {
+                    accum = 0;
+                    emit();
+                }
+            } else {
+                accum = 0;
+            }
+        },
+
+        reset() {
+            accum = 0;
+        },
+    };
+}


### PR DESCRIPTION
## Summary

- Extracted `createTrailEmitter()` factory in `demos/arena/src/nodes/trailEmitter.ts` that encapsulates the velocity-proportional trail accumulator, interval calculation, vmag guard, and reset-on-idle logic
- Updated `LocalPlayerNode.ts`, `RemotePlayerNode.ts`, and `ReplayNode.ts` to use the shared utility instead of duplicating the pattern
- Added comprehensive unit tests (8 tests) covering emission timing, threshold guards, accumulator resets, and velocity-proportional scaling

## Test plan

- [x] `trailEmitter.test.ts` — 8 tests passing
- [x] `ReplayNode.test.ts` — existing test passing
- [x] `LocalPlayerNode.test.ts` / `RemotePlayerNode.test.ts` — pre-existing failures (unresolved `@pulse-ts/core` in worktree), unrelated to changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)