### PR TITLE
TICKET-139: Centralize particle burst and sound configs

### DIFF
--- a/.claude/ticket-tracker/swimlanes/done/EPIC-026-arena-demo-refactoring-cleanup/TICKET-139-centralize-particle-burst-sound-configs.md
+++ b/.claude/ticket-tracker/swimlanes/done/EPIC-026-arena-demo-refactoring-cleanup/TICKET-139-centralize-particle-burst-sound-configs.md
@@ -1,7 +1,7 @@
 ---
 id: TICKET-139
 title: Centralize particle burst and sound configs
-status: in-progress
+status: done
 epic: EPIC-026
 created: 2026-03-14
 priority: medium

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-139-centralize-particle-burst-sound-configs.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-139-centralize-particle-burst-sound-configs.md
@@ -1,7 +1,7 @@
 ---
 id: TICKET-139
 title: Centralize particle burst and sound configs
-status: todo
+status: in-progress
 epic: EPIC-026
 created: 2026-03-14
 priority: medium

--- a/demos/arena/src/config/particles.ts
+++ b/demos/arena/src/config/particles.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared particle burst configurations used across player nodes and replay.
+ *
+ * Each config omits `color` so callers can supply a per-player or fixed color
+ * when invoking `useParticleBurst`.
+ */
+
+/**
+ * Trail burst — small particles emitted behind a moving player.
+ *
+ * @example
+ * ```ts
+ * const burst = useParticleBurst({ ...TRAIL_BURST_CONFIG, color: playerColor });
+ * ```
+ */
+export const TRAIL_BURST_CONFIG = {
+    count: 8,
+    lifetime: 1.0,
+    speed: [0.2, 0.8] as [number, number],
+    gravity: 1,
+    size: 0.4,
+    blending: 'additive' as const,
+    shrink: true,
+};
+
+/**
+ * Impact burst — white particles emitted at a collision point.
+ *
+ * @example
+ * ```ts
+ * const burst = useParticleBurst({ ...IMPACT_BURST_CONFIG, color: 0xffffff });
+ * ```
+ */
+export const IMPACT_BURST_CONFIG = {
+    count: 16,
+    lifetime: 0.4,
+    color: 0xffffff,
+    speed: [1, 3] as [number, number],
+    gravity: 6,
+    size: 0.3,
+    blending: 'additive' as const,
+};

--- a/demos/arena/src/config/sounds.ts
+++ b/demos/arena/src/config/sounds.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared sound effect configurations used across player nodes and replay.
+ */
+
+/**
+ * Impact sound — short percussive hit played on player collision.
+ *
+ * @example
+ * ```ts
+ * const sfx = useSound('tone', IMPACT_SOUND_CONFIG);
+ * ```
+ */
+export const IMPACT_SOUND_CONFIG = {
+    wave: 'square' as const,
+    frequency: [300, 100] as [number, number],
+    duration: 0.1,
+    gain: 0.15,
+};

--- a/demos/arena/src/nodes/LocalPlayerNode.ts
+++ b/demos/arena/src/nodes/LocalPlayerNode.ts
@@ -28,6 +28,8 @@ import {
     PLAYER_COLORS,
 } from '../config/arena';
 import { KnockoutChannel } from '../config/channels';
+import { TRAIL_BURST_CONFIG, IMPACT_BURST_CONFIG } from '../config/particles';
+import { IMPACT_SOUND_CONFIG } from '../config/sounds';
 import {
     ReplayStore,
     stagePlayerPosition,
@@ -199,23 +201,12 @@ export function LocalPlayerNode({
         group: 'sfx',
     });
     const impactSfx = useSound('tone', {
-        wave: 'square',
-        frequency: [300, 100],
-        duration: 0.1,
-        gain: 0.15,
+        ...IMPACT_SOUND_CONFIG,
         group: 'sfx',
     });
 
     // --- Particle effects ---
-    const impactBurst = useParticleBurst({
-        count: 16,
-        lifetime: 0.4,
-        color: 0xffffff,
-        speed: [1, 3],
-        gravity: 6,
-        size: 0.3,
-        blending: 'additive',
-    });
+    const impactBurst = useParticleBurst(IMPACT_BURST_CONFIG);
 
     const knockoutBurst = useParticleBurst({
         count: KNOCKOUT_BURST_COUNT,
@@ -229,14 +220,8 @@ export function LocalPlayerNode({
     });
 
     const trailBurst = useParticleBurst({
-        count: 8,
-        lifetime: 1.0,
+        ...TRAIL_BURST_CONFIG,
         color: meshColor,
-        speed: [0.2, 0.8],
-        gravity: 1,
-        size: 0.4,
-        blending: 'additive',
-        shrink: true,
     });
     const trail = createTrailEmitter();
 

--- a/demos/arena/src/nodes/LocalPlayerNode.ts
+++ b/demos/arena/src/nodes/LocalPlayerNode.ts
@@ -8,10 +8,7 @@ import {
     Transform,
 } from '@pulse-ts/core';
 import { useAxis2D, useAction } from '@pulse-ts/input';
-import {
-    useRigidBody,
-    useSphereCollider,
-} from '@pulse-ts/physics';
+import { useRigidBody, useSphereCollider } from '@pulse-ts/physics';
 import {
     useMesh,
     useThreeContext,
@@ -30,19 +27,12 @@ import {
 import { KnockoutChannel } from '../config/channels';
 import { TRAIL_BURST_CONFIG, IMPACT_BURST_CONFIG } from '../config/particles';
 import { IMPACT_SOUND_CONFIG } from '../config/sounds';
-import {
-    ReplayStore,
-    stagePlayerPosition,
-    getReplayPosition,
-} from '../replay';
+import { ReplayStore, stagePlayerPosition, getReplayPosition } from '../replay';
 import { useShockwavePool, worldToScreen } from '../shockwave';
 import { useHitImpactPool } from '../hitImpact';
 import { setPlayerPosition } from '../ai/playerPositions';
 import { DashCooldownStore } from '../dashCooldown';
-import {
-    PlayerVelocityStore,
-    updatePlayerVelocity,
-} from '../playerVelocity';
+import { PlayerVelocityStore, updatePlayerVelocity } from '../playerVelocity';
 
 // Extracted modules
 import { useDash, tryActivateDash, DASH_SPEED, DASH_COOLDOWN } from './dash';
@@ -176,7 +166,10 @@ export function LocalPlayerNode({
     });
 
     // --- Indicator ring ---
-    const ring = useIndicatorRing(!!replicate || !!showIndicatorRing, PLAYER_RADIUS);
+    const ring = useIndicatorRing(
+        !!replicate || !!showIndicatorRing,
+        PLAYER_RADIUS,
+    );
 
     // --- Shockwave / hit impact pools ---
     const shockwavePool = useShockwavePool();
@@ -317,12 +310,8 @@ export function LocalPlayerNode({
         const dashActionState = getDash();
 
         // Dash activation
-        tryActivateDash(
-            dash,
-            move.x,
-            move.y,
-            dashActionState.pressed,
-            () => dashSfx.play(),
+        tryActivateDash(dash, move.x, move.y, dashActionState.pressed, () =>
+            dashSfx.play(),
         );
 
         if (dash.timer.active) {
@@ -394,9 +383,6 @@ export function LocalPlayerNode({
         });
 
         // Indicator ring
-        ring.updatePosition(
-            root.position,
-            gameState.phase === 'playing',
-        );
+        ring.updatePosition(root.position, gameState.phase === 'playing');
     });
 }

--- a/demos/arena/src/nodes/RemotePlayerNode.ts
+++ b/demos/arena/src/nodes/RemotePlayerNode.ts
@@ -11,6 +11,7 @@ import { useRigidBody, useSphereCollider } from '@pulse-ts/physics';
 import { useMesh } from '@pulse-ts/three';
 import { useParticleBurst } from '@pulse-ts/effects';
 import { useRemoteEntity } from '@pulse-ts/network';
+import { TRAIL_BURST_CONFIG } from '../config/particles';
 import { PlayerTag } from '../components/PlayerTag';
 import { GameCtx } from '../contexts';
 import { PLAYER_RADIUS } from './LocalPlayerNode';
@@ -80,14 +81,8 @@ export function RemotePlayerNode({
 
     // Velocity-proportional trail burst — emitted when moving fast
     const trailBurst = useParticleBurst({
-        count: 8,
-        lifetime: 1.0,
+        ...TRAIL_BURST_CONFIG,
         color: PLAYER_COLORS[remotePlayerId],
-        speed: [0.2, 0.8],
-        gravity: 1,
-        size: 0.4,
-        blending: 'additive',
-        shrink: true,
     });
     const trail = createTrailEmitter();
     let prevTrailX = spawn[0];

--- a/demos/arena/src/nodes/ReplayNode.ts
+++ b/demos/arena/src/nodes/ReplayNode.ts
@@ -20,6 +20,8 @@ import {
     getReplaySpeed,
 } from '../replay';
 import { PLAYER_COLORS, TRAIL_VELOCITY_REFERENCE } from '../config/arena';
+import { TRAIL_BURST_CONFIG, IMPACT_BURST_CONFIG } from '../config/particles';
+import { IMPACT_SOUND_CONFIG } from '../config/sounds';
 import { createTrailEmitter } from './trailEmitter';
 import { triggerCameraShake } from './CameraRigNode';
 import { useShockwavePool, worldToScreen } from '../shockwave';
@@ -39,48 +41,23 @@ export function ReplayNode() {
     const hitImpactPool = useHitImpactPool();
 
     // Hit impact burst — white particles at the collision point
-    const hitImpactBurst = useParticleBurst({
-        count: 16,
-        lifetime: 0.4,
-        color: 0xffffff,
-        speed: [1, 3],
-        gravity: 6,
-        size: 0.3,
-        blending: 'additive',
-    });
+    const hitImpactBurst = useParticleBurst(IMPACT_BURST_CONFIG);
 
     // Velocity-proportional trail bursts — one per player
     const p0Color = gameState.playerHexColors?.[0] ?? PLAYER_COLORS[0];
     const p1Color = gameState.playerHexColors?.[1] ?? PLAYER_COLORS[1];
     const trailBurst0 = useParticleBurst({
-        count: 8,
-        lifetime: 1.0,
+        ...TRAIL_BURST_CONFIG,
         color: p0Color,
-        speed: [0.2, 0.8],
-        gravity: 1,
-        size: 0.4,
-        blending: 'additive',
-        shrink: true,
     });
     const trailBurst1 = useParticleBurst({
-        count: 8,
-        lifetime: 1.0,
+        ...TRAIL_BURST_CONFIG,
         color: p1Color,
-        speed: [0.2, 0.8],
-        gravity: 1,
-        size: 0.4,
-        blending: 'additive',
-        shrink: true,
     });
     const trailBursts = [trailBurst0, trailBurst1];
 
     // Impact sound — matches the live collision sound from LocalPlayerNode
-    const impactSfx = useSound('tone', {
-        wave: 'square',
-        frequency: [300, 100],
-        duration: 0.1,
-        gain: 0.15,
-    });
+    const impactSfx = useSound('tone', IMPACT_SOUND_CONFIG);
 
     // Scale particle time to match replay speed (slow-motion)
     const world = useWorld();

--- a/demos/arena/src/nodes/ReplayNode.ts
+++ b/demos/arena/src/nodes/ReplayNode.ts
@@ -1,9 +1,4 @@
-import {
-    useFrameUpdate,
-    useContext,
-    useWorld,
-    useStore,
-} from '@pulse-ts/core';
+import { useFrameUpdate, useContext, useWorld, useStore } from '@pulse-ts/core';
 import { useThreeContext } from '@pulse-ts/three';
 import {
     useParticleBurst,


### PR DESCRIPTION
## Summary
- Created `config/particles.ts` with `TRAIL_BURST_CONFIG` and `IMPACT_BURST_CONFIG` shared constants
- Created `config/sounds.ts` with `IMPACT_SOUND_CONFIG` shared constant
- Updated `LocalPlayerNode`, `RemotePlayerNode`, and `ReplayNode` to import and spread shared configs instead of duplicating inline values

## Test plan
- [ ] Verify trail particles appear correctly for local, remote, and replay players
- [ ] Verify impact particles fire on collision in gameplay and replay
- [ ] Verify impact sound plays on collision in gameplay and replay

🤖 Generated with [Claude Code](https://claude.com/claude-code)