### PR TITLE
TICKET-138: Extract shared collision VFX trigger

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-138-extract-shared-collision-vfx-trigger.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-138-extract-shared-collision-vfx-trigger.md
@@ -1,7 +1,7 @@
 ---
 id: TICKET-138
 title: Extract shared collision VFX trigger
-status: in-progress
+status: done
 epic: EPIC-026
 created: 2026-03-14
 updated: 2026-03-14

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-138-extract-shared-collision-vfx-trigger.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-138-extract-shared-collision-vfx-trigger.md
@@ -1,10 +1,12 @@
 ---
 id: TICKET-138
 title: Extract shared collision VFX trigger
-status: todo
+status: in-progress
 epic: EPIC-026
 created: 2026-03-14
+updated: 2026-03-14
 priority: medium
+branch: ticket-138-extract-shared-collision-vfx-trigger
 ---
 
 ## Problem

--- a/demos/arena/src/nodes/LocalPlayerNode.ts
+++ b/demos/arena/src/nodes/LocalPlayerNode.ts
@@ -46,7 +46,7 @@ import {
 import { useDash, tryActivateDash, DASH_SPEED, DASH_COOLDOWN } from './dash';
 import { useIndicatorRing } from './indicatorRing';
 import { useKnockback, KNOCKOUT_BURST_COUNT } from './knockback';
-import type { KnockbackDeps } from './knockback';
+import type { CollisionEffectsDeps } from './collisionEffects';
 import { createTrailEmitter } from './trailEmitter';
 
 // Re-export pure functions and constants so existing imports continue to work.
@@ -247,11 +247,13 @@ export function LocalPlayerNode({
         dash,
         playerId,
         replicate: !!replicate,
-        impactSfx,
-        impactBurst,
-        shockwavePool,
-        hitImpactPool,
-        threeCamera: threeCamera as KnockbackDeps['threeCamera'],
+        collisionEffects: {
+            impactBurst,
+            impactSfx,
+            shockwavePool,
+            hitImpactPool,
+            camera: threeCamera as CollisionEffectsDeps['camera'],
+        },
         replay,
         velocityStates: velocities.states,
         playerRadius: PLAYER_RADIUS,

--- a/demos/arena/src/nodes/ReplayNode.ts
+++ b/demos/arena/src/nodes/ReplayNode.ts
@@ -21,9 +21,9 @@ import {
 } from '../replay';
 import { PLAYER_COLORS, TRAIL_VELOCITY_REFERENCE } from '../config/arena';
 import { createTrailEmitter } from './trailEmitter';
-import { triggerCameraShake } from './CameraRigNode';
-import { useShockwavePool, worldToScreen } from '../shockwave';
+import { useShockwavePool } from '../shockwave';
 import { useHitImpactPool } from '../hitImpact';
+import { triggerCollisionEffects } from './collisionEffects';
 
 /**
  * Drives replay playback and VFX (particles, camera shake, sounds) during
@@ -124,12 +124,18 @@ export function ReplayNode() {
                         const mx = (p0[0] + p1[0]) / 2;
                         const my = (p0[1] + p1[1]) / 2;
                         const mz = (p0[2] + p1[2]) / 2;
-                        hitImpactBurst([mx, my, mz]);
-                        triggerCameraShake(0.4, 0.3);
-                        const [su, sv] = worldToScreen(mx, my, mz, camera);
-                        shockwavePool.trigger({ centerX: su, centerY: sv });
-                        hitImpactPool.trigger({ worldX: mx, worldZ: mz });
-                        impactSfx.play();
+                        triggerCollisionEffects(
+                            [mx, my, mz],
+                            {
+                                impactBurst: hitImpactBurst,
+                                impactSfx,
+                                shockwavePool,
+                                hitImpactPool,
+                                camera,
+                            },
+                            0.4,
+                            0.3,
+                        );
                     }
                     hitBurstsEmitted.add(hitIdx);
                 }

--- a/demos/arena/src/nodes/collisionEffects.test.ts
+++ b/demos/arena/src/nodes/collisionEffects.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { triggerCollisionEffects } from './collisionEffects';
+import type { CollisionEffectsDeps } from './collisionEffects';
+
+// Mock CameraRigNode's triggerCameraShake
+vi.mock('./CameraRigNode', () => ({
+    triggerCameraShake: vi.fn(),
+}));
+
+// Mock worldToScreen — returns fixed screen UVs
+vi.mock('../shockwave', () => ({
+    worldToScreen: vi.fn(() => [0.5, 0.6]),
+}));
+
+import { triggerCameraShake } from './CameraRigNode';
+import { worldToScreen } from '../shockwave';
+
+function makeDeps(): CollisionEffectsDeps {
+    return {
+        impactBurst: vi.fn(),
+        impactSfx: { play: vi.fn() },
+        shockwavePool: { trigger: vi.fn() },
+        hitImpactPool: { trigger: vi.fn() },
+        camera: {} as CollisionEffectsDeps['camera'],
+    };
+}
+
+describe('triggerCollisionEffects', () => {
+    it('calls all VFX and audio callbacks in sequence', () => {
+        const deps = makeDeps();
+        const pos: [number, number, number] = [1, 2, 3];
+
+        triggerCollisionEffects(pos, deps);
+
+        expect(deps.impactBurst).toHaveBeenCalledWith(pos);
+        expect(triggerCameraShake).toHaveBeenCalledWith(0.3, 0.2);
+        expect(worldToScreen).toHaveBeenCalledWith(1, 2, 3, deps.camera);
+        expect(deps.shockwavePool.trigger).toHaveBeenCalledWith({
+            centerX: 0.5,
+            centerY: 0.6,
+        });
+        expect(deps.hitImpactPool.trigger).toHaveBeenCalledWith({
+            worldX: 1,
+            worldZ: 3,
+        });
+        expect(deps.impactSfx.play).toHaveBeenCalled();
+    });
+
+    it('forwards custom shake intensity and duration', () => {
+        const deps = makeDeps();
+
+        triggerCollisionEffects([0, 0, 0], deps, 0.4, 0.3);
+
+        expect(triggerCameraShake).toHaveBeenCalledWith(0.4, 0.3);
+    });
+});

--- a/demos/arena/src/nodes/collisionEffects.ts
+++ b/demos/arena/src/nodes/collisionEffects.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared collision VFX trigger — encapsulates the visual and audio burst
+ * that fires on every player-vs-player collision (live or replay).
+ */
+
+import { triggerCameraShake } from './CameraRigNode';
+import { worldToScreen } from '../shockwave';
+
+/** Dependencies for {@link triggerCollisionEffects}. */
+export interface CollisionEffectsDeps {
+    /** Particle burst callback — spawns white particles at the given position. */
+    impactBurst: (pos: [number, number, number]) => void;
+    /** Impact sound effect. */
+    impactSfx: { play: () => void };
+    /** Shockwave post-process pool. */
+    shockwavePool: { trigger: (opts: { centerX: number; centerY: number }) => void };
+    /** Hit impact pool (ground ring). */
+    hitImpactPool: { trigger: (opts: { worldX: number; worldZ: number }) => void };
+    /** Three.js camera for world-to-screen projection. */
+    camera: Parameters<typeof worldToScreen>[3];
+}
+
+/**
+ * Fire the full collision VFX + audio burst at a world-space position.
+ *
+ * Sequence:
+ * 1. Spawn white particle burst at `worldPos`
+ * 2. Trigger camera shake
+ * 3. Project position to screen-space UV
+ * 4. Trigger shockwave pool
+ * 5. Trigger hit impact pool
+ * 6. Play impact sound
+ *
+ * @param worldPos - `[x, y, z]` world-space impact position.
+ * @param deps - Pool handles, camera, and sound effect.
+ * @param shakeIntensity - Camera shake intensity (default 0.3).
+ * @param shakeDuration - Camera shake duration in seconds (default 0.2).
+ *
+ * @example
+ * ```ts
+ * triggerCollisionEffects([mx, my, mz], {
+ *     impactBurst, impactSfx, shockwavePool, hitImpactPool, camera,
+ * });
+ * ```
+ */
+export function triggerCollisionEffects(
+    worldPos: [number, number, number],
+    deps: CollisionEffectsDeps,
+    shakeIntensity = 0.3,
+    shakeDuration = 0.2,
+): void {
+    deps.impactBurst(worldPos);
+    triggerCameraShake(shakeIntensity, shakeDuration);
+
+    const [su, sv] = worldToScreen(
+        worldPos[0],
+        worldPos[1],
+        worldPos[2],
+        deps.camera,
+    );
+    deps.shockwavePool.trigger({ centerX: su, centerY: sv });
+    deps.hitImpactPool.trigger({ worldX: worldPos[0], worldZ: worldPos[2] });
+
+    deps.impactSfx.play();
+}

--- a/demos/arena/src/nodes/knockback.ts
+++ b/demos/arena/src/nodes/knockback.ts
@@ -14,11 +14,11 @@ import {
 import { useOnCollisionStart } from '@pulse-ts/physics';
 import { useChannel } from '@pulse-ts/network';
 import { PlayerTag } from '../components/PlayerTag';
-import { triggerCameraShake } from './CameraRigNode';
 import { markHit } from '../replay';
-import { worldToScreen } from '../shockwave';
 import { getPlayerVelocity } from '../playerVelocity';
 import { computeKnockback, computeApproachSpeed } from './mechanics';
+import { triggerCollisionEffects } from './collisionEffects';
+import type { CollisionEffectsDeps } from './collisionEffects';
 import type { DashState } from './dash';
 
 /** Minimum knockback applied even when both players have zero closing speed. */
@@ -50,16 +50,8 @@ export interface KnockbackDeps {
     playerId: number;
     /** Whether online replication is enabled. */
     replicate: boolean;
-    /** Impact sound effect. */
-    impactSfx: { play: () => void };
-    /** Impact particle burst function. */
-    impactBurst: (pos: [number, number, number]) => void;
-    /** Shockwave pool trigger. */
-    shockwavePool: { trigger: (opts: { centerX: number; centerY: number }) => void };
-    /** Hit impact pool trigger. */
-    hitImpactPool: { trigger: (opts: { worldX: number; worldZ: number }) => void };
-    /** Three.js camera for screen projection. */
-    threeCamera: { projectionMatrix: unknown; matrixWorldInverse: unknown };
+    /** Collision VFX dependencies (particles, pools, camera, sound). */
+    collisionEffects: CollisionEffectsDeps;
     /** Replay state. */
     replay: unknown;
     /** Velocity states map. */
@@ -102,8 +94,6 @@ export function useKnockback(deps: KnockbackDeps): void {
         // Cancel any active dash and reset cooldown
         deps.dash.timer.cancel();
         deps.dash.cooldown.trigger();
-
-        deps.impactSfx.play();
         impactCD.trigger();
 
         // Particle burst at surface facing hit direction
@@ -118,19 +108,12 @@ export function useKnockback(deps: KnockbackDeps): void {
             const surfZ =
                 deps.transform.localPosition.z +
                 (hz / hLen) * deps.playerRadius;
-            deps.impactBurst([surfX, surfY, surfZ]);
-
-            const [su, sv] = worldToScreen(
-                surfX,
-                surfY,
-                surfZ,
-                deps.threeCamera as Parameters<typeof worldToScreen>[3],
+            triggerCollisionEffects(
+                [surfX, surfY, surfZ],
+                deps.collisionEffects,
             );
-            deps.shockwavePool.trigger({ centerX: su, centerY: sv });
-            deps.hitImpactPool.trigger({ worldX: surfX, worldZ: surfZ });
         }
 
-        triggerCameraShake(0.3, 0.2);
         markHit(deps.replay as Parameters<typeof markHit>[0]);
     };
 


### PR DESCRIPTION
## Summary

- Extracted duplicated collision VFX sequence (particle burst, camera shake, shockwave pool, hit impact pool, impact sound) into a shared `triggerCollisionEffects()` helper in `collisionEffects.ts`
- Updated `knockback.ts` to use the shared helper via a `CollisionEffectsDeps` interface instead of individual pool/sound fields
- Updated `ReplayNode.ts` to use the shared helper, removing direct VFX orchestration

## Test plan

- [x] New unit tests for `triggerCollisionEffects` pass (2 tests)
- [x] Existing `ReplayNode.test.ts` passes
- [ ] Verify live collision VFX still fire correctly in arena demo
- [ ] Verify replay hit VFX still fire correctly in arena demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)