### PR TITLE
TICKET-150: Replace scene traversal with store reads for player positions

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-150-replace-scene-traversal-with-store.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-150-replace-scene-traversal-with-store.md
@@ -1,7 +1,7 @@
 ---
 id: TICKET-150
 title: Replace scene traversal with store reads for player positions
-status: in-progress
+status: done
 epic: EPIC-026
 created: 2026-03-14
 priority: low

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-150-replace-scene-traversal-with-store.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-150-replace-scene-traversal-with-store.md
@@ -1,7 +1,7 @@
 ---
 id: TICKET-150
 title: Replace scene traversal with store reads for player positions
-status: todo
+status: in-progress
 epic: EPIC-026
 created: 2026-03-14
 priority: low

--- a/demos/arena/src/nodes/AtmosphericDustNode.ts
+++ b/demos/arena/src/nodes/AtmosphericDustNode.ts
@@ -1,8 +1,8 @@
 import { useContext, useFrameUpdate, curlNoise2D } from '@pulse-ts/core';
 import { useParticleBurst } from '@pulse-ts/effects';
-import { useThreeContext } from '@pulse-ts/three';
 import { ARENA_RADIUS } from '../config/arena';
 import { GameCtx, type RoundPhase } from '../contexts';
+import { getPlayerPosition } from '../ai/playerPositions';
 import { isMobile } from '@pulse-ts/platform';
 import {
     useHitImpactPool,
@@ -95,7 +95,6 @@ const DUST_LIFETIME = 999999;
  * Dust is cleared and re-spawned at replay start and round start.
  */
 export function AtmosphericDustNode() {
-    const { scene } = useThreeContext();
     const gameState = useContext(GameCtx);
     const hitPool = useHitImpactPool();
     const mobile = isMobile();
@@ -353,17 +352,15 @@ export function AtmosphericDustNode() {
             }
         }
 
-        // Find current player positions
+        // Read current player positions from shared store
         const currentPlayers: { x: number; z: number }[] = [];
-        scene.traverse((child) => {
-            const p = child.position;
-            if (child.type === 'Group' && child.parent !== scene) {
-                const xzDistSq = p.x * p.x + p.z * p.z;
-                if (xzDistSq < ARENA_RADIUS * ARENA_RADIUS * 4) {
-                    currentPlayers.push({ x: p.x, z: p.z });
-                }
+        for (let i = 0; i < 2; i++) {
+            const [px, , pz] = getPlayerPosition(i);
+            const xzDistSq = px * px + pz * pz;
+            if (xzDistSq < ARENA_RADIUS * ARENA_RADIUS * 4) {
+                currentPlayers.push({ x: px, z: pz });
             }
-        });
+        }
 
         // Decay existing trail entries and remove fully faded ones
         for (let i = trail.length - 1; i >= 0; i--) {

--- a/demos/arena/src/nodes/PlatformNode.ts
+++ b/demos/arena/src/nodes/PlatformNode.ts
@@ -3,7 +3,6 @@ import { useRigidBody, useCylinderCollider } from '@pulse-ts/physics';
 import {
     useMesh,
     useCustomMesh,
-    useThreeContext,
 } from '@pulse-ts/three';
 import { useAnimate } from '@pulse-ts/effects';
 import * as THREE from 'three';
@@ -41,6 +40,7 @@ import {
     RIPPLE_INTENSITY,
 } from './platform/shaderPatch';
 import { applyPlatformShaderPatch } from './platform/shaderPatch';
+import { getPlayerPosition } from '../ai/playerPositions';
 
 // Re-export all public symbols so existing imports from './PlatformNode' continue to work
 export {
@@ -237,9 +237,6 @@ export function PlatformNode() {
     let rippleTimer = 0;
     let nextRipple = 0;
 
-    // Scene access for finding player positions
-    const { scene } = useThreeContext();
-
     // Animation — pulsing glow on the ring
     const pulse = useAnimate({
         wave: 'sine',
@@ -317,15 +314,13 @@ export function PlatformNode() {
 
         // --- Wake trail tracking ---
         const currentPlayers: { x: number; z: number }[] = [];
-        scene.traverse((child: THREE.Object3D) => {
-            if (child.type === 'Group' && child.parent !== scene) {
-                const p = child.position;
-                const xzDistSq = p.x * p.x + p.z * p.z;
-                if (xzDistSq < ARENA_RADIUS * ARENA_RADIUS * 4) {
-                    currentPlayers.push({ x: p.x, z: p.z });
-                }
+        for (let i = 0; i < 2; i++) {
+            const [px, , pz] = getPlayerPosition(i);
+            const xzDistSq = px * px + pz * pz;
+            if (xzDistSq < ARENA_RADIUS * ARENA_RADIUS * 4) {
+                currentPlayers.push({ x: px, z: pz });
             }
-        });
+        }
 
         // Decay existing trail entries and remove fully faded ones
         for (let i = wakeTrail.length - 1; i >= 0; i--) {

--- a/demos/arena/src/nodes/PlatformNode.ts
+++ b/demos/arena/src/nodes/PlatformNode.ts
@@ -1,9 +1,6 @@
 import { useComponent, Transform, useFrameUpdate } from '@pulse-ts/core';
 import { useRigidBody, useCylinderCollider } from '@pulse-ts/physics';
-import {
-    useMesh,
-    useCustomMesh,
-} from '@pulse-ts/three';
+import { useMesh, useCustomMesh } from '@pulse-ts/three';
 import { useAnimate } from '@pulse-ts/effects';
 import * as THREE from 'three';
 import { ARENA_RADIUS } from '../config/arena';
@@ -35,10 +32,7 @@ import {
     WAKE_MAX_TRAIL,
 } from './platform/wake';
 import type { WakeTrailPoint } from './platform/wake';
-import {
-    createPlatformShaderUniforms,
-    RIPPLE_INTENSITY,
-} from './platform/shaderPatch';
+import { createPlatformShaderUniforms } from './platform/shaderPatch';
 import { applyPlatformShaderPatch } from './platform/shaderPatch';
 import { getPlayerPosition } from '../ai/playerPositions';
 


### PR DESCRIPTION
## Summary
- Replaced `scene.traverse()` calls in `PlatformNode.ts` and `AtmosphericDustNode.ts` with direct `getPlayerPosition()` reads from the shared player positions store
- Removed `useThreeContext` imports that were only used for scene traversal
- Cleaned up unused `RIPPLE_INTENSITY` import in PlatformNode

## Test plan
- [ ] Verify wake trail tracking still follows player positions on the platform
- [ ] Verify atmospheric dust still reacts to player proximity
- [ ] Confirm no regressions in arena demo visual effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)