### PR TITLE
TICKET-146: Remove redundant replay accessor functions

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-146-remove-redundant-replay-accessors.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-146-remove-redundant-replay-accessors.md
@@ -1,7 +1,7 @@
 ---
 id: TICKET-146
 title: Remove redundant replay accessor functions
-status: in-progress
+status: done
 epic: EPIC-026
 created: 2026-03-14
 priority: low

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-146-remove-redundant-replay-accessors.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-146-remove-redundant-replay-accessors.md
@@ -1,7 +1,7 @@
 ---
 id: TICKET-146
 title: Remove redundant replay accessor functions
-status: todo
+status: in-progress
 epic: EPIC-026
 created: 2026-03-14
 priority: low

--- a/demos/arena/src/nodes/CameraRigNode.ts
+++ b/demos/arena/src/nodes/CameraRigNode.ts
@@ -9,13 +9,9 @@ import { useThreeContext } from '@pulse-ts/three';
 import { GameCtx } from '../contexts';
 import {
     ReplayStore,
-    isReplayActive,
     getReplayPosition,
-    getReplayScorer,
-    getReplayKnockedOut,
     getReplayHitProximity,
     getReplayPastHit,
-    hasReplayHit,
 } from '../replay';
 import { SPAWN_POSITIONS } from '../config/arena';
 
@@ -173,8 +169,8 @@ export function CameraRigNode() {
             targetLookX = p2Spawn[0];
             targetLookY = p2Spawn[1] + INTRO_LOOK_Y_OFFSET;
             targetLookZ = p2Spawn[2];
-        } else if (isReplayActive(replay)) {
-            const hitProx = hasReplayHit(replay)
+        } else if (replay.active) {
+            const hitProx = replay.hadRealHit
                 ? getReplayHitProximity(replay)
                 : 0;
 
@@ -225,14 +221,14 @@ export function CameraRigNode() {
                 }
             } else {
                 // Normal replay: follow scorer before hit, loser after hit
-                const scorerId = getReplayScorer(replay);
-                const knockedOutId = getReplayKnockedOut(replay);
-                const pastHit = hasReplayHit(replay)
+                const scorerId = replay.scorer;
+                const knockedOutId = replay.knockedOut;
+                const pastHit = replay.hadRealHit
                     ? getReplayPastHit(replay)
                     : 0;
 
                 let followId: number;
-                if (!hasReplayHit(replay) || pastHit > 0) {
+                if (!replay.hadRealHit || pastHit > 0) {
                     followId = knockedOutId;
                 } else {
                     followId = scorerId;

--- a/demos/arena/src/nodes/DashCooldownHudNode.test.ts
+++ b/demos/arena/src/nodes/DashCooldownHudNode.test.ts
@@ -18,7 +18,7 @@ jest.mock('../dashCooldown', () => ({
 }));
 
 jest.mock('../replay', () => ({
-    isReplayActive: jest.fn(() => false),
+    ReplayStore: {},
 }));
 
 import { DashCooldownHudNode } from './DashCooldownHudNode';

--- a/demos/arena/src/nodes/DashCooldownHudNode.tsx
+++ b/demos/arena/src/nodes/DashCooldownHudNode.tsx
@@ -4,7 +4,7 @@ import { useOverlay, Column } from '@pulse-ts/dom';
 import { isMobile } from '@pulse-ts/platform';
 import { GameCtx } from '../contexts';
 import { DashCooldownStore } from '../dashCooldown';
-import { ReplayStore, isReplayActive } from '../replay';
+import { ReplayStore } from '../replay';
 
 export interface DashCooldownHudNodeProps {
     /** Local player ID for reading dash cooldown progress. @defaultValue `0` */
@@ -87,7 +87,7 @@ export function DashCooldownHudNode(
     useFrameUpdate(() => {
         const hidden =
             gameState.phase === 'intro' ||
-            (gameState.phase === 'replay' && isReplayActive(replay));
+            (gameState.phase === 'replay' && replay.active);
 
         if (hidden) {
             wrapperOpacity = '0';

--- a/demos/arena/src/nodes/GameManagerNode.ts
+++ b/demos/arena/src/nodes/GameManagerNode.ts
@@ -25,7 +25,6 @@ import {
 import {
     ReplayStore,
     startReplay,
-    isReplayActive,
     endReplay,
     commitFrame,
     clearRecording,
@@ -285,7 +284,7 @@ export function GameManagerNode(props?: Readonly<GameManagerNodeProps>) {
 
         switch (gameState.phase) {
             case 'replay': {
-                if (!isReplayActive(replay)) {
+                if (!replay.active) {
                     const isNonHostOnline = props?.online && !props?.isHost;
 
                     if (isNonHostOnline && !receivedOutcome) {

--- a/demos/arena/src/nodes/ReplayNode.ts
+++ b/demos/arena/src/nodes/ReplayNode.ts
@@ -15,12 +15,9 @@ import { GameCtx } from '../contexts';
 import {
     ReplayStore,
     advanceReplay,
-    isReplayActive,
     getReplayPosition,
     getReplayVelocity,
     getReplaySpeed,
-    getReplayHitIndices,
-    getReplayCursorPos,
 } from '../replay';
 import { PLAYER_COLORS, TRAIL_BASE_INTERVAL } from '../config/arena';
 import { triggerCameraShake } from './CameraRigNode';
@@ -97,7 +94,7 @@ export function ReplayNode() {
     const hitBurstsEmitted = new Set<number>();
 
     useFrameUpdate((dt) => {
-        const isReplay = gameState.phase === 'replay' && isReplayActive(replay);
+        const isReplay = gameState.phase === 'replay' && replay.active;
 
         // Detect transition into replay — clear lingering particles
         if (isReplay && !wasReplay) {
@@ -115,8 +112,8 @@ export function ReplayNode() {
             advanceReplay(replay, dt);
 
             // Hit impact bursts + camera shake at each collision moment
-            const cursor = getReplayCursorPos(replay);
-            for (const hitIdx of getReplayHitIndices(replay)) {
+            const cursor = replay.cursorPos;
+            for (const hitIdx of replay.hitIndices) {
                 if (hitBurstsEmitted.has(hitIdx)) continue;
                 // Fire when cursor is within 1 frame of the hit
                 if (Math.abs(cursor - hitIdx) < 1) {

--- a/demos/arena/src/nodes/ReplayOverlayNode.ts
+++ b/demos/arena/src/nodes/ReplayOverlayNode.ts
@@ -8,8 +8,6 @@ import { useThreeContext } from '@pulse-ts/three';
 import { GameCtx } from '../contexts';
 import {
     ReplayStore,
-    isReplayActive,
-    hasReplayHit,
 } from '../replay';
 
 /** Height of each cinematic letterbox bar as a CSS value. */
@@ -153,7 +151,7 @@ export function ReplayOverlayNode() {
     let selfKoMessagePicked = false;
 
     useFrameUpdate((dt) => {
-        const isReplay = gameState.phase === 'replay' && isReplayActive(replay);
+        const isReplay = gameState.phase === 'replay' && replay.active;
 
         // Detect transition into replay — trigger dark flash
         if (isReplay && !wasReplay) {
@@ -181,7 +179,7 @@ export function ReplayOverlayNode() {
 
         // Self-KO text — per-letter bobbing animation
         if (isReplay) {
-            if (!hasReplayHit(replay)) {
+            if (!replay.hadRealHit) {
                 if (!selfKoMessagePicked) {
                     const msg =
                         SELF_KO_MESSAGES[

--- a/demos/arena/src/nodes/ScoreHudNode.test.ts
+++ b/demos/arena/src/nodes/ScoreHudNode.test.ts
@@ -39,7 +39,6 @@ jest.mock(
 
 jest.mock('../replay', () => ({
     ReplayStore: {},
-    isReplayActive: jest.fn(() => false),
 }));
 
 import { ScoreHudNode, SCORE_COLORS } from './ScoreHudNode';

--- a/demos/arena/src/nodes/ScoreHudNode.tsx
+++ b/demos/arena/src/nodes/ScoreHudNode.tsx
@@ -3,7 +3,7 @@ import { useThreeContext } from '@pulse-ts/three';
 import { useOverlay, Row } from '@pulse-ts/dom';
 import { useAnimate } from '@pulse-ts/effects';
 import { GameCtx } from '../contexts';
-import { ReplayStore, isReplayActive } from '../replay';
+import { ReplayStore } from '../replay';
 import { ANIM_EASING } from '../overlayAnimations';
 
 /** Player colors: P1 = teal, P2 = coral. */
@@ -194,7 +194,7 @@ export function ScoreHudNode() {
     }
 
     useFrameUpdate(() => {
-        const inReplay = gameState.phase === 'replay' && isReplayActive(replay);
+        const inReplay = gameState.phase === 'replay' && replay.active;
         const hidden = gameState.phase === 'intro' || inReplay;
         border.style.opacity = hidden ? '0' : '1';
 

--- a/demos/arena/src/nodes/TouchControlsNode.ts
+++ b/demos/arena/src/nodes/TouchControlsNode.ts
@@ -7,7 +7,7 @@ import {
 import { useInput, useVirtualJoystick } from '@pulse-ts/input';
 import { isMobile } from '@pulse-ts/platform';
 import { GameCtx } from '../contexts';
-import { ReplayStore, isReplayActive } from '../replay';
+import { ReplayStore } from '../replay';
 import { DashCooldownStore } from '../dashCooldown';
 
 /** Dash button radius in pixels. */
@@ -173,7 +173,7 @@ export function TouchControlsNode(props?: Readonly<TouchControlsNodeProps>) {
     useFrameUpdate(() => {
         const hidden =
             gameState.phase === 'intro' ||
-            (gameState.phase === 'replay' && isReplayActive(replay));
+            (gameState.phase === 'replay' && replay.active);
         const vis = hidden ? 'hidden' : 'visible';
         joystick.setVisible(!hidden);
         dashBtn.style.visibility = vis;

--- a/demos/arena/src/replay.test.ts
+++ b/demos/arena/src/replay.test.ts
@@ -5,17 +5,11 @@ import {
     startReplay,
     advanceReplay,
     getReplayPosition,
-    isReplayActive,
-    getReplayScorer,
-    getReplayKnockedOut,
     getReplayHitProximity,
     getReplayPastHit,
     getSpeedAtFrame,
     getReplayVelocity,
     getReplaySpeed,
-    getReplayHitIndices,
-    getReplayCursorPos,
-    hasReplayHit,
     endReplay,
     clearRecording,
     resetReplay,
@@ -33,9 +27,9 @@ describe('recordFrame + startReplay', () => {
         recordFrame(s, 7, 8, 9, 10, 11, 12);
 
         startReplay(s, 1);
-        expect(isReplayActive(s)).toBe(true);
-        expect(getReplayScorer(s)).toBe(0);
-        expect(getReplayKnockedOut(s)).toBe(1);
+        expect(s.active).toBe(true);
+        expect(s.scorer).toBe(0);
+        expect(s.knockedOut).toBe(1);
 
         const p0 = getReplayPosition(s, 0);
         expect(p0).not.toBeNull();
@@ -78,7 +72,7 @@ describe('advanceReplay', () => {
             steps++;
         }
         expect(playing).toBe(false);
-        expect(isReplayActive(s)).toBe(false);
+        expect(s.active).toBe(false);
     });
 
     it('returns false when no replay is active', () => {
@@ -216,11 +210,11 @@ describe('clearRecording', () => {
         recordFrame(s, 0, 0, 0, 0, 0, 0);
         recordFrame(s, 1, 0, 0, 0, 0, 0);
         startReplay(s, 1);
-        expect(isReplayActive(s)).toBe(true);
+        expect(s.active).toBe(true);
 
         clearRecording(s);
 
-        expect(isReplayActive(s)).toBe(true);
+        expect(s.active).toBe(true);
 
         endReplay(s);
         recordFrame(s, 5, 0, 0, 0, 0, 0);
@@ -231,13 +225,13 @@ describe('clearRecording', () => {
     });
 });
 
-describe('hasReplayHit', () => {
+describe('hadRealHit', () => {
     it('returns false when no hit was marked', () => {
         const s = create();
         recordFrame(s, 0, 0, 0, 0, 0, 0);
         recordFrame(s, 1, 0, 0, 0, 0, 0);
         startReplay(s, 1);
-        expect(hasReplayHit(s)).toBe(false);
+        expect(s.hadRealHit).toBe(false);
     });
 
     it('returns true when markHit was called before replay', () => {
@@ -246,7 +240,7 @@ describe('hasReplayHit', () => {
         markHit(s);
         recordFrame(s, 1, 0, 0, 0, 0, 0);
         startReplay(s, 1);
-        expect(hasReplayHit(s)).toBe(true);
+        expect(s.hadRealHit).toBe(true);
     });
 
     it('returns false after endReplay', () => {
@@ -255,9 +249,9 @@ describe('hasReplayHit', () => {
         markHit(s);
         recordFrame(s, 1, 0, 0, 0, 0, 0);
         startReplay(s, 1);
-        expect(hasReplayHit(s)).toBe(true);
+        expect(s.hadRealHit).toBe(true);
         endReplay(s);
-        expect(hasReplayHit(s)).toBe(false);
+        expect(s.hadRealHit).toBe(false);
     });
 
     it('self-KO has no slow-motion (normal speed throughout)', () => {
@@ -266,18 +260,18 @@ describe('hasReplayHit', () => {
             recordFrame(s, i, 0, 0, 0, 0, 0);
         }
         startReplay(s, 1);
-        expect(hasReplayHit(s)).toBe(false);
+        expect(s.hadRealHit).toBe(false);
         expect(getReplaySpeed(s)).toBeCloseTo(0.8);
         expect(getReplayHitProximity(s)).toBe(0);
     });
 });
 
-describe('getReplayHitIndices (multi-hit)', () => {
+describe('hitIndices (multi-hit)', () => {
     it('returns empty array when no hits recorded', () => {
         const s = create();
         recordFrame(s, 0, 0, 0, 0, 0, 0);
         startReplay(s, 1);
-        expect(getReplayHitIndices(s)).toEqual([]);
+        expect(s.hitIndices).toEqual([]);
     });
 
     it('tracks a single hit', () => {
@@ -286,7 +280,7 @@ describe('getReplayHitIndices (multi-hit)', () => {
         markHit(s);
         recordFrame(s, 1, 0, 0, 0, 0, 0);
         startReplay(s, 1);
-        expect(getReplayHitIndices(s)).toEqual([1]);
+        expect(s.hitIndices).toEqual([1]);
     });
 
     it('tracks multiple hits at different frames', () => {
@@ -296,7 +290,7 @@ describe('getReplayHitIndices (multi-hit)', () => {
             if (i === 5 || i === 12) markHit(s);
         }
         startReplay(s, 1);
-        const indices = getReplayHitIndices(s);
+        const indices = s.hitIndices;
         expect(indices.length).toBe(2);
         expect(indices[0]).toBe(6);
         expect(indices[1]).toBe(13);
@@ -309,14 +303,14 @@ describe('getReplayHitIndices (multi-hit)', () => {
             if (i === 5 || i === 60) markHit(s);
         }
         startReplay(s, 1);
-        const indices = getReplayHitIndices(s);
-        expect(getSpeedAtFrame(indices as number[], indices[0])).toBeCloseTo(
+        const indices = s.hitIndices;
+        expect(getSpeedAtFrame(indices, indices[0])).toBeCloseTo(
             0.15,
         );
-        expect(getSpeedAtFrame(indices as number[], indices[1])).toBeCloseTo(
+        expect(getSpeedAtFrame(indices, indices[1])).toBeCloseTo(
             0.15,
         );
-        expect(getSpeedAtFrame(indices as number[], 35)).toBeCloseTo(0.8);
+        expect(getSpeedAtFrame(indices, 35)).toBeCloseTo(0.8);
     });
 
     it('cleared after endReplay', () => {
@@ -325,19 +319,19 @@ describe('getReplayHitIndices (multi-hit)', () => {
         markHit(s);
         recordFrame(s, 1, 0, 0, 0, 0, 0);
         startReplay(s, 1);
-        expect(getReplayHitIndices(s).length).toBe(1);
+        expect(s.hitIndices.length).toBe(1);
         endReplay(s);
-        expect(getReplayHitIndices(s)).toEqual([]);
+        expect(s.hitIndices).toEqual([]);
     });
 });
 
-describe('getReplayCursorPos', () => {
+describe('cursorPos', () => {
     it('starts at 0', () => {
         const s = create();
         recordFrame(s, 0, 0, 0, 0, 0, 0);
         recordFrame(s, 1, 0, 0, 0, 0, 0);
         startReplay(s, 1);
-        expect(getReplayCursorPos(s)).toBe(0);
+        expect(s.cursorPos).toBe(0);
     });
 
     it('advances with advanceReplay', () => {
@@ -345,7 +339,7 @@ describe('getReplayCursorPos', () => {
         for (let i = 0; i < 20; i++) recordFrame(s, i, 0, 0, 0, 0, 0);
         startReplay(s, 1);
         advanceReplay(s, 0.1);
-        expect(getReplayCursorPos(s)).toBeGreaterThan(0);
+        expect(s.cursorPos).toBeGreaterThan(0);
     });
 });
 
@@ -354,9 +348,9 @@ describe('endReplay / resetReplay', () => {
         const s = create();
         recordFrame(s, 0, 0, 0, 0, 0, 0);
         startReplay(s, 0);
-        expect(isReplayActive(s)).toBe(true);
+        expect(s.active).toBe(true);
         endReplay(s);
-        expect(isReplayActive(s)).toBe(false);
+        expect(s.active).toBe(false);
     });
 
     it('resetReplay clears all state', () => {
@@ -365,8 +359,8 @@ describe('endReplay / resetReplay', () => {
         markHit(s);
         startReplay(s, 0);
         resetReplay(s);
-        expect(isReplayActive(s)).toBe(false);
+        expect(s.active).toBe(false);
         expect(getReplayPosition(s, 0)).toBeNull();
-        expect(getReplayScorer(s)).toBe(-1);
+        expect(s.scorer).toBe(-1);
     });
 });

--- a/demos/arena/src/replay.ts
+++ b/demos/arena/src/replay.ts
@@ -322,26 +322,6 @@ export function getReplayPosition(
     ];
 }
 
-/** Whether a replay is currently active.
- * @param state - The replay state from the store.
- */
-export function isReplayActive(state: ReplayState): boolean {
-    return state.active;
-}
-
-/** The player ID of the scorer (winner) in the current/last replay.
- * @param state - The replay state from the store.
- */
-export function getReplayScorer(state: ReplayState): number {
-    return state.scorer;
-}
-
-/** The player ID that was knocked out in the current/last replay.
- * @param state - The replay state from the store.
- */
-export function getReplayKnockedOut(state: ReplayState): number {
-    return state.knockedOut;
-}
 
 /**
  * How close the current cursor is to the hit moment (0 = far, 1 = at hit).
@@ -417,33 +397,6 @@ export function getReplaySpeed(state: ReplayState): number {
         Math.min(state.cursorPos, state.playbackFrames.length - 1),
     );
     return getSpeedAtFrame(state.hitIndices, frameIdx);
-}
-
-/**
- * Whether the current replay had a real collision hit.
- *
- * @param state - The replay state from the store.
- */
-export function hasReplayHit(state: ReplayState): boolean {
-    return state.hadRealHit;
-}
-
-/**
- * Get the frame indices of all recorded collision hits in the current replay.
- *
- * @param state - The replay state from the store.
- */
-export function getReplayHitIndices(state: ReplayState): readonly number[] {
-    return state.hitIndices;
-}
-
-/**
- * Get the current replay cursor position (floating-point frame index).
- *
- * @param state - The replay state from the store.
- */
-export function getReplayCursorPos(state: ReplayState): number {
-    return state.cursorPos;
 }
 
 /** End the replay and release the playback buffer.


### PR DESCRIPTION
## Summary
- Removed 6 trivial one-liner accessor functions from `replay.ts`: `isReplayActive`, `getReplayScorer`, `getReplayKnockedOut`, `hasReplayHit`, `getReplayHitIndices`, `getReplayCursorPos`
- Updated all consumers (CameraRigNode, ReplayNode, ReplayOverlayNode, GameManagerNode, DashCooldownHudNode, ScoreHudNode, TouchControlsNode) to use direct property access on `ReplayState`
- Updated tests and mocks to match

## Test plan
- [ ] Verify `replay.test.ts` passes
- [ ] Verify no remaining references to removed functions
- [ ] Verify replay playback works in arena demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)