### PR TITLE
TICKET-147: Narrow GameCtx and extract knockout detection

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-147-narrow-game-ctx-extract-knockout.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-147-narrow-game-ctx-extract-knockout.md
@@ -1,7 +1,7 @@
 ---
 id: TICKET-147
 title: Narrow GameCtx and extract knockout detection
-status: todo
+status: in-progress
 epic: EPIC-026
 created: 2026-03-14
 priority: low

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-147-narrow-game-ctx-extract-knockout.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-147-narrow-game-ctx-extract-knockout.md
@@ -1,7 +1,7 @@
 ---
 id: TICKET-147
 title: Narrow GameCtx and extract knockout detection
-status: in-progress
+status: done
 epic: EPIC-026
 created: 2026-03-14
 priority: low

--- a/demos/arena/src/contexts.ts
+++ b/demos/arena/src/contexts.ts
@@ -10,6 +10,19 @@ export type RoundPhase =
     | 'countdown'
     | 'match_over';
 
+/**
+ * Static player configuration set once at game creation.
+ * Used in solo mode to customize labels and colors per player.
+ */
+export interface PlayerConfig {
+    /** Custom player labels (e.g. `['You', 'Brawler']` in solo mode). */
+    labels: [string, string];
+    /** Custom player CSS colors (e.g. personality accent for P2 in solo mode). */
+    colors: [string, string];
+    /** Custom player hex colors for particle effects (e.g. `[0x48c9b0, 0xe74c3c]`). */
+    hexColors: [number, number];
+}
+
 /** Game state — scores, round lifecycle, and match status. */
 export interface GameState {
     scores: [number, number];
@@ -22,20 +35,12 @@ export interface GameState {
     countdownValue: number;
     /** Player ID of the match winner (-1 = no winner yet). */
     matchWinner: number;
-    /** Pending knockout: player ID that just fell off (-1 = none). */
-    pendingKnockout: number;
-    /** Second pending knockout slot for tie detection (-1 = none). */
-    pendingKnockout2: number;
     /** Whether the current round ended in a tie (both players fell simultaneously). */
     isTie: boolean;
     /** Whether the game is currently paused. */
     paused: boolean;
-    /** Custom player labels (e.g. `['You', 'Brawler']` in solo mode). */
-    playerLabels?: [string, string];
-    /** Custom player CSS colors (e.g. personality accent for P2 in solo mode). */
-    playerColors?: [string, string];
-    /** Custom player hex colors for particle effects (e.g. `[0x48c9b0, 0xe74c3c]`). */
-    playerHexColors?: [number, number];
+    /** Static player config for solo mode (labels, colors). Undefined in multiplayer. */
+    playerConfig?: PlayerConfig;
 }
 
 /** Shared game state context — read/written by GameManagerNode, read by HUD. */

--- a/demos/arena/src/knockoutQueue.ts
+++ b/demos/arena/src/knockoutQueue.ts
@@ -1,0 +1,29 @@
+import { defineStore } from '@pulse-ts/core';
+
+/**
+ * World-scoped store for the pending knockout queue.
+ *
+ * Written by `LocalPlayerNode` / `RemotePlayerNode` when a player falls off
+ * the arena, consumed by `GameManagerNode` to drive the scoring state machine.
+ *
+ * Two slots allow simultaneous knockouts (tie detection):
+ * - `pending`: first player ID that fell (-1 = none)
+ * - `pending2`: second player ID for tie detection (-1 = none)
+ *
+ * @example
+ * ```ts
+ * import { useStore } from '@pulse-ts/core';
+ * import { KnockoutQueueStore } from '../knockoutQueue';
+ *
+ * const [ko] = useStore(KnockoutQueueStore);
+ * if (ko.pending >= 0) {
+ *     // A player has been knocked out
+ * }
+ * ```
+ */
+export const KnockoutQueueStore = defineStore('knockoutQueue', () => ({
+    /** Player ID that just fell off (-1 = none). */
+    pending: -1,
+    /** Second pending knockout slot for tie detection (-1 = none). */
+    pending2: -1,
+}));

--- a/demos/arena/src/nodes/ArenaNode.ts
+++ b/demos/arena/src/nodes/ArenaNode.ts
@@ -118,18 +118,17 @@ export function ArenaNode(props?: Readonly<ArenaNodeProps>) {
         lastKnockedOut: -1,
         countdownValue: -1,
         matchWinner: -1,
-        pendingKnockout: -1,
-        pendingKnockout2: -1,
         isTie: false,
         paused: false,
-        playerLabels: props?.aiPersonality
-            ? ['You', props.aiPersonality.name]
-            : undefined,
-        playerColors: props?.aiPersonality
-            ? [color(0x48c9b0).rgb, color(props.aiPersonality.color).rgb]
-            : undefined,
-        playerHexColors: props?.aiPersonality
-            ? [0x48c9b0, props.aiPersonality.color]
+        playerConfig: props?.aiPersonality
+            ? {
+                  labels: ['You', props.aiPersonality.name],
+                  colors: [
+                      color(0x48c9b0).rgb,
+                      color(props.aiPersonality.color).rgb,
+                  ],
+                  hexColors: [0x48c9b0, props.aiPersonality.color],
+              }
             : undefined,
     };
     useProvideContext(GameCtx, gameState);

--- a/demos/arena/src/nodes/GameManagerNode.ts
+++ b/demos/arena/src/nodes/GameManagerNode.ts
@@ -30,6 +30,7 @@ import {
     clearRecording,
 } from '../replay';
 import { DashCooldownStore } from '../dashCooldown';
+import { KnockoutQueueStore } from '../knockoutQueue';
 import { useHitImpactPool } from '../hitImpact';
 import { resetPlayerPositions } from '../ai/playerPositions';
 import { resetCameraShake } from './CameraRigNode';
@@ -87,6 +88,7 @@ export function GameManagerNode(props?: Readonly<GameManagerNodeProps>) {
     const [cooldown] = useStore(DashCooldownStore);
     const hitImpactPool = useHitImpactPool();
     const [velocities] = useStore(PlayerVelocityStore);
+    const [ko] = useStore(KnockoutQueueStore);
 
     // Clear non-store module state from any previous game session.
     clearRecording(replay);
@@ -130,11 +132,11 @@ export function GameManagerNode(props?: Readonly<GameManagerNodeProps>) {
 
     if (props?.online) {
         useChannel(KnockoutChannel, (knockedOutPlayerId) => {
-            // Use pendingKnockout2 if the first slot is already occupied
-            if (gameState.pendingKnockout >= 0) {
-                gameState.pendingKnockout2 = knockedOutPlayerId;
+            // Use pending2 if the first slot is already occupied
+            if (ko.pending >= 0) {
+                ko.pending2 = knockedOutPlayerId;
             } else {
-                gameState.pendingKnockout = knockedOutPlayerId;
+                ko.pending = knockedOutPlayerId;
             }
         });
 
@@ -241,16 +243,16 @@ export function GameManagerNode(props?: Readonly<GameManagerNodeProps>) {
 
     useFixedUpdate(() => {
         // --- Tie window knockout detection ---
-        if (gameState.pendingKnockout >= 0 && gameState.phase === 'playing') {
+        if (ko.pending >= 0 && gameState.phase === 'playing') {
             if (tieWindowCounter < 0) {
-                firstKnockedOut = gameState.pendingKnockout;
-                gameState.pendingKnockout = -1;
+                firstKnockedOut = ko.pending;
+                ko.pending = -1;
                 tieWindowCounter = TIE_WINDOW_FRAMES;
 
-                if (gameState.pendingKnockout2 >= 0) {
+                if (ko.pending2 >= 0) {
                     gameState.isTie = true;
                     gameState.lastKnockedOut = firstKnockedOut;
-                    gameState.pendingKnockout2 = -1;
+                    ko.pending2 = -1;
                     tieWindowCounter = -1;
                     startReplay(replay, firstKnockedOut);
                     gameState.phase = 'replay';
@@ -262,14 +264,11 @@ export function GameManagerNode(props?: Readonly<GameManagerNodeProps>) {
         if (tieWindowCounter > 0 && gameState.phase === 'playing') {
             tieWindowCounter--;
 
-            if (
-                gameState.pendingKnockout >= 0 ||
-                gameState.pendingKnockout2 >= 0
-            ) {
+            if (ko.pending >= 0 || ko.pending2 >= 0) {
                 gameState.isTie = true;
                 gameState.lastKnockedOut = firstKnockedOut;
-                gameState.pendingKnockout = -1;
-                gameState.pendingKnockout2 = -1;
+                ko.pending = -1;
+                ko.pending2 = -1;
                 tieWindowCounter = -1;
                 startReplay(replay, firstKnockedOut);
                 gameState.phase = 'replay';
@@ -323,7 +322,7 @@ export function GameManagerNode(props?: Readonly<GameManagerNodeProps>) {
                     gameState.phase = 'resetting';
                     resetPauseTimer.reset();
                     gameState.isTie = false;
-                    gameState.pendingKnockout2 = -1;
+                    ko.pending2 = -1;
                     firstKnockedOut = -1;
                     clearRecording(replay);
                 }

--- a/demos/arena/src/nodes/IntroOverlayNode.test.ts
+++ b/demos/arena/src/nodes/IntroOverlayNode.test.ts
@@ -17,7 +17,6 @@ let mockGameState = {
     lastKnockedOut: -1,
     countdownValue: -1,
     matchWinner: -1,
-    pendingKnockout: -1,
     paused: false,
 };
 
@@ -119,7 +118,6 @@ beforeEach(() => {
         lastKnockedOut: -1,
         countdownValue: -1,
         matchWinner: -1,
-        pendingKnockout: -1,
         paused: false,
     };
     mockContainer.innerHTML = '';

--- a/demos/arena/src/nodes/KnockoutOverlayNode.tsx
+++ b/demos/arena/src/nodes/KnockoutOverlayNode.tsx
@@ -83,9 +83,10 @@ export function KnockoutOverlayNode() {
             } else {
                 const scorer = 1 - gameState.lastKnockedOut;
                 const label =
-                    gameState.playerLabels?.[scorer] ?? PLAYER_LABELS[scorer];
+                    gameState.playerConfig?.labels[scorer] ??
+                    PLAYER_LABELS[scorer];
                 textContent = `${label} scored!`;
-                const customColor = gameState.playerColors?.[scorer];
+                const customColor = gameState.playerConfig?.colors[scorer];
                 flashBg = customColor
                     ? customColor
                           .replace('rgb(', 'rgba(')

--- a/demos/arena/src/nodes/LocalPlayerNode.ts
+++ b/demos/arena/src/nodes/LocalPlayerNode.ts
@@ -32,6 +32,7 @@ import { useShockwavePool, worldToScreen } from '../shockwave';
 import { useHitImpactPool } from '../hitImpact';
 import { setPlayerPosition } from '../ai/playerPositions';
 import { DashCooldownStore } from '../dashCooldown';
+import { KnockoutQueueStore } from '../knockoutQueue';
 import { PlayerVelocityStore, updatePlayerVelocity } from '../playerVelocity';
 
 // Extracted modules
@@ -103,6 +104,7 @@ export function LocalPlayerNode({
     const [replay] = useStore(ReplayStore);
     const [cooldown] = useStore(DashCooldownStore);
     const [velocities] = useStore(PlayerVelocityStore);
+    const [ko] = useStore(KnockoutQueueStore);
 
     useStableId(`player-${playerId}`);
     useComponent(PlayerTag);
@@ -337,10 +339,10 @@ export function LocalPlayerNode({
                 transform.localPosition.z,
             ]);
             deathSfx.play();
-            if (gameState.pendingKnockout >= 0) {
-                gameState.pendingKnockout2 = playerId;
+            if (ko.pending >= 0) {
+                ko.pending2 = playerId;
             } else {
-                gameState.pendingKnockout = playerId;
+                ko.pending = playerId;
             }
             if (publishKnockout) publishKnockout(playerId);
             knockedOut = true;

--- a/demos/arena/src/nodes/MatchOverOverlayNode.tsx
+++ b/demos/arena/src/nodes/MatchOverOverlayNode.tsx
@@ -249,7 +249,7 @@ export function MatchOverOverlayNode(
 
         if (visible) {
             const winner = gameState.matchWinner;
-            const labels = gameState.playerLabels;
+            const labels = gameState.playerConfig?.labels;
 
             if (labels) {
                 // Solo mode --- Victory (teal) or Defeat (red)

--- a/demos/arena/src/nodes/MenuSceneNode.ts
+++ b/demos/arena/src/nodes/MenuSceneNode.ts
@@ -81,8 +81,6 @@ export function MenuSceneNode() {
         lastKnockedOut: -1,
         countdownValue: -1,
         matchWinner: -1,
-        pendingKnockout: -1,
-        pendingKnockout2: -1,
         isTie: false,
         paused: false,
     };

--- a/demos/arena/src/nodes/RemotePlayerNode.ts
+++ b/demos/arena/src/nodes/RemotePlayerNode.ts
@@ -23,6 +23,7 @@ import {
 import { createTrailEmitter } from './trailEmitter';
 import { ReplayStore, stagePlayerPosition, getReplayPosition } from '../replay';
 import { PlayerVelocityStore, setPlayerVelocity } from '../playerVelocity';
+import { KnockoutQueueStore } from '../knockoutQueue';
 
 export interface RemotePlayerNodeProps {
     remotePlayerId: number;
@@ -45,6 +46,7 @@ export function RemotePlayerNode({
 
     const [replay] = useStore(ReplayStore);
     const [velocities] = useStore(PlayerVelocityStore);
+    const [ko] = useStore(KnockoutQueueStore);
 
     // Network identity + consumer replication via one-liner hook.
     // Higher lambda = snappier tracking. Default 12 is too sluggish for a
@@ -141,7 +143,7 @@ export function RemotePlayerNode({
         useFixedUpdate(() => {
             if (gameState.phase !== 'playing') return;
             if (transform.localPosition.y < DEATH_PLANE_Y) {
-                gameState.pendingKnockout = remotePlayerId;
+                ko.pending = remotePlayerId;
             }
         });
     }

--- a/demos/arena/src/nodes/ReplayNode.ts
+++ b/demos/arena/src/nodes/ReplayNode.ts
@@ -39,8 +39,8 @@ export function ReplayNode() {
     const hitImpactBurst = useParticleBurst(IMPACT_BURST_CONFIG);
 
     // Velocity-proportional trail bursts — one per player
-    const p0Color = gameState.playerHexColors?.[0] ?? PLAYER_COLORS[0];
-    const p1Color = gameState.playerHexColors?.[1] ?? PLAYER_COLORS[1];
+    const p0Color = gameState.playerConfig?.hexColors[0] ?? PLAYER_COLORS[0];
+    const p1Color = gameState.playerConfig?.hexColors[1] ?? PLAYER_COLORS[1];
     const trailBurst0 = useParticleBurst({
         ...TRAIL_BURST_CONFIG,
         color: p0Color,

--- a/demos/arena/src/nodes/ScoreHudNode.tsx
+++ b/demos/arena/src/nodes/ScoreHudNode.tsx
@@ -64,8 +64,8 @@ export function ScoreHudNode() {
     const [replay] = useStore(ReplayStore);
 
     // Use custom player colors when available (solo mode personality accent)
-    const p1Color = gameState.playerColors?.[0] ?? SCORE_COLORS[0];
-    const p2Color = gameState.playerColors?.[1] ?? SCORE_COLORS[1];
+    const p1Color = gameState.playerConfig?.colors[0] ?? SCORE_COLORS[0];
+    const p2Color = gameState.playerConfig?.colors[1] ?? SCORE_COLORS[1];
 
     const root = useOverlay(
         <div

--- a/demos/arena/src/nodes/VictoryEffectNode.ts
+++ b/demos/arena/src/nodes/VictoryEffectNode.ts
@@ -38,7 +38,7 @@ export function VictoryEffectNode() {
         if (gameState.phase === 'match_over' && lastPhase !== 'match_over') {
             // In solo mode, only fire confetti when the human wins
             const soloLoss =
-                gameState.playerLabels && gameState.matchWinner !== 0;
+                gameState.playerConfig && gameState.matchWinner !== 0;
             if (!soloLoss) {
                 for (const burst of bursts) {
                     burst(SPAWN_POSITION);


### PR DESCRIPTION
## Summary

- Extracted `pendingKnockout`/`pendingKnockout2` from `GameState` into a dedicated world-scoped `KnockoutQueueStore`, narrowing the shared context to only hold core game state
- Grouped `playerLabels`/`playerColors`/`playerHexColors` into a `PlayerConfig` sub-object on `GameState`, clearly separating static config from dynamic state
- Updated all producers and consumers across ArenaNode, GameManagerNode, LocalPlayerNode, RemotePlayerNode, MenuSceneNode, and HUD/overlay nodes

## Test plan

- [x] IntroOverlayNode tests pass (the test file was updated to remove `pendingKnockout`)
- [x] Pre-existing test failures are unrelated (module resolution for `@pulse-ts/audio` etc.)
- [x] No new lint errors introduced in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)