### PR TITLE
TICKET-143: Move player positions to world-scoped store

### DIFF
--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-143-player-positions-world-scoped-store.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/done/TICKET-143-player-positions-world-scoped-store.md
@@ -1,7 +1,7 @@
 ---
 id: TICKET-143
 title: Move player positions to world-scoped store
-status: in-progress
+status: done
 epic: EPIC-026
 created: 2026-03-14
 priority: medium

--- a/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-143-player-positions-world-scoped-store.md
+++ b/.claude/ticket-tracker/swimlanes/in-progress/EPIC-026-arena-demo-refactoring-cleanup/in-progress/TICKET-143-player-positions-world-scoped-store.md
@@ -1,7 +1,7 @@
 ---
 id: TICKET-143
 title: Move player positions to world-scoped store
-status: todo
+status: in-progress
 epic: EPIC-026
 created: 2026-03-14
 priority: medium

--- a/demos/arena/src/ai/playerPositions.test.ts
+++ b/demos/arena/src/ai/playerPositions.test.ts
@@ -1,47 +1,58 @@
 import {
+    PlayerPositionStore,
     setPlayerPosition,
     getPlayerPosition,
-    resetPlayerPositions,
 } from './playerPositions';
 
-afterEach(() => {
-    resetPlayerPositions();
-});
+function createStore() {
+    return PlayerPositionStore._factory();
+}
 
 describe('playerPositions', () => {
     it('returns [0,0,0] by default', () => {
-        expect(getPlayerPosition(0)).toEqual([0, 0, 0]);
-        expect(getPlayerPosition(1)).toEqual([0, 0, 0]);
+        const store = createStore();
+        expect(getPlayerPosition(store, 0)).toEqual([0, 0, 0]);
+        expect(getPlayerPosition(store, 1)).toEqual([0, 0, 0]);
     });
 
     it('stores and retrieves player 0 position', () => {
-        setPlayerPosition(0, 1, 2, 3);
-        expect(getPlayerPosition(0)).toEqual([1, 2, 3]);
+        const store = createStore();
+        setPlayerPosition(store, 0, 1, 2, 3);
+        expect(getPlayerPosition(store, 0)).toEqual([1, 2, 3]);
     });
 
     it('stores and retrieves player 1 position', () => {
-        setPlayerPosition(1, 4, 5, 6);
-        expect(getPlayerPosition(1)).toEqual([4, 5, 6]);
+        const store = createStore();
+        setPlayerPosition(store, 1, 4, 5, 6);
+        expect(getPlayerPosition(store, 1)).toEqual([4, 5, 6]);
     });
 
     it('players are independent', () => {
-        setPlayerPosition(0, 1, 1, 1);
-        setPlayerPosition(1, 9, 9, 9);
-        expect(getPlayerPosition(0)).toEqual([1, 1, 1]);
-        expect(getPlayerPosition(1)).toEqual([9, 9, 9]);
+        const store = createStore();
+        setPlayerPosition(store, 0, 1, 1, 1);
+        setPlayerPosition(store, 1, 9, 9, 9);
+        expect(getPlayerPosition(store, 0)).toEqual([1, 1, 1]);
+        expect(getPlayerPosition(store, 1)).toEqual([9, 9, 9]);
     });
 
-    it('resetPlayerPositions clears both players', () => {
-        setPlayerPosition(0, 10, 20, 30);
-        setPlayerPosition(1, 40, 50, 60);
-        resetPlayerPositions();
-        expect(getPlayerPosition(0)).toEqual([0, 0, 0]);
-        expect(getPlayerPosition(1)).toEqual([0, 0, 0]);
+    it('each store instance starts fresh (world-scoped isolation)', () => {
+        const store1 = createStore();
+        setPlayerPosition(store1, 0, 10, 20, 30);
+
+        const store2 = createStore();
+        expect(getPlayerPosition(store2, 0)).toEqual([0, 0, 0]);
     });
 
     it('overwrites previous values', () => {
-        setPlayerPosition(0, 1, 2, 3);
-        setPlayerPosition(0, 7, 8, 9);
-        expect(getPlayerPosition(0)).toEqual([7, 8, 9]);
+        const store = createStore();
+        setPlayerPosition(store, 0, 1, 2, 3);
+        setPlayerPosition(store, 0, 7, 8, 9);
+        expect(getPlayerPosition(store, 0)).toEqual([7, 8, 9]);
+    });
+
+    it('factory returns a fresh object each call', () => {
+        const a = PlayerPositionStore._factory();
+        const b = PlayerPositionStore._factory();
+        expect(a).not.toBe(b);
     });
 });

--- a/demos/arena/src/ai/playerPositions.ts
+++ b/demos/arena/src/ai/playerPositions.ts
@@ -1,18 +1,40 @@
+import { defineStore } from '@pulse-ts/core';
+
 /**
- * Shared player position store.
+ * World-scoped store for shared player positions.
  * Written by LocalPlayerNode each fixed step, read by AiPlayerNode
  * to determine the opponent's position.
+ *
+ * Replaces the previous module-level arrays so that state is
+ * automatically scoped to the world lifetime — no manual reset needed.
+ *
+ * @example
+ * ```ts
+ * import { useStore } from '@pulse-ts/core';
+ * import { PlayerPositionStore, setPlayerPosition, getPlayerPosition } from '../ai/playerPositions';
+ *
+ * const [positions] = useStore(PlayerPositionStore);
+ * setPlayerPosition(positions, 0, x, y, z);
+ * const [ox, oy, oz] = getPlayerPosition(positions, 1);
+ * ```
  */
+export const PlayerPositionStore = defineStore('playerPositions', () => ({
+    values: [
+        [0, 0, 0],
+        [0, 0, 0],
+    ] as [[number, number, number], [number, number, number]],
+}));
 
-const positions: [[number, number, number], [number, number, number]] = [
-    [0, 0, 0],
-    [0, 0, 0],
-];
+/** The data shape held by {@link PlayerPositionStore}. */
+export type PlayerPositionData = ReturnType<
+    (typeof PlayerPositionStore)['_factory']
+>;
 
 /**
  * Update a player's shared position. Call once per fixed step from
  * LocalPlayerNode (or any node that owns a player entity).
  *
+ * @param store - The store data obtained via `useStore(PlayerPositionStore)`.
  * @param playerId - Player index (0 or 1).
  * @param x - World X position.
  * @param y - World Y position.
@@ -20,42 +42,37 @@ const positions: [[number, number, number], [number, number, number]] = [
  *
  * @example
  * ```ts
- * setPlayerPosition(0, transform.localPosition.x, transform.localPosition.y, transform.localPosition.z);
+ * setPlayerPosition(positions, 0, transform.localPosition.x, transform.localPosition.y, transform.localPosition.z);
  * ```
  */
 export function setPlayerPosition(
+    store: PlayerPositionData,
     playerId: number,
     x: number,
     y: number,
     z: number,
 ): void {
-    positions[playerId][0] = x;
-    positions[playerId][1] = y;
-    positions[playerId][2] = z;
+    store.values[playerId][0] = x;
+    store.values[playerId][1] = y;
+    store.values[playerId][2] = z;
 }
 
 /**
  * Read a player's last-known position. Returns a shared array reference
  * — do not mutate the returned tuple.
  *
+ * @param store - The store data obtained via `useStore(PlayerPositionStore)`.
  * @param playerId - Player index (0 or 1).
  * @returns `[x, y, z]` world position.
  *
  * @example
  * ```ts
- * const [ox, oy, oz] = getPlayerPosition(1); // opponent position
+ * const [ox, oy, oz] = getPlayerPosition(positions, 1); // opponent position
  * ```
  */
 export function getPlayerPosition(
+    store: PlayerPositionData,
     playerId: number,
 ): readonly [number, number, number] {
-    return positions[playerId];
-}
-
-/**
- * Reset all stored positions to origin. Useful for testing.
- */
-export function resetPlayerPositions(): void {
-    positions[0][0] = positions[0][1] = positions[0][2] = 0;
-    positions[1][0] = positions[1][1] = positions[1][2] = 0;
+    return store.values[playerId];
 }

--- a/demos/arena/src/nodes/AiPlayerNode.ts
+++ b/demos/arena/src/nodes/AiPlayerNode.ts
@@ -3,11 +3,12 @@ import {
     useDestroy,
     useChild,
     useContext,
+    useStore,
 } from '@pulse-ts/core';
 import { useInput } from '@pulse-ts/input';
 import { GameCtx } from '../contexts';
 import { ARENA_RADIUS } from '../config/arena';
-import { getPlayerPosition } from '../ai/playerPositions';
+import { PlayerPositionStore, getPlayerPosition } from '../ai/playerPositions';
 import { computeAiDecision } from '../ai/aiDecision';
 import { createAiState, updateAiState } from '../ai/aiState';
 import type { AiPersonality } from '../ai/personalities';
@@ -55,6 +56,7 @@ export function AiPlayerNode({
 }: Readonly<AiPlayerNodeProps>) {
     const input = useInput();
     const gameState = useContext(GameCtx);
+    const [playerPositions] = useStore(PlayerPositionStore);
     const opponentId = 1 - playerId;
 
     // Frame-to-frame state for stateful personality knobs
@@ -78,8 +80,8 @@ export function AiPlayerNode({
             return;
         }
 
-        const [selfX, , selfZ] = getPlayerPosition(playerId);
-        const [opX, , opZ] = getPlayerPosition(opponentId);
+        const [selfX, , selfZ] = getPlayerPosition(playerPositions, playerId);
+        const [opX, , opZ] = getPlayerPosition(playerPositions, opponentId);
 
         const dt = 1 / 60;
 

--- a/demos/arena/src/nodes/GameManagerNode.ts
+++ b/demos/arena/src/nodes/GameManagerNode.ts
@@ -32,7 +32,6 @@ import {
 import { DashCooldownStore } from '../dashCooldown';
 import { KnockoutQueueStore } from '../knockoutQueue';
 import { useHitImpactPool } from '../hitImpact';
-import { resetPlayerPositions } from '../ai/playerPositions';
 import { resetCameraShake } from './CameraRigNode';
 import { PlayerVelocityStore } from '../playerVelocity';
 
@@ -93,7 +92,6 @@ export function GameManagerNode(props?: Readonly<GameManagerNodeProps>) {
     // Clear non-store module state from any previous game session.
     clearRecording(replay);
     endReplay(replay);
-    resetPlayerPositions();
     resetCameraShake();
 
     // Store state is already fresh from world-scoped initialization,

--- a/demos/arena/src/nodes/LocalPlayerNode.ts
+++ b/demos/arena/src/nodes/LocalPlayerNode.ts
@@ -30,7 +30,7 @@ import { IMPACT_SOUND_CONFIG } from '../config/sounds';
 import { ReplayStore, stagePlayerPosition, getReplayPosition } from '../replay';
 import { useShockwavePool, worldToScreen } from '../shockwave';
 import { useHitImpactPool } from '../hitImpact';
-import { setPlayerPosition } from '../ai/playerPositions';
+import { PlayerPositionStore, setPlayerPosition } from '../ai/playerPositions';
 import { DashCooldownStore } from '../dashCooldown';
 import { KnockoutQueueStore } from '../knockoutQueue';
 import { PlayerVelocityStore, updatePlayerVelocity } from '../playerVelocity';
@@ -105,6 +105,7 @@ export function LocalPlayerNode({
     const [cooldown] = useStore(DashCooldownStore);
     const [velocities] = useStore(PlayerVelocityStore);
     const [ko] = useStore(KnockoutQueueStore);
+    const [playerPositions] = useStore(PlayerPositionStore);
 
     useStableId(`player-${playerId}`);
     useComponent(PlayerTag);
@@ -256,6 +257,7 @@ export function LocalPlayerNode({
             transform.localPosition.z,
         );
         setPlayerPosition(
+            playerPositions,
             playerId,
             transform.localPosition.x,
             transform.localPosition.y,


### PR DESCRIPTION
## Summary

- Replaced module-level arrays in `playerPositions.ts` with a `defineStore`-based `PlayerPositionStore`, scoping state to the world lifetime
- Updated `setPlayerPosition` and `getPlayerPosition` to accept store data as first argument (consistent with `PlayerVelocityStore` pattern)
- Removed `resetPlayerPositions()` call from `GameManagerNode` since the store auto-resets when the world is destroyed
- Updated all consumers (`LocalPlayerNode`, `AiPlayerNode`, `GameManagerNode`) and tests

## Test plan

- [x] All 7 `playerPositions.test.ts` tests pass, including new world-scoped isolation test
- [x] Lint passes on all changed files
- [x] Verified store factory returns fresh instances each call

🤖 Generated with [Claude Code](https://claude.com/claude-code)